### PR TITLE
feat(backend): integrate db-migrate migration system

### DIFF
--- a/backend/database.json
+++ b/backend/database.json
@@ -1,0 +1,18 @@
+{
+  "dev": {
+    "driver": "sqlite3",
+    "filename": "./dev.sqlite3"
+  },
+  "test": {
+    "driver": "sqlite3",
+    "filename": ":memory:"
+  },
+  "production": {
+    "driver": "pg",
+    "host": { "ENV": "DB_HOST" },
+    "port": { "ENV": "DB_PORT" },
+    "database": { "ENV": "DB_NAME" },
+    "user": { "ENV": "DB_USER" },
+    "password": { "ENV": "DB_PASSWORD" }
+  }
+}

--- a/backend/migrations/20260425000000-initial-schema.js
+++ b/backend/migrations/20260425000000-initial-schema.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260425000000-initial-schema-up.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260425000000-initial-schema-down.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/backend/migrations/sqls/20260425000000-initial-schema-down.sql
+++ b/backend/migrations/sqls/20260425000000-initial-schema-down.sql
@@ -1,0 +1,6 @@
+-- Migration: 001-initial-schema (down)
+DROP INDEX IF EXISTS idx_collaterals_owner;
+DROP INDEX IF EXISTS idx_loans_borrower;
+DROP TABLE IF EXISTS idempotency_keys;
+DROP TABLE IF EXISTS loans;
+DROP TABLE IF EXISTS collaterals;

--- a/backend/migrations/sqls/20260425000000-initial-schema-up.sql
+++ b/backend/migrations/sqls/20260425000000-initial-schema-up.sql
@@ -1,0 +1,34 @@
+-- Migration: 001-initial-schema (up)
+-- Creates the initial StellarKraal schema: collaterals, loans, idempotency_keys
+
+CREATE TABLE IF NOT EXISTS collaterals (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  owner       TEXT    NOT NULL,
+  animal_type TEXT    NOT NULL,
+  count       INTEGER NOT NULL CHECK (count > 0),
+  appraised_value INTEGER NOT NULL CHECK (appraised_value > 0),
+  loan_id     INTEGER,
+  created_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS loans (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  borrower         TEXT    NOT NULL,
+  collateral_id    INTEGER NOT NULL REFERENCES collaterals(id),
+  collateral_value INTEGER NOT NULL,
+  principal        INTEGER NOT NULL CHECK (principal > 0),
+  outstanding      INTEGER NOT NULL CHECK (outstanding >= 0),
+  status           TEXT    NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'repaid', 'liquidated')),
+  created_at       INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+  updated_at       INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  key         TEXT    PRIMARY KEY,
+  status_code INTEGER NOT NULL,
+  response    TEXT    NOT NULL,
+  created_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_loans_borrower ON loans(borrower);
+CREATE INDEX IF NOT EXISTS idx_collaterals_owner ON collaterals(owner);


### PR DESCRIPTION
- Add database.json config for dev (sqlite3), test (in-memory), production (pg)
- Create migrations/20260425000000-initial-schema.js migration runner
- Create migrations/sqls/20260425000000-initial-schema-up.sql with:
  - collaterals table (id, owner, animal_type, count, appraised_value, loan_id)
  - loans table (id, borrower, collateral_id, principal, outstanding, status)
  - idempotency_keys table (key, status_code, response, created_at)
  - Indexes on loans.borrower and collaterals.owner
- Create migrations/sqls/20260425000000-initial-schema-down.sql rollback
- Add npm scripts: migrate:dev, migrate:prod, migrate:down, migrate:status
- dev script auto-runs migrations before starting server
- Install db-migrate@0.11.14 and db-migrate-sqlite3@0.4.0

Closes #41 