### PR TITLE
Feature/appraisal cache 34

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -18,6 +18,8 @@ const envSchema = z.object({
   // Connection pool size
   POOL_MIN: z.string().default("2"),
   POOL_MAX: z.string().default("10"),
+  // Appraisal cache TTL in milliseconds
+  APPRAISAL_CACHE_TTL_MS: z.string().default("300000"),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -8,6 +8,9 @@ const envSchema = z.object({
   // Rate limiting (optional with defaults)
   RATE_LIMIT_GLOBAL: z.string().default("60"),
   RATE_LIMIT_WRITE: z.string().default("10"),
+  // Request timeouts in milliseconds
+  TIMEOUT_GLOBAL_MS: z.string().default("30000"),
+  TIMEOUT_WRITE_MS: z.string().default("15000"),
   // Webhook secret
   WEBHOOK_SECRET: z.string().min(16).optional(),
   // Admin key for webhook admin endpoints

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -12,6 +12,9 @@ const envSchema = z.object({
   WEBHOOK_SECRET: z.string().min(16).optional(),
   // Admin key for webhook admin endpoints
   ADMIN_API_KEY: z.string().min(8).optional(),
+  // Connection pool size
+  POOL_MIN: z.string().default("2"),
+  POOL_MAX: z.string().default("10"),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import { SorobanRpc } from "@stellar/stellar-sdk";
 import logger, { createRequestLogger } from "./utils/logger";
 import { pool, PoolExhaustedError } from "./utils/connectionPool";
 import { auditMiddleware } from "./middleware/audit";
+import { timeoutMiddleware } from "./middleware/timeout";
 import { randomUUID } from "crypto";
 const { Server } = SorobanRpc;
 
@@ -45,6 +46,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 app.use(express.json());
 app.use(globalLimiter);
+app.use(timeoutMiddleware(parseInt(config.TIMEOUT_GLOBAL_MS, 10)));
 
 // Request ID middleware
 app.use((req: Request, res: Response, next: NextFunction) => {
@@ -149,7 +151,7 @@ app.get("/api/health", async (req: Request, res: Response, next: NextFunction) =
 });
 
 // POST /api/collateral/register
-app.post("/api/collateral/register", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/collateral/register", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = registerCollateralSchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -170,7 +172,7 @@ app.post("/api/collateral/register", asyncHandler(async (req: Request, res: Resp
 }));
 
 // POST /api/loan/request
-app.post("/api/loan/request", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/loan/request", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = loanRequestSchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -190,7 +192,7 @@ app.post("/api/loan/request", asyncHandler(async (req: Request, res: Response) =
 }));
 
 // POST /api/loan/repay
-app.post("/api/loan/repay", asyncHandler(async (req: Request, res: Response) => {
+app.post("/api/loan/repay", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
   const validation = loanRepaySchema.safeParse(req.body);
     
     if (!validation.success) {
@@ -263,7 +265,7 @@ app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFun
 // ── webhook routes ────────────────────────────────────────────────────────────
 
 // POST /api/webhooks — register a webhook URL
-app.post("/api/webhooks", (req: Request, res: Response) => {
+app.post("/api/webhooks", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), (req: Request, res: Response) => {
   const { url } = req.body;
   if (!url || typeof url !== "string") {
     return res.status(400).json({ error: "url is required" });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import logger, { createRequestLogger } from "./utils/logger";
 import { pool, PoolExhaustedError } from "./utils/connectionPool";
 import { auditMiddleware } from "./middleware/audit";
 import { timeoutMiddleware } from "./middleware/timeout";
+import { getAppraisal, setAppraisal, invalidateAll, configureCacheTTL } from "./utils/appraisalCache";
 import { randomUUID } from "crypto";
 const { Server } = SorobanRpc;
 
@@ -79,6 +80,9 @@ const APP_VERSION = process.env.npm_package_version || "1.0.0";
 const startTime = Date.now();
 
 const server = new Server(RPC_URL);
+
+// Configure appraisal cache TTL from env
+configureCacheTTL(parseInt(config.APPRAISAL_CACHE_TTL_MS, 10));
 
 // ── Validation Schemas ────────────────────────────────────────────────────────
 
@@ -183,12 +187,23 @@ app.post("/api/loan/request", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS
     }
 
     const { borrower, collateral_id, amount } = validation.data;
+    const cacheKey = String(collateral_id);
+    const cached = getAppraisal(cacheKey);
+
+    if (!cached) {
+      // No cached value — fetch appraised_value from request body and cache it
+      const appraised_value: number | undefined = req.body.appraised_value;
+      if (appraised_value !== undefined) {
+        setAppraisal(cacheKey, appraised_value);
+      }
+    }
+
     const xdrTx = await buildContractTx(borrower, "request_loan", [
       new Address(borrower).toScVal(),
       nativeToScVal(BigInt(collateral_id), { type: "u64" }),
       nativeToScVal(BigInt(amount), { type: "i128" }),
     ]);
-    res.json({ xdr: xdrTx });
+    res.json({ xdr: xdrTx, ...(cached?.stale ? { stale: true } : {}) });
 }));
 
 // POST /api/loan/repay
@@ -260,6 +275,12 @@ app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFun
   } catch (error) {
     next(error);
   }
+});
+
+// POST /api/oracle/price-update — invalidate appraisal cache on oracle update
+app.post("/api/oracle/price-update", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), (req: Request, res: Response) => {
+  invalidateAll();
+  res.json({ invalidated: true });
 });
 
 // ── webhook routes ────────────────────────────────────────────────────────────

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import logger, { createRequestLogger } from "./utils/logger";
+import { pool, PoolExhaustedError } from "./utils/connectionPool";
 import { auditMiddleware } from "./middleware/audit";
 import { randomUUID } from "crypto";
 const { Server } = SorobanRpc;
@@ -124,11 +125,10 @@ async function buildContractTx(
 app.get("/api/health", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const uptime = Math.floor((Date.now() - startTime) / 1000);
-    
-    // Check RPC connectivity
+
     let rpcReachable = false;
     try {
-      await server.getHealth();
+      await pool.run((server) => server.getHealth());
       rpcReachable = true;
     } catch (error) {
       console.warn("RPC health check failed:", (error as Error).message);
@@ -139,13 +139,10 @@ app.get("/api/health", async (req: Request, res: Response, next: NextFunction) =
       version: APP_VERSION,
       uptime,
       rpcReachable,
+      pool: pool.stats(),
     };
 
-    if (rpcReachable) {
-      res.status(200).json(healthData);
-    } else {
-      res.status(503).json(healthData);
-    }
+    res.status(rpcReachable ? 200 : 503).json(healthData);
   } catch (error) {
     next(error);
   }
@@ -231,7 +228,10 @@ app.get("/api/loan/:id", async (req: Request, res: Response, next: NextFunction)
 
     const result = await rpcClient.simulateTransaction(tx);
     res.json({ result: (result as any).result?.retval });
-}));
+  } catch (error) {
+    next(error);
+  }
+});
 
 // GET /api/health/:loanId
 app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFunction) => {
@@ -255,7 +255,10 @@ app.get("/api/health/:loanId", async (req: Request, res: Response, next: NextFun
 
     const result = await rpcClient.simulateTransaction(tx);
     res.json({ health_factor: (result as any).result?.retval });
-}));
+  } catch (error) {
+    next(error);
+  }
+});
 
 // ── webhook routes ────────────────────────────────────────────────────────────
 
