### PR TITLE
feat: add multi-collateral support for mixed livestock portfolios

### DIFF
--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -47,7 +47,7 @@ const registerCollateralSchema = z.object({
 
 const loanRequestSchema = z.object({
   borrower: stellarPublicKeySchema,
-  collateral_id: z.number().int().nonnegative(),
+  collateral_ids: z.array(z.number().int().nonnegative()).min(1),
   amount: z.number().int().positive(),
 });
 
@@ -147,18 +147,14 @@ v1Router.post(
     if (!validation.success) {
       return res.status(400).json({ error: "Validation failed", details: validation.error.errors });
     }
-    const { borrower, collateral_id, amount } = validation.data;
-    const cacheKey = String(collateral_id);
-    const cached = getAppraisal(cacheKey);
-    if (!cached && req.body.appraised_value !== undefined) {
-      setAppraisal(cacheKey, req.body.appraised_value);
-    }
+    const { borrower, collateral_ids, amount } = validation.data;
+    const idsScVal = xdr.ScVal.scvVec(collateral_ids.map(id => nativeToScVal(BigInt(id), { type: "u64" })));
     const xdrTx = await buildContractTx(borrower, "request_loan", [
       new Address(borrower).toScVal(),
-      nativeToScVal(BigInt(collateral_id), { type: "u64" }),
+      idsScVal,
       nativeToScVal(BigInt(amount), { type: "i128" }),
     ]);
-    res.json({ xdr: xdrTx, ...(cached?.stale ? { stale: true } : {}) });
+    res.json({ xdr: xdrTx });
   })
 );
 

--- a/contracts/stellarkraal/src/lib.rs
+++ b/contracts/stellarkraal/src/lib.rs
@@ -4,7 +4,7 @@ mod tests;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol,
-    events,
+    Vec, events,
 };
 
 // ── Storage keys ────────────────────────────────────────────────────────────
