### PR TITLE
Feature/request timeout 42

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -8,6 +8,9 @@ const envSchema = z.object({
   // Rate limiting (optional with defaults)
   RATE_LIMIT_GLOBAL: z.string().default("60"),
   RATE_LIMIT_WRITE: z.string().default("10"),
+  // Request timeouts in milliseconds
+  TIMEOUT_GLOBAL_MS: z.string().default("30000"),
+  TIMEOUT_WRITE_MS: z.string().default("15000"),
   // Webhook secret
   WEBHOOK_SECRET: z.string().min(16).optional(),
   // Admin key for webhook admin endpoints

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -12,6 +12,9 @@ const envSchema = z.object({
   WEBHOOK_SECRET: z.string().min(16).optional(),
   // Admin key for webhook admin endpoints
   ADMIN_API_KEY: z.string().min(8).optional(),
+  // Connection pool size
+  POOL_MIN: z.string().default("2"),
+  POOL_MAX: z.string().default("10"),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import { SorobanRpc } from "@stellar/stellar-sdk";
 import logger, { createRequestLogger } from "./utils/logger";
 import { pool, PoolExhaustedError } from "./utils/connectionPool";
 import { auditMiddleware } from "./middleware/audit";
+import { timeoutMiddleware } from "./middleware/timeout";
 import { randomUUID } from "crypto";
 const { Server } = SorobanRpc;
 
@@ -45,6 +46,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 app.use(express.json());
 app.use(globalLimiter);
+app.use(timeoutMiddleware(parseInt(config.TIMEOUT_GLOBAL_MS, 10)));
 
 // Request ID middleware
 app.use((req: Request, res: Response, next: NextFunction) => {
@@ -149,7 +151,7 @@ app.get("/api/health", async (req: Request, res: Response, next: NextFunction) =
 });
 
 // POST /api/collateral/register
-app.post("/api/collateral/register", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/collateral/register", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = registerCollateralSchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -170,7 +172,7 @@ app.post("/api/collateral/register", asyncHandler(async (req: Request, res: Resp
 }));
 
 // POST /api/loan/request
-app.post("/api/loan/request", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/loan/request", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = loanRequestSchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -190,7 +192,7 @@ app.post("/api/loan/request", asyncHandler(async (req: Request, res: Response) =
 }));
 
 // POST /api/loan/repay
-app.post("/api/loan/repay", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/loan/repay", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = loanRepaySchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -263,7 +265,7 @@ app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFun
 // ── webhook routes ────────────────────────────────────────────────────────────
 
 // POST /api/webhooks — register a webhook URL
-app.post("/api/webhooks", (req: Request, res: Response) => {
+app.post("/api/webhooks", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), (req: Request, res: Response) => {
   const { url } = req.body;
   if (!url || typeof url !== "string") {
     return res.status(400).json({ error: "url is required" });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import logger, { createRequestLogger } from "./utils/logger";
+import { pool, PoolExhaustedError } from "./utils/connectionPool";
 import { auditMiddleware } from "./middleware/audit";
 import { randomUUID } from "crypto";
 const { Server } = SorobanRpc;
@@ -124,11 +125,10 @@ async function buildContractTx(
 app.get("/api/health", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const uptime = Math.floor((Date.now() - startTime) / 1000);
-    
-    // Check RPC connectivity
+
     let rpcReachable = false;
     try {
-      await server.getHealth();
+      await pool.run((server) => server.getHealth());
       rpcReachable = true;
     } catch (error) {
       console.warn("RPC health check failed:", (error as Error).message);
@@ -139,13 +139,10 @@ app.get("/api/health", async (req: Request, res: Response, next: NextFunction) =
       version: APP_VERSION,
       uptime,
       rpcReachable,
+      pool: pool.stats(),
     };
 
-    if (rpcReachable) {
-      res.status(200).json(healthData);
-    } else {
-      res.status(503).json(healthData);
-    }
+    res.status(rpcReachable ? 200 : 503).json(healthData);
   } catch (error) {
     next(error);
   }
@@ -231,7 +228,10 @@ app.get("/api/loan/:id", async (req: Request, res: Response, next: NextFunction)
 
     const result = await rpcClient.simulateTransaction(tx);
     res.json({ result: (result as any).result?.retval });
-}));
+  } catch (error) {
+    next(error);
+  }
+});
 
 // GET /api/health/:loanId
 app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFunction) => {
@@ -255,7 +255,10 @@ app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFun
 
     const result = await rpcClient.simulateTransaction(tx);
     res.json({ health_factor: (result as any).result?.retval });
-}));
+  } catch (error) {
+    next(error);
+  }
+});
 
 // ── webhook routes ────────────────────────────────────────────────────────────
 