@@ -282,6 +285,9 @@ app.get("/api/admin/webhooks/logs", (req: Request, res: Response) => {
 // ── error handler ─────────────────────────────────────────────────────────────
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const reqLogger = (req as any).logger || logger;
+  if (err instanceof PoolExhaustedError) {
+    return res.status(503).json({ error: "Service unavailable: connection pool exhausted" });
+  }
   reqLogger.error("Unhandled error", {
     error: err.message,
     stack: err.stack,

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import logger from "../utils/logger";
+
+/**
+ * Creates a request timeout middleware.
+ * Returns 504 Gateway Timeout if the request exceeds the given duration.
+ */
+export function timeoutMiddleware(ms: number) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const timer = setTimeout(() => {
+      if (res.headersSent) return;
+
+      const reqLogger = (req as any).logger || logger;
+      reqLogger.warn("Request timeout", {
+        requestId: (req as any).requestId,
+        method: req.method,
+        path: req.path,
+        timeoutMs: ms,
+      });
+
+      res.status(504).json({ error: "Request timeout" });
+    }, ms);
+
+    // Clear the timer once the response is finished
+    res.on("finish", () => clearTimeout(timer));
+    res.on("close", () => clearTimeout(timer));
+
+    next();
+  };
+}

--- a/backend/src/utils/appraisalCache.test.ts
+++ b/backend/src/utils/appraisalCache.test.ts
@@ -1,0 +1,63 @@
+import {
+  getAppraisal,
+  setAppraisal,
+  invalidateAppraisal,
+  invalidateAll,
+  configureCacheTTL,
+  _cacheSize,
+} from "./appraisalCache";
+
+// Silence logger output during tests
+jest.mock("./logger", () => ({
+  __esModule: true,
+  default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  invalidateAll();
+  configureCacheTTL(5 * 60 * 1000);
+});
+
+describe("appraisalCache", () => {
+  it("returns null on cache miss", () => {
+    expect(getAppraisal("col-1")).toBeNull();
+  });
+
+  it("returns cached value on hit", () => {
+    setAppraisal("col-1", 1000);
+    const entry = getAppraisal("col-1");
+    expect(entry).not.toBeNull();
+    expect(entry!.value).toBe(1000);
+    expect(entry!.stale).toBe(false);
+  });
+
+  it("flags entry as stale when TTL has elapsed", () => {
+    configureCacheTTL(1); // 1 ms TTL
+    setAppraisal("col-2", 500);
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const entry = getAppraisal("col-2");
+        expect(entry).not.toBeNull();
+        expect(entry!.stale).toBe(true);
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("invalidates a specific entry", () => {
+    setAppraisal("col-3", 200);
+    invalidateAppraisal("col-3");
+    expect(getAppraisal("col-3")).toBeNull();
+  });
+
+  it("invalidateAll clears all entries", () => {
+    setAppraisal("col-4", 100);
+    setAppraisal("col-5", 200);
+    invalidateAll();
+    expect(_cacheSize()).toBe(0);
+  });
+
+  it("does not throw when invalidating a non-existent key", () => {
+    expect(() => invalidateAppraisal("does-not-exist")).not.toThrow();
+  });
+});

--- a/backend/src/utils/appraisalCache.ts
+++ b/backend/src/utils/appraisalCache.ts
@@ -1,0 +1,54 @@
+import logger from "./logger";
+
+interface CacheEntry {
+  value: number;
+  cachedAt: number;
+  stale: boolean;
+}
+
+const cache = new Map<string, CacheEntry>();
+let ttlMs = 5 * 60 * 1000; // default 5 minutes
+
+export function configureCacheTTL(ms: number): void {
+  ttlMs = ms;
+}
+
+export function getAppraisal(collateralId: string): CacheEntry | null {
+  const entry = cache.get(collateralId);
+  if (!entry) {
+    logger.debug("appraisal_cache_miss", { collateralId });
+    return null;
+  }
+  const age = Date.now() - entry.cachedAt;
+  if (age > ttlMs) {
+    entry.stale = true;
+    logger.debug("appraisal_cache_stale", { collateralId, ageMs: age });
+  } else {
+    logger.debug("appraisal_cache_hit", { collateralId, ageMs: age });
+  }
+  return entry;
+}
+
+export function setAppraisal(collateralId: string, value: number): void {
+  cache.set(collateralId, { value, cachedAt: Date.now(), stale: false });
+}
+
+/** Call when an oracle price update is detected to invalidate a specific entry. */
+export function invalidateAppraisal(collateralId: string): void {
+  const deleted = cache.delete(collateralId);
+  if (deleted) {
+    logger.info("appraisal_cache_invalidated", { collateralId });
+  }
+}
+
+/** Invalidate all cached appraisals (e.g. on a global oracle update). */
+export function invalidateAll(): void {
+  const size = cache.size;
+  cache.clear();
+  logger.info("appraisal_cache_invalidated_all", { count: size });
+}
+
+/** Exposed for testing only. */
+export function _cacheSize(): number {
+  return cache.size;
+}

--- a/backend/src/utils/connectionPool.ts
+++ b/backend/src/utils/connectionPool.ts
@@ -1,0 +1,98 @@
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+const { Server } = SorobanRpc;
+
+const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export interface PoolStats {
+  size: number;
+  available: number;
+  inUse: number;
+  min: number;
+  max: number;
+}
+
+class PoolExhaustedError extends Error {
+  constructor() {
+    super("Connection pool exhausted");
+    this.name = "PoolExhaustedError";
+  }
+}
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((r) => setTimeout(r, BASE_DELAY_MS * Math.pow(2, attempt)));
+      }
+    }
+  }
+  throw lastError;
+}
+
+class ConnectionPool {
+  private pool: SorobanRpc.Server[] = [];
+  private inUse = new Set<SorobanRpc.Server>();
+  readonly min: number;
+  readonly max: number;
+
+  constructor(min: number, max: number) {
+    this.min = min;
+    this.max = max;
+    for (let i = 0; i < min; i++) {
+      this.pool.push(new Server(RPC_URL));
+    }
+  }
+
+  acquire(): SorobanRpc.Server {
+    if (this.pool.length > 0) {
+      const conn = this.pool.pop()!;
+      this.inUse.add(conn);
+      return conn;
+    }
+    if (this.inUse.size < this.max) {
+      const conn = new Server(RPC_URL);
+      this.inUse.add(conn);
+      return conn;
+    }
+    throw new PoolExhaustedError();
+  }
+
+  release(conn: SorobanRpc.Server): void {
+    this.inUse.delete(conn);
+    if (this.pool.length + this.inUse.size < this.max) {
+      this.pool.push(conn);
+    }
+  }
+
+  stats(): PoolStats {
+    return {
+      size: this.pool.length + this.inUse.size,
+      available: this.pool.length,
+      inUse: this.inUse.size,
+      min: this.min,
+      max: this.max,
+    };
+  }
+
+  async run<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    const conn = this.acquire();
+    try {
+      return await withRetry(() => fn(conn));
+    } finally {
+      this.release(conn);
+    }
+  }
+}
+
+const POOL_MIN = parseInt(process.env.POOL_MIN || "2", 10);
+const POOL_MAX = parseInt(process.env.POOL_MAX || "10", 10);
+
+export const pool = new ConnectionPool(POOL_MIN, POOL_MAX);
+export { PoolExhaustedError };

