### PR TITLE
feat: implement webhook system with HMAC signing and retry logic

### DIFF
--- a/backend/src/webhooks.ts
+++ b/backend/src/webhooks.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { config } from "./config";
+
+export interface WebhookRegistration {
+  id: string;
+  url: string;
+  createdAt: number;
+}
+
+export interface DeliveryLog {
+  webhookId: string;
+  event: string;
+  payload: object;
+  attempts: number;
+  lastStatus: number | null;
+  lastError: string | null;
+  deliveredAt: number | null;
+}
+
+// In-memory stores (replace with DB in production)
+const webhooks = new Map<string, WebhookRegistration>();
+const deliveryLogs: DeliveryLog[] = [];
+
+export function registerWebhook(url: string): WebhookRegistration {
+  const id = crypto.randomUUID();
+  const reg: WebhookRegistration = { id, url, createdAt: Date.now() };
+  webhooks.set(id, reg);
+  return reg;
+}
+
+export function getWebhooks(): WebhookRegistration[] {
+  return Array.from(webhooks.values());
+}
+
+export function getDeliveryLogs(): DeliveryLog[] {
+  return deliveryLogs;
+}
+
+function sign(payload: string): string {
+  const secret = config.WEBHOOK_SECRET ?? "default-webhook-secret-change-me";
+  return "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export async function fireWebhooks(event: string, payload: object): Promise<void> {
+  const body = JSON.stringify({ event, payload, timestamp: Date.now() });
+  const signature = sign(body);
+
+  for (const wh of webhooks.values()) {
+    const log: DeliveryLog = {
+      webhookId: wh.id,
+      event,
+      payload,
+      attempts: 0,
+      lastStatus: null,
+      lastError: null,
+      deliveredAt: null,
+    };
+    deliveryLogs.push(log);
+    deliver(wh.url, body, signature, log);
+  }
+}
+
+async function deliver(
+  url: string,
+  body: string,
+  signature: string,
+  log: DeliveryLog,
+  attempt = 0
+): Promise<void> {
+  const MAX_ATTEMPTS = 5;
+  log.attempts = attempt + 1;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+      },
+      body,
+    });
+    log.lastStatus = res.status;
+    if (res.ok) {
+      log.deliveredAt = Date.now();
+      return;
+    }
+    log.lastError = `HTTP ${res.status}`;
+  } catch (err: any) {
+    log.lastError = err.message;
+    log.lastStatus = null;
+  }
+
+  if (attempt + 1 < MAX_ATTEMPTS) {
+    const delay = Math.pow(2, attempt) * 1000; // exponential backoff
+    setTimeout(() => deliver(url, body, signature, log, attempt + 1), delay);
+  }
+}


### PR DESCRIPTION

### #38 — Webhook System
- Added `backend/src/webhooks.ts` with registration, HMAC signing, and retry logic
- `POST /api/webhooks` — register a callback URL
- Payloads signed with `HMAC-SHA256` and delivered via `X-Webhook-Signature` header
- Failed deliveries retried up to **5 times** with exponential backoff
- Events fired: `loan.requested`, `loan.repaid`
- Admin endpoints: `GET /api/admin/webhooks`, `GET /api/admin/webhooks/logs`
- Signing secret configurable via `WEBHOOK_SECRET` env var

Closes #38