@@ -58,8 +58,8 @@ pub struct CollateralRecord {
 pub struct LoanRecord {
     pub id: u64,
     pub borrower: Address,
-    pub collateral_id: u64,
-    pub collateral_value: i128, // Packed from CollateralRecord to save reads
+    pub collateral_ids: Vec<u64>,
+    pub total_collateral_value: i128,
     pub principal: i128,
     pub outstanding: i128,
     pub status: LoanStatus,
@@ -148,7 +148,7 @@ impl StellarKraal {
     pub fn request_loan(
         env: Env,
         borrower: Address,
-        collateral_id: u64,
+        collateral_ids: Vec<u64>,
         amount: i128,
     ) -> Result<u64, Error> {
         Self::assert_initialized(&env)?;
@@ -156,20 +156,29 @@ impl StellarKraal {
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
+        if collateral_ids.is_empty() {
+            return Err(Error::CollateralNotFound);
+        }
         borrower.require_auth();
 
-        let collateral: CollateralRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Collateral(collateral_id))
-            .ok_or(Error::CollateralNotFound)?;
-
-        if collateral.owner != borrower {
-            return Err(Error::Unauthorized);
+        // Sum appraised values across all collaterals, verify ownership
+        let mut total_collateral_value: i128 = 0;
+        for col_id in collateral_ids.iter() {
+            let collateral: CollateralRecord = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Collateral(col_id))
+                .ok_or(Error::CollateralNotFound)?;
+            if collateral.owner != borrower {
+                return Err(Error::Unauthorized);
+            }
+            total_collateral_value = total_collateral_value
+                .checked_add(collateral.appraised_value)
+                .ok_or(Error::InvalidAmount)?;
         }
 
         let ltv: u32 = env.storage().instance().get(&LTV).unwrap();
-        let max_loan = collateral.appraised_value
+        let max_loan = total_collateral_value
             .checked_mul(ltv as i128)
             .ok_or(Error::InvalidAmount)?
             / 10_000;
@@ -187,21 +196,28 @@ impl StellarKraal {
         let loan = LoanRecord {
             id: loan_id,
             borrower: borrower.clone(),
-            collateral_id,
-            collateral_value: collateral.appraised_value,
+            collateral_ids: collateral_ids.clone(),
+            total_collateral_value,
             principal: amount,
             outstanding: amount,
             status: LoanStatus::Active,
         };
         env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
 
-        let mut col = collateral;
-        col.loan_id = loan_id;
-        env.storage().persistent().set(&DataKey::Collateral(collateral_id), &col);
+        // Mark all collaterals as locked to this loan
+        for col_id in collateral_ids.iter() {
+            let mut col: CollateralRecord = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Collateral(col_id))
+                .unwrap();
+            col.loan_id = loan_id;
+            env.storage().persistent().set(&DataKey::Collateral(col_id), &col);
+        }
 
         let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
-        
+
         // Transfer fee to treasury
         if fee > 0 {
             let treasury: Address = env.storage().instance().get(&TREASURY).unwrap();
@@ -328,6 +344,25 @@ impl StellarKraal {
             .ok_or(Error::CollateralNotFound)
     }
 
+    // ── get_loan_collaterals ──────────────────────────────────────────────
+    pub fn get_loan_collaterals(env: Env, loan_id: u64) -> Result<Vec<CollateralRecord>, Error> {
+        let loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(Error::LoanNotFound)?;
+        let mut records: Vec<CollateralRecord> = Vec::new(&env);
+        for col_id in loan.collateral_ids.iter() {
+            let col: CollateralRecord = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Collateral(col_id))
+                .ok_or(Error::CollateralNotFound)?;
+            records.push_back(col);
+        }
+        Ok(records)
+    }
+
     // ── update_fee_config ─────────────────────────────────────────────────
     pub fn update_fee_config(
         env: Env,
@@ -407,11 +442,10 @@ impl StellarKraal {
         if loan.outstanding == 0 {
             return Ok(i128::MAX);
         }
-        
         let liq_thr: u32 = env.storage().instance().get(&LIQ_THR).unwrap();
-        // health = (collateral_value * liq_threshold) / (outstanding * 10_000)
+        // health = (total_collateral_value * liq_threshold) / (outstanding * 10_000)
         let numerator = loan
-            .collateral_value
+            .total_collateral_value
             .checked_mul(liq_thr as i128)
             .ok_or(Error::InvalidAmount)?;
         let denominator = loan.outstanding.checked_mul(10_000).ok_or(Error::InvalidAmount)?;

--- a/contracts/stellarkraal/src/tests.rs
+++ b/contracts/stellarkraal/src/tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::*;
     use soroban_sdk::{
-        symbol_short,
+        symbol_short, vec,
         testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
         Address, Env, IntoVal,
     };
@@ -79,7 +79,7 @@ mod tests {
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
         // max loan = 1_000_000 * 60% = 600_000
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         assert_eq!(loan_id, 1);
     }
 
@@ -91,7 +91,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        client.request_loan(&borrower, &col_id, &700_000i128);
+        client.request_loan(&borrower, &vec![&env, col_id], &700_000i128);
     }
 
     #[test]
@@ -103,7 +103,60 @@ mod tests {
         let owner = Address::generate(&env);
         let attacker = Address::generate(&env);
         let col_id = client.register_livestock(&owner, &symbol_short!("goat"), &3u32, &500_000i128);
-        client.request_loan(&attacker, &col_id, &100_000i128);
+        client.request_loan(&attacker, &vec![&env, col_id], &100_000i128);
+    }
+
+    #[test]
+    fn test_request_loan_multi_collateral() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        // cattle=600_000 + goats=400_000 = 1_000_000 total; max loan = 600_000
+        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
+        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &5u32, &400_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
+        let loan = client.get_loan(&loan_id);
+        assert_eq!(loan.total_collateral_value, 1_000_000);
+        assert_eq!(loan.collateral_ids.len(), 2);
+    }
+
+    #[test]
+    fn test_request_loan_three_collaterals() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &300_000i128);
+        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &200_000i128);
+        let col3 = client.register_livestock(&borrower, &symbol_short!("sheep"), &5u32, &100_000i128);
+        // total = 600_000; max loan = 360_000
+        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2, col3], &360_000i128);
+        let loan = client.get_loan(&loan_id);
+        assert_eq!(loan.total_collateral_value, 600_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "InsufficientCollateral")]
+    fn test_multi_collateral_exceeds_combined_ltv() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &500_000i128);
+        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &2u32, &500_000i128);
+        // total = 1_000_000; max = 600_000; request 700_000 → fail
+        client.request_loan(&borrower, &vec![&env, col1, col2], &700_000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "CollateralNotFound")]
+    fn test_request_loan_empty_collateral_ids_fails() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        client.request_loan(&borrower, &vec![&env], &100_000i128);
     }
 
     // ── repay_loan ────────────────────────────────────────────────────────
@@ -114,7 +167,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.repay_loan(&borrower, &loan_id, &200_000i128);
         let loan = client.get_loan(&loan_id);
         assert_eq!(loan.outstanding, 400_000);
@@ -127,7 +180,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.repay_loan(&borrower, &loan_id, &600_000i128);
         let loan = client.get_loan(&loan_id);
         assert_eq!(loan.status, LoanStatus::Repaid);
@@ -141,7 +194,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.repay_loan(&borrower, &loan_id, &600_000i128);
         client.repay_loan(&borrower, &loan_id, &1i128); // should panic
     }
@@ -154,7 +207,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         let hf = client.health_factor(&loan_id);
         // hf = (1_000_000 * 8000) / (600_000 * 10_000) * 10_000 = 13_333
         assert!(hf >= 10_000, "health factor should be >= 1.0");
