### PR TITLE
feat: implement partial liquidation with configurable close factor

### DIFF
--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -57,6 +57,12 @@ const loanRepaySchema = z.object({
   amount: z.number().int().positive(),
 });
 
+const loanLiquidateSchema = z.object({
+  liquidator: stellarPublicKeySchema,
+  loan_id: z.number().int().nonnegative(),
+  repay_amount: z.number().int().positive(),
+});
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 async function buildContractTx(
@@ -177,6 +183,26 @@ v1Router.post(
       new Address(borrower).toScVal(),
       nativeToScVal(BigInt(loan_id), { type: "u64" }),
       nativeToScVal(BigInt(amount), { type: "i128" }),
+    ]);
+    res.json({ xdr: xdrTx });
+  })
+);
+
+// POST /loan/liquidate
+v1Router.post(
+  "/loan/liquidate",
+  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  writeLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = loanLiquidateSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({ error: "Validation failed", details: validation.error.errors });
+    }
+    const { liquidator, loan_id, repay_amount } = validation.data;
+    const xdrTx = await buildContractTx(liquidator, "liquidate", [
+      new Address(liquidator).toScVal(),
+      nativeToScVal(BigInt(loan_id), { type: "u64" }),
+      nativeToScVal(BigInt(repay_amount), { type: "i128" }),
     ]);
     res.json({ xdr: xdrTx });
   })

--- a/contracts/stellarkraal/src/lib.rs
+++ b/contracts/stellarkraal/src/lib.rs
@@ -16,6 +16,7 @@ const LIQ_THR: Symbol = symbol_short!("LIQTHR"); // liquidation threshold bps e.
 const TREASURY: Symbol = symbol_short!("TREASURY");
 const ORIG_FEE: Symbol = symbol_short!("ORIGFEE"); // origination fee bps e.g. 50 = 0.5%
 const INT_FEE: Symbol = symbol_short!("INTFEE");   // interest fee bps e.g. 1000 = 10%
+const CLOSE_FACTOR: Symbol = symbol_short!("CLSFACT"); // close factor bps e.g. 5000 = 50%
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 #[contracterror]
@@ -32,6 +33,8 @@ pub enum Error {
     InvalidAmount = 8,
     LoanAlreadyClosed = 9,
     InvalidFeeRate = 10,
+    ExceedsCloseFactor = 11,
+    InvalidCloseFactor = 12,
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -109,6 +112,7 @@ impl StellarKraal {
         env.storage().instance().set(&LIQ_THR, &liquidation_threshold_bps);
         env.storage().instance().set(&ORIG_FEE, &50u32); // 0.5%
         env.storage().instance().set(&INT_FEE, &1000u32); // 10%
+        env.storage().instance().set(&CLOSE_FACTOR, &5000u32); // 50%
         Ok(())
     }
 
@@ -271,9 +275,14 @@ impl StellarKraal {
     }
 
     // ── liquidate ─────────────────────────────────────────────────────────
-    pub fn liquidate(env: Env, liquidator: Address, loan_id: u64) -> Result<(), Error> {
+    /// `repay_amount`: how much debt the liquidator wants to repay.
+    /// Must be > 0 and ≤ outstanding * close_factor / 10_000.
+    pub fn liquidate(env: Env, liquidator: Address, loan_id: u64, repay_amount: i128) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_not_paused(&env)?;
+        if repay_amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
         liquidator.require_auth();
 
         let mut loan: LoanRecord = env
@@ -291,14 +300,45 @@ impl StellarKraal {
             return Err(Error::HealthFactorSafe);
         }
 
+        // Enforce close factor cap
+        let close_factor: u32 = env.storage().instance().get(&CLOSE_FACTOR).unwrap();
+        let max_repay = loan.outstanding
+            .checked_mul(close_factor as i128)
+            .ok_or(Error::InvalidAmount)?
+            / 10_000;
+        if repay_amount > max_repay {
+            return Err(Error::ExceedsCloseFactor);
+        }
+
         let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&liquidator, &env.current_contract_address(), &loan.outstanding);
+        token_client.transfer(&liquidator, &env.current_contract_address(), &repay_amount);
 
-        loan.status = LoanStatus::Liquidated;
-        loan.outstanding = 0;
+        loan.outstanding = loan.outstanding.checked_sub(repay_amount).ok_or(Error::InvalidAmount)?;
+        if loan.outstanding == 0 {
+            loan.status = LoanStatus::Liquidated;
+        }
         env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
         Ok(())
+    }
+
+    // ── set_close_factor ──────────────────────────────────────────────────
+    pub fn set_close_factor(env: Env, admin: Address, close_factor_bps: u32) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+        // Must be between 1 bps and 100% (10_000 bps)
+        if close_factor_bps == 0 || close_factor_bps > 10_000 {
+            return Err(Error::InvalidCloseFactor);
+        }
+        env.storage().instance().set(&CLOSE_FACTOR, &close_factor_bps);
+        Ok(())
+    }
+
+    // ── get_close_factor ──────────────────────────────────────────────────
+    pub fn get_close_factor(env: Env) -> Result<u32, Error> {
+        Self::assert_initialized(&env)?;
+        Ok(env.storage().instance().get(&CLOSE_FACTOR).unwrap())
     }
 
     // ── health_factor ─────────────────────────────────────────────────────

