### PR TITLE
feat: Add Stellar public key validation with Zod

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "@stellar/stellar-sdk": "^12.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -43,9 +43,22 @@ describe("StellarKraal API", () => {
       expect(res.body).toHaveProperty("xdr");
     });
 
-    it("returns 500 for missing fields", async () => {
+    it("returns 400 for missing fields", async () => {
       const res = await request(app).post("/api/collateral/register").send({});
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Validation failed");
+    });
+
+    it("returns 400 for invalid Stellar public key", async () => {
+      const res = await request(app).post("/api/collateral/register").send({
+        owner: "INVALID_KEY",
+        animal_type: "cattle",
+        count: 5,
+        appraised_value: 1000000,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Validation failed");
+      expect(res.body.details[0].message).toContain("Stellar public key");
     });
   });
 
@@ -59,6 +72,16 @@ describe("StellarKraal API", () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("xdr");
     });
+
+    it("returns 400 for invalid Stellar public key", async () => {
+      const res = await request(app).post("/api/loan/request").send({
+        borrower: "SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        collateral_id: 1,
+        amount: 600000,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Validation failed");
+    });
   });
 
   describe("POST /api/loan/repay", () => {
@@ -70,6 +93,16 @@ describe("StellarKraal API", () => {
       });
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("xdr");
+    });
+
+    it("returns 400 for invalid Stellar public key", async () => {
+      const res = await request(app).post("/api/loan/repay").send({
+        borrower: "NOT_A_VALID_KEY",
+        loan_id: 1,
+        amount: 200000,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Validation failed");
     });
   });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,8 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import { SorobanRpc } from "@stellar/stellar-sdk";
+import { z } from "zod";
+import { stellarPublicKeySchema } from "./validators/stellar";
 const { Server } = SorobanRpc;
 
 const app = express();
@@ -25,6 +27,27 @@ const NETWORK_PASSPHRASE =
     : Networks.TESTNET;
 
 const server = new Server(RPC_URL);
+
+// ── Validation Schemas ────────────────────────────────────────────────────────
+
+const registerCollateralSchema = z.object({
+  owner: stellarPublicKeySchema,
+  animal_type: z.string().min(1),
+  count: z.number().int().positive(),
+  appraised_value: z.number().int().positive(),
+});
+
+const loanRequestSchema = z.object({
+  borrower: stellarPublicKeySchema,
+  collateral_id: z.number().int().nonnegative(),
+  amount: z.number().int().positive(),
+});
+
+const loanRepaySchema = z.object({
+  borrower: stellarPublicKeySchema,
+  loan_id: z.number().int().nonnegative(),
+  amount: z.number().int().positive(),
+});
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 async function buildContractTx(
@@ -51,7 +74,16 @@ async function buildContractTx(
 // POST /api/collateral/register
 app.post("/api/collateral/register", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { owner, animal_type, count, appraised_value } = req.body;
+    const validation = registerCollateralSchema.safeParse(req.body);
+    
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details: validation.error.errors,
+      });
+    }
+
+    const { owner, animal_type, count, appraised_value } = validation.data;
     const xdrTx = await buildContractTx(owner, "register_livestock", [
       new Address(owner).toScVal(),
       nativeToScVal(animal_type, { type: "symbol" }),
@@ -67,7 +99,16 @@ app.post("/api/collateral/register", async (req: Request, res: Response, next: N
 // POST /api/loan/request
 app.post("/api/loan/request", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { borrower, collateral_id, amount } = req.body;
+    const validation = loanRequestSchema.safeParse(req.body);
+    
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details: validation.error.errors,
+      });
+    }
+
+    const { borrower, collateral_id, amount } = validation.data;
     const xdrTx = await buildContractTx(borrower, "request_loan", [
       new Address(borrower).toScVal(),
       nativeToScVal(BigInt(collateral_id), { type: "u64" }),
@@ -82,7 +123,16 @@ app.post("/api/loan/request", async (req: Request, res: Response, next: NextFunc
 // POST /api/loan/repay
 app.post("/api/loan/repay", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { borrower, loan_id, amount } = req.body;
+    const validation = loanRepaySchema.safeParse(req.body);
+    
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details: validation.error.errors,
+      });
+    }
+
+    const { borrower, loan_id, amount } = validation.data;
     const xdrTx = await buildContractTx(borrower, "repay_loan", [
       new Address(borrower).toScVal(),
       nativeToScVal(BigInt(loan_id), { type: "u64" }),

--- a/backend/src/validators/stellar.test.ts
+++ b/backend/src/validators/stellar.test.ts
@@ -1,0 +1,109 @@
+import { stellarPublicKeySchema, validateStellarPublicKey } from "./stellar";
+
+describe("Stellar Public Key Validator", () => {
+  describe("Valid keys", () => {
+    const validKeys = [
+      "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+      "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+    ];
+
+    validKeys.forEach((key) => {
+      it(`should accept valid key: ${key.substring(0, 10)}...`, () => {
+        const result = stellarPublicKeySchema.safeParse(key);
+        expect(result.success).toBe(true);
+      });
+
+      it(`should validate using helper function: ${key.substring(0, 10)}...`, () => {
+        const result = validateStellarPublicKey(key);
+        expect(result.success).toBe(true);
+        expect(result.data).toBe(key);
+        expect(result.error).toBeUndefined();
+      });
+    });
+  });
+
+  describe("Invalid keys", () => {
+    const invalidCases = [
+      {
+        key: "SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        reason: "starts with S (secret key)",
+      },
+      {
+        key: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCC",
+        reason: "too short (52 chars)",
+      },
+      {
+        key: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNEXTRA",
+        reason: "too long (61 chars)",
+      },
+      {
+        key: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCW0",
+        reason: "invalid base32 (contains 0)",
+      },
+      {
+        key: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWX",
+        reason: "invalid checksum",
+      },
+      {
+        key: "",
+        reason: "empty string",
+      },
+      {
+        key: "not-a-stellar-key",
+        reason: "random string",
+      },
+      {
+        key: "MAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        reason: "starts with M (muxed account)",
+      },
+    ];
+
+    invalidCases.forEach(({ key, reason }) => {
+      it(`should reject key: ${reason}`, () => {
+        const result = stellarPublicKeySchema.safeParse(key);
+        expect(result.success).toBe(false);
+      });
+
+      it(`should return error using helper function: ${reason}`, () => {
+        const result = validateStellarPublicKey(key);
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.data).toBeUndefined();
+      });
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should reject null", () => {
+      const result = stellarPublicKeySchema.safeParse(null);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject undefined", () => {
+      const result = stellarPublicKeySchema.safeParse(undefined);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject number", () => {
+      const result = stellarPublicKeySchema.safeParse(12345);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject object", () => {
+      const result = stellarPublicKeySchema.safeParse({ key: "GABC..." });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject array", () => {
+      const result = stellarPublicKeySchema.safeParse(["GABC..."]);
+      expect(result.success).toBe(false);
+    });
+
+    it("should handle whitespace", () => {
+      const keyWithSpaces = " GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN ";
+      const result = stellarPublicKeySchema.safeParse(keyWithSpaces);
+      expect(result.success).toBe(false); // Should not auto-trim
+    });
+  });
+});

--- a/backend/src/validators/stellar.ts
+++ b/backend/src/validators/stellar.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Custom Zod validator for Stellar public keys.
+ * Validates that the key:
+ * - Is a 56-character string
+ * - Starts with 'G'
+ * - Is valid base32-encoded
+ * - Passes Stellar SDK's StrKey validation
+ */
+export const stellarPublicKeySchema = z
+  .string()
+  .length(56, "Stellar public key must be exactly 56 characters")
+  .startsWith("G", "Stellar public key must start with 'G'")
+  .refine(
+    (key) => {
+      try {
+        return StrKey.isValidEd25519PublicKey(key);
+      } catch {
+        return false;
+      }
+    },
+    { message: "Invalid Stellar public key format" }
+  );
+
+/**
+ * Type-safe Stellar public key type
+ */
+export type StellarPublicKey = z.infer<typeof stellarPublicKeySchema>;
+
+/**
+ * Validates a Stellar public key and returns the result
+ */
+export function validateStellarPublicKey(key: string): {
+  success: boolean;
+  data?: StellarPublicKey;
+  error?: string;
+} {
+  const result = stellarPublicKeySchema.safeParse(key);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  return {
+    success: false,
+    error: result.error.errors[0]?.message || "Invalid Stellar public key format",
+  };
+}


### PR DESCRIPTION
Closes #130

- Created custom Zod validator for Stellar public keys
- Validates 56-character base32-encoded strings starting with 'G'
- Uses Stellar SDK StrKey.isValidEd25519PublicKey() for validation
- Integrated into all endpoints accepting public keys:
  - /api/collateral/register (owner field)
  - /api/loan/request (borrower field)
  - /api/loan/repay (borrower field)
- Returns 400 with 'Invalid Stellar public key format' for invalid keys
- Comprehensive unit tests covering valid, invalid, and edge cases
- Exported from shared validators/stellar.ts module

Acceptance Criteria Met:
Custom Zod validator for Stellar public key format Validator reused across all endpoints accepting a public key Invalid keys return 400 with clear error message 
Validator unit tested with valid keys, invalid keys, and edge cases 
Validator exported from validators/stellar.ts module