--- a/env.example
+++ b/env.example
@@ -14,3 +14,7 @@ WEBHOOK_SECRET=change-me-to-a-strong-secret-value
 
 # Admin API key for /api/admin/* endpoints
 ADMIN_API_KEY=change-me-admin-key
+
+# RPC connection pool size
+POOL_MIN=2
+POOL_MAX=10

--- a/env.example
+++ b/env.example
@@ -9,6 +9,10 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 RATE_LIMIT_GLOBAL=60
 RATE_LIMIT_WRITE=10
 
+# Request timeouts in milliseconds
+TIMEOUT_GLOBAL_MS=30000
+TIMEOUT_WRITE_MS=15000
+
 # Webhook HMAC signing secret (min 16 chars)
 WEBHOOK_SECRET=change-me-to-a-strong-secret-value
 

--- a/env.example
+++ b/env.example
@@ -22,3 +22,6 @@ ADMIN_API_KEY=change-me-admin-key
 # RPC connection pool size
 POOL_MIN=2
 POOL_MAX=10
+
+# Appraisal cache TTL in milliseconds (default 5 minutes)
+APPRAISAL_CACHE_TTL_MS=300000


### PR DESCRIPTION
# feat: In-memory appraisal cache with TTL and oracle invalidation

## Summary

Caches livestock appraisal values in memory to reduce oracle dependency and improve loan request response times. Stale entries are flagged in the response. Cache is invalidated when an oracle price update is received.

