### PR TITLE
feat: implement JWT-based authentication for API endpoints

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -20,6 +20,8 @@ const envSchema = z.object({
   POOL_MAX: z.string().default("10"),
   // Appraisal cache TTL in milliseconds
   APPRAISAL_CACHE_TTL_MS: z.string().default("300000"),
+  // JWT secret (min 32 chars recommended)
+  JWT_SECRET: z.string().min(16).optional(),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import { auditMiddleware } from "./middleware/audit";
 import { timeoutMiddleware } from "./middleware/timeout";
 import { getAppraisal, setAppraisal, invalidateAll, configureCacheTTL } from "./utils/appraisalCache";
 import { randomUUID } from "crypto";
+import { authRouter, jwtMiddleware } from "./middleware/auth";
 const { Server } = SorobanRpc;
 
 const app = express();
@@ -70,6 +71,10 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 
 // Audit logging middleware — logs all requests with redacted body to audit log
 app.use(auditMiddleware);
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+app.use("/api/auth", authRouter);
+app.use(jwtMiddleware);
 
 const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
 const CONTRACT_ID = process.env.CONTRACT_ID || "";

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -1,0 +1,194 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import request from "supertest";
+import app from "../index";
+
+// Suppress logger noise
+jest.mock("./utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createRequestLogger: jest.fn(() => ({
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  })),
+}));
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Networks: { TESTNET: "Test SDF Network ; September 2015", PUBLIC: "Public Global Stellar Network ; September 2015" },
+    BASE_FEE: "100",
+    Contract: jest.fn().mockImplementation(() => ({ call: jest.fn().mockReturnValue({}) })),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({ toXDR: () => "mock_xdr" }),
+    })),
+    Address: jest.fn().mockImplementation(() => ({ toScVal: jest.fn().mockReturnValue({}) })),
+    nativeToScVal: jest.fn().mockReturnValue({}),
+    // Keep real Keypair for signature tests
+    Keypair: actual.Keypair,
+    SorobanRpc: {
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: jest.fn().mockResolvedValue({ id: "GABC", sequence: "1" }),
+        prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => "prepared_xdr" }),
+        simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+        getHealth: jest.fn().mockResolvedValue({ status: "healthy" }),
+      })),
+    },
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function getChallenge(): Promise<string> {
+  const res = await request(app).get("/api/auth/challenge");
+  expect(res.status).toBe(200);
+  return res.body.challenge as string;
+}
+
+async function login(kp: Keypair): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
+  const challenge = await getChallenge();
+  const signature = kp.sign(Buffer.from(challenge, "hex")).toString("hex");
+  const res = await request(app).post("/api/auth/login").send({
+    publicKey: kp.publicKey(),
+    signature,
+    challenge,
+  });
+  expect(res.status).toBe(200);
+  return res.body;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("JWT Authentication", () => {
+  const kp = Keypair.random();
+
+  describe("GET /api/auth/challenge", () => {
+    it("returns a hex challenge string", async () => {
+      const res = await request(app).get("/api/auth/challenge");
+      expect(res.status).toBe(200);
+      expect(typeof res.body.challenge).toBe("string");
+      expect(res.body.challenge).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("each call returns a unique challenge", async () => {
+      const a = await getChallenge();
+      const b = await getChallenge();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("POST /api/auth/login", () => {
+    it("returns accessToken and refreshToken for valid signature", async () => {
+      const tokens = await login(kp);
+      expect(typeof tokens.accessToken).toBe("string");
+      expect(typeof tokens.refreshToken).toBe("string");
+      expect(tokens.expiresIn).toBe(900); // 15 min
+    });
+
+    it("rejects missing fields with 400", async () => {
+      const res = await request(app).post("/api/auth/login").send({});
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid signature with 401", async () => {
+      const challenge = await getChallenge();
+      const res = await request(app).post("/api/auth/login").send({
+        publicKey: kp.publicKey(),
+        signature: "deadbeef".repeat(8), // wrong sig
+        challenge,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects unknown challenge with 401", async () => {
+      const fakeSig = kp.sign(Buffer.from("a".repeat(64), "hex")).toString("hex");
+      const res = await request(app).post("/api/auth/login").send({
+        publicKey: kp.publicKey(),
+        signature: fakeSig,
+        challenge: "a".repeat(64),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("challenge is single-use — reuse returns 401", async () => {
+      const challenge = await getChallenge();
+      const signature = kp.sign(Buffer.from(challenge, "hex")).toString("hex");
+      const body = { publicKey: kp.publicKey(), signature, challenge };
+
+      const first = await request(app).post("/api/auth/login").send(body);
+      expect(first.status).toBe(200);
+
+      const second = await request(app).post("/api/auth/login").send(body);
+      expect(second.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/auth/refresh", () => {
+    it("returns new tokens for valid refresh token", async () => {
+      const { refreshToken } = await login(kp);
+      const res = await request(app).post("/api/auth/refresh").send({ refreshToken });
+      expect(res.status).toBe(200);
+      expect(typeof res.body.accessToken).toBe("string");
+      expect(typeof res.body.refreshToken).toBe("string");
+    });
+
+    it("refresh token is rotated — old token rejected", async () => {
+      const { refreshToken } = await login(kp);
+      await request(app).post("/api/auth/refresh").send({ refreshToken });
+      const res = await request(app).post("/api/auth/refresh").send({ refreshToken });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects missing refreshToken with 400", async () => {
+      const res = await request(app).post("/api/auth/refresh").send({});
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid refresh token with 401", async () => {
+      const res = await request(app).post("/api/auth/refresh").send({ refreshToken: "bogus" });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("JWT middleware — protected routes", () => {
+    it("POST without token returns 401", async () => {
+      const res = await request(app).post("/api/collateral/register").send({
+        owner: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        animal_type: "cattle",
+        count: 5,
+        appraised_value: 1_000_000,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("POST with valid token succeeds", async () => {
+      const { accessToken } = await login(kp);
+      const res = await request(app)
+        .post("/api/collateral/register")
+        .set("Authorization", `Bearer ${accessToken}`)
+        .send({
+          owner: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+          animal_type: "cattle",
+          count: 5,
+          appraised_value: 1_000_000,
+        });
+      expect(res.status).toBe(200);
+    });
+
+    it("POST with tampered token returns 401", async () => {
+      const { accessToken } = await login(kp);
+      const tampered = accessToken.slice(0, -4) + "xxxx";
+      const res = await request(app)
+        .post("/api/collateral/register")
+        .set("Authorization", `Bearer ${tampered}`)
+        .send({});
+      expect(res.status).toBe(401);
+    });
+
+    it("GET routes are not protected", async () => {
+      const res = await request(app).get("/api/health");
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,151 @@
+/**
+ * JWT authentication middleware and auth routes.
+ *
+ * Flow:
+ *   1. GET  /api/auth/challenge  — returns a one-time challenge string
+ *   2. POST /api/auth/login      — client submits { publicKey, signature, challenge }
+ *                                  backend verifies Stellar signature, issues JWT + refresh token
+ *   3. POST /api/auth/refresh    — exchanges a valid refresh token for a new JWT
+ *
+ * JWT expires in 15 minutes; refresh tokens expire in 7 days.
+ * All POST/PUT/DELETE routes (except auth endpoints) require a valid JWT.
+ */
+import { Request, Response, NextFunction, Router } from "express";
+import { createHmac, randomBytes } from "crypto";
+import { Keypair } from "@stellar/stellar-sdk";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "change-me-in-production-min-32-chars!!";
+const ACCESS_TTL_MS = 15 * 60 * 1000;       // 15 minutes
+const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;     // 5 minutes
+
+// ── Minimal JWT (HS256, no external dep) ─────────────────────────────────────
+
+function b64url(buf: Buffer | string): string {
+  const s = typeof buf === "string" ? Buffer.from(buf) : buf;
+  return s.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function signJwt(payload: object): string {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const sig = b64url(
+    createHmac("sha256", JWT_SECRET).update(`${header}.${body}`).digest()
+  );
+  return `${header}.${body}.${sig}`;
+}
+
+function verifyJwt(token: string): Record<string, unknown> {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("malformed");
+  const [header, body, sig] = parts;
+  const expected = b64url(
+    createHmac("sha256", JWT_SECRET).update(`${header}.${body}`).digest()
+  );
+  if (sig !== expected) throw new Error("invalid signature");
+  const payload = JSON.parse(Buffer.from(body, "base64").toString()) as Record<string, unknown>;
+  if (typeof payload.exp === "number" && Date.now() > payload.exp) throw new Error("expired");
+  return payload;
+}
+
+// ── In-memory stores ──────────────────────────────────────────────────────────
+
+// challenge → expiry
+const challenges = new Map<string, number>();
+// refreshToken → { publicKey, expiry }
+const refreshTokens = new Map<string, { publicKey: string; exp: number }>();
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function issueTokens(publicKey: string) {
+  const now = Date.now();
+  const accessToken = signJwt({ sub: publicKey, exp: now + ACCESS_TTL_MS, iat: now });
+  const refreshToken = randomBytes(32).toString("hex");
+  refreshTokens.set(refreshToken, { publicKey, exp: now + REFRESH_TTL_MS });
+  return { accessToken, refreshToken, expiresIn: ACCESS_TTL_MS / 1000 };
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+export const authRouter = Router();
+
+// GET /api/auth/challenge — issue a one-time challenge
+authRouter.get("/challenge", (_req: Request, res: Response) => {
+  const challenge = randomBytes(32).toString("hex");
+  challenges.set(challenge, Date.now() + CHALLENGE_TTL_MS);
+  res.json({ challenge });
+});
+
+// POST /api/auth/login — verify Stellar signature, issue JWT
+authRouter.post("/login", (req: Request, res: Response) => {
+  const { publicKey, signature, challenge } = req.body as {
+    publicKey?: string;
+    signature?: string;
+    challenge?: string;
+  };
+
+  if (!publicKey || !signature || !challenge) {
+    return res.status(400).json({ error: "publicKey, signature, and challenge are required" });
+  }
+
+  // Validate challenge exists and hasn't expired
+  const expiry = challenges.get(challenge);
+  if (!expiry || Date.now() > expiry) {
+    return res.status(401).json({ error: "Invalid or expired challenge" });
+  }
+  challenges.delete(challenge); // one-time use
+
+  // Verify Stellar ed25519 signature
+  try {
+    const kp = Keypair.fromPublicKey(publicKey);
+    const valid = kp.verify(Buffer.from(challenge, "hex"), Buffer.from(signature, "hex"));
+    if (!valid) return res.status(401).json({ error: "Signature verification failed" });
+  } catch {
+    return res.status(401).json({ error: "Invalid public key or signature" });
+  }
+
+  res.json(issueTokens(publicKey));
+});
+
+// POST /api/auth/refresh — rotate refresh token
+authRouter.post("/refresh", (req: Request, res: Response) => {
+  const { refreshToken } = req.body as { refreshToken?: string };
+  if (!refreshToken) return res.status(400).json({ error: "refreshToken is required" });
+
+  const entry = refreshTokens.get(refreshToken);
+  if (!entry || Date.now() > entry.exp) {
+    return res.status(401).json({ error: "Invalid or expired refresh token" });
+  }
+
+  // Rotate: invalidate old token, issue new pair
+  refreshTokens.delete(refreshToken);
+  res.json(issueTokens(entry.publicKey));
+});
+
+// ── JWT middleware ────────────────────────────────────────────────────────────
+
+/**
+ * Protects all POST/PUT/DELETE routes except /api/auth/*.
+ * Attach as app-level middleware after auth router is mounted.
+ */
+export function jwtMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const mutating = ["POST", "PUT", "DELETE", "PATCH"];
+  if (!mutating.includes(req.method)) return next();
+  if (req.path.startsWith("/api/auth/")) return next();
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Authorization header required" });
+    return;
+  }
+
+  try {
+    const payload = verifyJwt(authHeader.slice(7));
+    (req as any).user = { publicKey: payload.sub };
+    next();
+  } catch (err: any) {
+    res.status(401).json({ error: err.message === "expired" ? "Token expired" : "Invalid token" });
+  }
+}

--- a/env.example
+++ b/env.example
@@ -25,3 +25,6 @@ POOL_MAX=10
 
 # Appraisal cache TTL in milliseconds (default 5 minutes)
 APPRAISAL_CACHE_TTL_MS=300000
+
+# JWT secret for signing access tokens (min 32 chars in production)
+JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars


### PR DESCRIPTION
## Summary

Adds JWT authentication using Stellar keypair signatures. No external JWT library — uses Node's built-in `crypto` for HS256 signing.

## Auth Flow

```
GET  /api/auth/challenge  →  { challenge: "<64-char hex>" }
POST /api/auth/login      ←  { publicKey, signature, challenge }
                          →  { accessToken, refreshToken, expiresIn }
POST /api/auth/refresh    ←  { refreshToken }
                          →  { accessToken, refreshToken, expiresIn }
```

The client signs the challenge bytes with their Stellar ed25519 private key (e.g. via Freighter). The backend verifies with `Keypair.verify()`.

## Files Changed

| File | Change |
|---|---|
| `backend/src/middleware/auth.ts` | Auth router + `jwtMiddleware` |
| `backend/src/middleware/auth.test.ts` | 15 test cases |
| `backend/src/index.ts` | Mount `authRouter` + `jwtMiddleware` |
| `backend/src/config.ts` | `JWT_SECRET` env var |
| `env.example` | Document `JWT_SECRET` |

## Acceptance Criteria

- [x] `POST /api/auth/login` accepts signed challenge and returns JWT
- [x] JWT middleware protects all POST/PUT/DELETE routes
- [x] Access tokens expire in 15 minutes; refresh tokens in 7 days
- [x] Invalid/expired tokens return 401
- [x] Refresh token rotation (old token invalidated on use)
- [x] Challenges are one-time use and expire in 5 minutes

Closes #28