--- a/contracts/stellarkraal/src/tests.rs
+++ b/contracts/stellarkraal/src/tests.rs
@@ -171,7 +171,177 @@ mod tests {
         let liquidator = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
         let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
-        client.liquidate(&liquidator, &loan_id);
+        // 50% of 600_000 = 300_000
+        client.liquidate(&liquidator, &loan_id, &300_000i128);
+    }
+
+    #[test]
+    fn test_partial_liquidation_reduces_outstanding() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let liquidator = Address::generate(&env);
+        // collateral = 500_000, LTV 60% → max loan 300_000
+        // liq threshold 80% → hf = (500_000 * 8000) / (300_000 * 10_000) = 1.333 → safe
+        // Use a loan that is undercollateralised: borrow 450_000 against 500_000
+        // hf = (500_000 * 8000) / (450_000 * 10_000) = 0.888 < 1 → liquidatable
+        // But LTV cap prevents borrowing 450_000 (max = 300_000).
+        // Workaround: register with high value, borrow at LTV, then simulate price drop
+        // by registering a new collateral with lower value and a loan that exceeds threshold.
+        // Simplest: use collateral_value stored in loan vs outstanding.
+        // Register 1_000_000 collateral, borrow 600_000 (at LTV), then partially repay
+        // to make outstanding = 900_000 — not possible without extra debt.
+        // Instead: register collateral 500_000, borrow 300_000 (LTV 60%).
+        // hf = (500_000 * 8000) / (300_000 * 10_000) = 1.333 — safe.
+        // To get an undercollateralised loan we need outstanding > collateral * liq_thr / 10_000.
+        // collateral * 0.8 < outstanding → outstanding > 400_000 for collateral=500_000.
+        // We can't borrow more than LTV allows via request_loan.
+        // Use a large collateral so LTV allows a big loan, then the stored collateral_value
+        // is the same. Let's use collateral=1_000_000, borrow=600_000 (LTV 60%).
+        // hf = (1_000_000 * 8000) / (600_000 * 10_000) = 1.333 — still safe.
+        // The only way to get hf < 1 in tests is to have outstanding > collateral * liq_thr.
+        // We need collateral_value < outstanding / 0.8.
+        // Register collateral=100_000, borrow=60_000 (LTV 60%).
+        // hf = (100_000 * 8000) / (60_000 * 10_000) = 1.333 — safe.
+        // We need a loan where outstanding > collateral * 0.8.
+        // The only way without a price oracle update is to register a very small collateral
+        // and borrow at exactly LTV, then the stored collateral_value is small enough.
+        // collateral=100, borrow=60 (LTV 60%). hf = (100*8000)/(60*10000) = 1.333 — still safe.
+        // The issue: at LTV=60% and liq_thr=80%, a loan at max LTV always has hf=1.333.
+        // To test liquidation we need to manipulate collateral_value after the fact.
+        // We'll use a direct storage manipulation via env.as_contract.
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+
+        // Simulate collateral price drop: overwrite loan's collateral_value to 500_000
+        // so hf = (500_000 * 8000) / (600_000 * 10_000) = 0.666 < 1 → liquidatable
+        env.as_contract(&cid, || {
+            let mut loan: LoanRecord = env.storage().persistent().get(&DataKey::Loan(loan_id)).unwrap();
+            loan.collateral_value = 500_000;
+            env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        });
+
+        // close factor = 50% → max repay = 600_000 * 50% = 300_000
+        client.liquidate(&liquidator, &loan_id, &300_000i128);
+        let loan = client.get_loan(&loan_id);
+        assert_eq!(loan.outstanding, 300_000);
+        assert_eq!(loan.status, LoanStatus::Active); // still active, not fully liquidated
+    }
+
+    #[test]
+    fn test_full_liquidation_via_two_partial_steps() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let liquidator = Address::generate(&env);
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+
+        env.as_contract(&cid, || {
+            let mut loan: LoanRecord = env.storage().persistent().get(&DataKey::Loan(loan_id)).unwrap();
+            loan.collateral_value = 500_000;
+            env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        });
+
+        // Step 1: liquidate 50% (300_000)
+        client.liquidate(&liquidator, &loan_id, &300_000i128);
+        // Step 2: liquidate remaining 50% (150_000 = 300_000 * 50%)
+        client.liquidate(&liquidator, &loan_id, &150_000i128);
+        let loan = client.get_loan(&loan_id);
+        assert_eq!(loan.outstanding, 150_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "ExceedsCloseFactor")]
+    fn test_liquidate_exceeds_close_factor_fails() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let liquidator = Address::generate(&env);
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+
+        env.as_contract(&cid, || {
+            let mut loan: LoanRecord = env.storage().persistent().get(&DataKey::Loan(loan_id)).unwrap();
+            loan.collateral_value = 500_000;
+            env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        });
+
+        // Try to repay 300_001 — exceeds 50% close factor cap of 300_000
+        client.liquidate(&liquidator, &loan_id, &300_001i128);
+    }
+
+    #[test]
+    fn test_set_close_factor_by_admin_ok() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        client.set_close_factor(&admin, &7500u32); // 75%
+        assert_eq!(client.get_close_factor(), 7500u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_set_close_factor_non_admin_fails() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let attacker = Address::generate(&env);
+        client.set_close_factor(&attacker, &7500u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidCloseFactor")]
+    fn test_set_close_factor_zero_fails() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        client.set_close_factor(&admin, &0u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidCloseFactor")]
+    fn test_set_close_factor_above_100pct_fails() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        client.set_close_factor(&admin, &10_001u32);
+    }
+
+    #[test]
+    fn test_get_close_factor_default_is_5000() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        assert_eq!(client.get_close_factor(), 5000u32);
+    }
+
+    #[test]
+    fn test_liquidate_full_with_100pct_close_factor() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        // Set close factor to 100%
+        client.set_close_factor(&admin, &10_000u32);
+        let borrower = Address::generate(&env);
+        let liquidator = Address::generate(&env);
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+
+        env.as_contract(&cid, || {
+            let mut loan: LoanRecord = env.storage().persistent().get(&DataKey::Loan(loan_id)).unwrap();
+            loan.collateral_value = 500_000;
+            env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        });
+
+        // With 100% close factor, can repay entire outstanding in one shot
+        client.liquidate(&liquidator, &loan_id, &600_000i128);
+        let loan = client.get_loan(&loan_id);
+        assert_eq!(loan.outstanding, 0);
+        assert_eq!(loan.status, LoanStatus::Liquidated);
     }
 
     // ── get_loan / get_collateral ─────────────────────────────────────────
@@ -354,7 +524,7 @@ mod tests {
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
         let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
         client.pause(&admin);
-        client.liquidate(&liquidator, &loan_id);
+        client.liquidate(&liquidator, &loan_id, &300_000i128);
     }
 
     #[test]
@@ -605,7 +775,7 @@ mod tests {
             // Invariant 6: Liquidation only possible when hf < 10,000
             if hf >= 10_000 {
                 let res = env.as_contract(&cid, || {
-                   client.liquidate(&liquidator, &loan_id)
+                   client.liquidate(&liquidator, &loan_id, &1i128)
                 });
                 // In the real sdk this might panic or return Err, our setup() mocks all auths.
                 // If it doesn't panic, it should return Error::HealthFactorSafe.


### PR DESCRIPTION
i Add CLOSE_FACTOR storage key (default 50% / 5000 bps)
- liquidate() now accepts repay_amount capped by close factor
- Add set_close_factor() and get_close_factor() admin functions
- Add ExceedsCloseFactor and InvalidCloseFactor error variants
- Add POST /loan/liquidate backend route
- Add 9 contract tests for partial liquidation and close factor


closes #119 