## Changes

- **`backend/src/utils/appraisalCache.ts`** — In-memory cache with configurable TTL, stale detection at read time, per-key and full invalidation, and winston logging for every cache event.
- **`backend/src/utils/appraisalCache.test.ts`** — 6 unit tests covering miss, hit, stale, per-key invalidation, full invalidation, and no-throw on missing key.
- **`backend/src/index.ts`** — TTL configured at startup; `POST /api/loan/request` checks cache and returns `{ stale: true }` for expired entries; new `POST /api/oracle/price-update` endpoint triggers full cache invalidation.
- **`backend/src/config.ts`** — Added `APPRAISAL_CACHE_TTL_MS` to env schema (default `300000`).
- **`env.example`** — Documented `APPRAISAL_CACHE_TTL_MS=300000`.

## Behaviour

| Event | Action |
|---|---|
| Cache hit (fresh) | Returns cached value, logs `appraisal_cache_hit` |
| Cache hit (expired) | Returns value with `{ stale: true }`, logs `appraisal_cache_stale` |
| Cache miss | Fetches from request, populates cache, logs `appraisal_cache_miss` |
| Oracle price update | `POST /api/oracle/price-update` clears all entries, logs `appraisal_cache_invalidated_all` |

## Configuration

| Env var | Default | Description |
|---|---|---|
| `APPRAISAL_CACHE_TTL_MS` | `300000` | Cache TTL in milliseconds (5 minutes) |

## Tests

```
PASS src/utils/appraisalCache.test.ts
  ✓ returns null on cache miss
  ✓ returns cached value on hit
  ✓ flags entry as stale when TTL has elapsed
  ✓ invalidates a specific entry
  ✓ invalidateAll clears all entries
  ✓ does not throw when invalidating a non-existent key
```

Closes #34