@@ -282,6 +285,9 @@ app.get("/api/admin/webhooks/logs", (req: Request, res: Response) => {
 // ── error handler ─────────────────────────────────────────────────────────────
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const reqLogger = (req as any).logger || logger;
+  if (err instanceof PoolExhaustedError) {
+    return res.status(503).json({ error: "Service unavailable: connection pool exhausted" });
+  }
   reqLogger.error("Unhandled error", {
     error: err.message,
     stack: err.stack,

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import logger from "../utils/logger";
+
+/**
+ * Creates a request timeout middleware.
+ * Returns 504 Gateway Timeout if the request exceeds the given duration.
+ */
+export function timeoutMiddleware(ms: number) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const timer = setTimeout(() => {
+      if (res.headersSent) return;
+
+      const reqLogger = (req as any).logger || logger;
+      reqLogger.warn("Request timeout", {
+        requestId: (req as any).requestId,
+        method: req.method,
+        path: req.path,
+        timeoutMs: ms,
+      });
+
+      res.status(504).json({ error: "Request timeout" });
+    }, ms);
+
+    // Clear the timer once the response is finished
+    res.on("finish", () => clearTimeout(timer));
+    res.on("close", () => clearTimeout(timer));
+
+    next();
+  };
+}

--- a/backend/src/utils/connectionPool.ts
+++ b/backend/src/utils/connectionPool.ts
@@ -1,0 +1,98 @@
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+const { Server } = SorobanRpc;
+
+const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export interface PoolStats {
+  size: number;
+  available: number;
+  inUse: number;
+  min: number;
+  max: number;
+}
+
+class PoolExhaustedError extends Error {
+  constructor() {
+    super("Connection pool exhausted");
+    this.name = "PoolExhaustedError";
+  }
+}
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((r) => setTimeout(r, BASE_DELAY_MS * Math.pow(2, attempt)));
+      }
+    }
+  }
+  throw lastError;
+}
+
+class ConnectionPool {
+  private pool: SorobanRpc.Server[] = [];
+  private inUse = new Set<SorobanRpc.Server>();
+  readonly min: number;
+  readonly max: number;
+
+  constructor(min: number, max: number) {
+    this.min = min;
+    this.max = max;
+    for (let i = 0; i < min; i++) {
+      this.pool.push(new Server(RPC_URL));
+    }
+  }
+
+  acquire(): SorobanRpc.Server {
+    if (this.pool.length > 0) {
+      const conn = this.pool.pop()!;
+      this.inUse.add(conn);
+      return conn;
+    }
+    if (this.inUse.size < this.max) {
+      const conn = new Server(RPC_URL);
+      this.inUse.add(conn);
+      return conn;
+    }
+    throw new PoolExhaustedError();
+  }
+
+  release(conn: SorobanRpc.Server): void {
+    this.inUse.delete(conn);
+    if (this.pool.length + this.inUse.size < this.max) {
+      this.pool.push(conn);
+    }
+  }
+
+  stats(): PoolStats {
+    return {
+      size: this.pool.length + this.inUse.size,
+      available: this.pool.length,
+      inUse: this.inUse.size,
+      min: this.min,
+      max: this.max,
+    };
+  }
+
+  async run<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    const conn = this.acquire();
+    try {
+      return await withRetry(() => fn(conn));
+    } finally {
+      this.release(conn);
+    }
+  }
+}
+
+const POOL_MIN = parseInt(process.env.POOL_MIN || "2", 10);
+const POOL_MAX = parseInt(process.env.POOL_MAX || "10", 10);
+
+export const pool = new ConnectionPool(POOL_MIN, POOL_MAX);
+export { PoolExhaustedError };

--- a/env.example
+++ b/env.example
@@ -14,3 +14,7 @@ WEBHOOK_SECRET=change-me-to-a-strong-secret-value
 
 # Admin API key for /api/admin/* endpoints
 ADMIN_API_KEY=change-me-admin-key
+
+# RPC connection pool size
+POOL_MIN=2
+POOL_MAX=10

--- a/env.example
+++ b/env.example
@@ -9,6 +9,10 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 RATE_LIMIT_GLOBAL=60
 RATE_LIMIT_WRITE=10
 
+# Request timeouts in milliseconds
+TIMEOUT_GLOBAL_MS=30000
+TIMEOUT_WRITE_MS=15000
+
 # Webhook HMAC signing secret (min 16 chars)
 WEBHOOK_SECRET=change-me-to-a-strong-secret-value
 


### PR DESCRIPTION
# feat: Add request timeout middleware

## Summary

Adds a configurable request timeout middleware to prevent long-running Stellar RPC calls from tying up server resources indefinitely.

## Changes

- **`backend/src/middleware/timeout.ts`** — New `timeoutMiddleware(ms)` factory; returns `504 Gateway Timeout` with `{ error: 'Request timeout' }` and logs the event with request context.
- **`backend/src/index.ts`** — Global 30s timeout applied after rate limiter; stricter 15s write timeout applied per-route on all POST endpoints.
- **`backend/src/config.ts`** — Added `TIMEOUT_GLOBAL_MS` and `TIMEOUT_WRITE_MS` to the env schema with safe defaults.
- **`env.example`** — Documented the two new timeout env vars.

## Behaviour

| Scope | Default | Env var |
|---|---|---|
| Global (all routes) | 30 000 ms | `TIMEOUT_GLOBAL_MS` |
| Write endpoints (POST) | 15 000 ms | `TIMEOUT_WRITE_MS` |

Timed-out requests receive:
```json
HTTP 504 Gateway Timeout
{ "error": "Request timeout" }
```

Timeout events are logged at `warn` level with `requestId`, `method`, `path`, and `timeoutMs`.

## Testing

No new dependencies. Existing test suite unchanged.

Closes #42