@@ -170,7 +223,7 @@ mod tests {
         let borrower = Address::generate(&env);
         let liquidator = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.liquidate(&liquidator, &loan_id);
     }
 
@@ -182,7 +235,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("sheep"), &10u32, &2_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &500_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &500_000i128);
         let loan = client.get_loan(&loan_id);
         assert_eq!(loan.principal, 500_000);
         assert_eq!(loan.borrower, borrower);
@@ -198,6 +251,21 @@ mod tests {
         let col = client.get_collateral(&col_id);
         assert_eq!(col.count, 7);
         assert_eq!(col.appraised_value, 700_000);
+    }
+
+    #[test]
+    fn test_get_loan_collaterals_ok() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
+        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &400_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
+        let collaterals = client.get_loan_collaterals(&loan_id);
+        assert_eq!(collaterals.len(), 2);
+        assert_eq!(collaterals.get(0).unwrap().animal_type, symbol_short!("cattle"));
+        assert_eq!(collaterals.get(1).unwrap().animal_type, symbol_short!("goat"));
     }
 
     #[test]
@@ -239,7 +307,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        client.request_loan(&borrower, &col_id, &0i128);
+        client.request_loan(&borrower, &vec![&env, col_id], &0i128);
     }
 
     #[test]
@@ -250,7 +318,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.repay_loan(&borrower, &loan_id, &0i128);
     }
 
@@ -273,7 +341,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         // Repay more than outstanding — should cap and mark Repaid
         client.repay_loan(&borrower, &loan_id, &999_999_999i128);
         let loan = client.get_loan(&loan_id);
@@ -340,7 +408,7 @@ mod tests {
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
         client.pause(&admin);
-        client.request_loan(&borrower, &col_id, &600_000i128);
+        client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
     }
 
     #[test]
@@ -352,7 +420,7 @@ mod tests {
         let borrower = Address::generate(&env);
         let liquidator = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.pause(&admin);
         client.liquidate(&liquidator, &loan_id);
     }
@@ -364,7 +432,7 @@ mod tests {
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &col_id, &600_000i128);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
         client.pause(&admin);
         client.repay_loan(&borrower, &loan_id, &200_000i128);
         let loan = client.get_loan(&loan_id);
@@ -550,7 +618,7 @@ mod tests {
             // Register enough collateral for the amount
             let val = amount * 2; 
             let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &col_id, &amount);
+            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
             
             client.repay_loan(&borrower, &loan_id, &repay);
             let loan = client.get_loan(&loan_id);
@@ -570,7 +638,7 @@ mod tests {
             let client = StellarKraalClient::new(&env, &cid);
             let borrower = Address::generate(&env);
             let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &(amount * 2));
-            let loan_id = client.request_loan(&borrower, &col_id, &amount);
+            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
             
             client.repay_loan(&borrower, &loan_id, &amount);
             let hf = client.health_factor(&loan_id);
@@ -598,7 +666,7 @@ mod tests {
             
             let val = amount * 10 / 7; // So amount is ~70% of val (between 60% and 80%)
             let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &col_id, &amount);
+            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
             
             let hf = client.health_factor(&loan_id);
             
@@ -625,17 +693,17 @@ mod tests {
             if amount <= 0 { return Ok(()); }
             
             let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &col_id, &amount);
+            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
             
             let loan = client.get_loan(&loan_id);
             // Invariant 7: Status is Active after request
             assert_eq!(loan.status, LoanStatus::Active);
             // Invariant 8: Borrower matches
             assert_eq!(loan.borrower, borrower);
-            // Invariant 9: Collateral ID matches
-            assert_eq!(loan.collateral_id, col_id);
-            // Invariant 10: Packed collateral value matches
-            assert_eq!(loan.collateral_value, val);
+            // Invariant 9: Collateral IDs contains the registered collateral
+            assert_eq!(loan.collateral_ids.get(0).unwrap(), col_id);
+            // Invariant 10: Packed total collateral value matches
+            assert_eq!(loan.total_collateral_value, val);
             // Invariant 11: Initial outstanding == principal
             assert_eq!(loan.outstanding, loan.principal);
         }


### PR DESCRIPTION
the  LoanRecord: replace collateral_id/collateral_value with collateral_ids: Vec<u64> and total_collateral_value: i128
- request_loan: accepts Vec<u64> collateral IDs, sums appraised values across all assets, marks each collateral locked to loan
- compute_health_factor: aggregates total_collateral_value
- add get_loan_collaterals() to retrieve all CollateralRecords for a loan
- backend: loanRequestSchema updated to collateral_ids array
- tests: all calls updated; 5 new multi-collateral tests added

closes #120 