### PR TITLE
feat(backend): Implement loan status state machine

### DIFF
--- a/backend/src/loanStateMachine.test.ts
+++ b/backend/src/loanStateMachine.test.ts
@@ -1,0 +1,100 @@
+import {
+  transition,
+  allowedTransitions,
+  InvalidTransitionError,
+  LoanStatus,
+  TransitionRecord,
+} from "./loanStateMachine";
+
+describe("LoanStateMachine", () => {
+  // ── valid transitions ──────────────────────────────────────────────────
+  it("pending → active", () => {
+    const h: TransitionRecord[] = [];
+    expect(transition("pending", "active", h)).toBe("active");
+    expect(h).toHaveLength(1);
+    expect(h[0].from).toBe("pending");
+    expect(h[0].to).toBe("active");
+  });
+
+  it("active → repaid", () => {
+    const h: TransitionRecord[] = [];
+    expect(transition("active", "repaid", h)).toBe("repaid");
+  });
+
+  it("active → liquidated", () => {
+    const h: TransitionRecord[] = [];
+    expect(transition("active", "liquidated", h)).toBe("liquidated");
+  });
+
+  // ── invalid transitions ────────────────────────────────────────────────
+  const invalid: [LoanStatus, LoanStatus][] = [
+    ["pending", "repaid"],
+    ["pending", "liquidated"],
+    ["pending", "pending"],
+    ["active", "pending"],
+    ["active", "active"],
+    ["repaid", "active"],
+    ["repaid", "liquidated"],
+    ["repaid", "pending"],
+    ["liquidated", "active"],
+    ["liquidated", "repaid"],
+    ["liquidated", "pending"],
+  ];
+
+  it.each(invalid)("throws InvalidTransitionError: %s → %s", (from, to) => {
+    expect(() => transition(from, to, [])).toThrow(InvalidTransitionError);
+    expect(() => transition(from, to, [])).toThrow(
+      `Invalid loan transition: ${from} → ${to}`
+    );
+  });
+
+  // ── terminal states ────────────────────────────────────────────────────
+  it("repaid is terminal — no allowed transitions", () => {
+    expect(allowedTransitions("repaid")).toEqual([]);
+  });
+
+  it("liquidated is terminal — no allowed transitions", () => {
+    expect(allowedTransitions("liquidated")).toEqual([]);
+  });
+
+  // ── history logging ────────────────────────────────────────────────────
+  it("logs full transition history", () => {
+    const h: TransitionRecord[] = [];
+    transition("pending", "active", h);
+    transition("active", "repaid", h);
+    expect(h).toHaveLength(2);
+    expect(h[0]).toMatchObject({ from: "pending", to: "active" });
+    expect(h[1]).toMatchObject({ from: "active", to: "repaid" });
+  });
+
+  it("history entries include ISO timestamp", () => {
+    const h: TransitionRecord[] = [];
+    transition("pending", "active", h);
+    expect(h[0].at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("history not mutated on invalid transition", () => {
+    const h: TransitionRecord[] = [];
+    expect(() => transition("pending", "repaid", h)).toThrow();
+    expect(h).toHaveLength(0);
+  });
+
+  // ── allowedTransitions ─────────────────────────────────────────────────
+  it("allowedTransitions(pending) = [active]", () => {
+    expect(allowedTransitions("pending")).toEqual(["active"]);
+  });
+
+  it("allowedTransitions(active) = [repaid, liquidated]", () => {
+    expect(allowedTransitions("active")).toEqual(["repaid", "liquidated"]);
+  });
+
+  // ── InvalidTransitionError identity ───────────────────────────────────
+  it("error name is InvalidTransitionError", () => {
+    try {
+      transition("repaid", "active", []);
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvalidTransitionError);
+      expect((e as Error).name).toBe("InvalidTransitionError");
+    }
+  });
+});

--- a/backend/src/loanStateMachine.ts
+++ b/backend/src/loanStateMachine.ts
@@ -1,0 +1,46 @@
+export type LoanStatus = "pending" | "active" | "repaid" | "liquidated";
+
+export interface TransitionRecord {
+  from: LoanStatus;
+  to: LoanStatus;
+  at: string; // ISO timestamp
+}
+
+export class InvalidTransitionError extends Error {
+  constructor(from: LoanStatus, to: LoanStatus) {
+    super(`Invalid loan transition: ${from} → ${to}`);
+    this.name = "InvalidTransitionError";
+  }
+}
+
+// Valid transitions: from → allowed next states
+const TRANSITIONS: Record<LoanStatus, LoanStatus[]> = {
+  pending: ["active"],
+  active: ["repaid", "liquidated"],
+  repaid: [],
+  liquidated: [],
+};
+
+/**
+ * Validate and apply a loan status transition.
+ * Throws InvalidTransitionError for disallowed transitions.
+ * Returns the new status and appends to the history array.
+ */
+export function transition(
+  current: LoanStatus,
+  next: LoanStatus,
+  history: TransitionRecord[]
+): LoanStatus {
+  if (!TRANSITIONS[current].includes(next)) {
+    throw new InvalidTransitionError(current, next);
+  }
+  history.push({ from: current, to: next, at: new Date().toISOString() });
+  return next;
+}
+
+/**
+ * Returns the valid next states from a given status.
+ */
+export function allowedTransitions(status: LoanStatus): LoanStatus[] {
+  return TRANSITIONS[status];
+}


### PR DESCRIPTION

### 40 — Loan State Machine (`backend/src/loanStateMachine.ts`)
- Formal state machine: `pending → active → repaid | liquidated`
- `transition()` validates and applies state changes; throws `InvalidTransitionError` on invalid transitions
- `TransitionRecord[]` history with ISO timestamps for audit trail
- 22 unit tests with 100% branch coverage

Closes #40