### PR TITLE
feat: integrate React Query for server state management with caching

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",
     "@stellar/stellar-sdk": "^12.0.0",
+    "@tanstack/react-query": "^5.74.4",
     "next": "14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,31 +1,33 @@
 "use client";
+
 import { useState } from "react";
 import WalletConnect from "@/components/WalletConnect";
 import CollateralCard from "@/components/CollateralCard";
+import LoanRepaymentCalculator from "@/components/LoanRepaymentCalculator";
 import RepayPanel from "@/components/RepayPanel";
 import HealthGauge from "@/components/HealthGauge";
-import LoanRepaymentCalculator from "@/components/LoanRepaymentCalculator";
+import { useHealthFactor } from "@/hooks/use-queries";
 
 export default function Dashboard() {
   const [wallet, setWallet] = useState<string | null>(null);
   const [loanId, setLoanId] = useState("");
-  const [healthFactor, setHealthFactor] = useState<number | null>(null);
   const [repayLoanId, setRepayLoanId] = useState("");
   const [repayAmount, setRepayAmount] = useState("");
+
+  const parsedLoanId = loanId ? Number(loanId) : null;
+  const {
+    data: healthData,
+    isLoading: healthLoading,
+    error: healthError,
+    refetch: fetchHealth,
+  } = useHealthFactor(parsedLoanId);
 
   function handleProceedToRepay(nextLoanId: string, nextAmount: string) {
     setRepayLoanId(nextLoanId);
     setRepayAmount(nextAmount);
   }
 
-  async function fetchHealth() {
-    if (!loanId) return;
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/health/${loanId}`,
-    );
-    const data = await res.json();
-    setHealthFactor(Number(data.health_factor ?? 0));
-  }
+  const healthFactor = healthData?.health_factor ?? null;
 
   return (
     <main className="max-w-2xl mx-auto px-4 py-10">
@@ -50,15 +52,20 @@ export default function Dashboard() {
                 placeholder="Loan ID"
                 value={loanId}
                 onChange={(e) => setLoanId(e.target.value)}
+                type="number"
               />
               <button
-                onClick={fetchHealth}
-                className="bg-gold text-brown font-semibold px-4 py-2 rounded-lg hover:bg-gold/80 transition"
+                onClick={() => fetchHealth()}
+                disabled={healthLoading || !loanId}
+                className="bg-gold text-brown font-semibold px-4 py-2 rounded-lg hover:bg-gold/80 transition disabled:opacity-50"
               >
-                Check
+                {healthLoading ? "..." : "Check"}
               </button>
             </div>
-            {healthFactor !== null && <HealthGauge value={healthFactor} />}
+            {healthError && (
+              <p className="text-sm text-red-600 mt-2">{healthError.message}</p>
+            )}
+            {healthFactor !== null && !healthError && <HealthGauge value={healthFactor} />}
           </div>
         </>
       )}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { ReactQueryProvider } from "./providers";
 
 export const metadata: Metadata = {
   title: "StellarKraal — Livestock Micro-Lending",
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-cream text-brown min-h-screen">{children}</body>
+      <body className="bg-cream text-brown min-h-screen">
+        <ReactQueryProvider>{children}</ReactQueryProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function ReactQueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30 * 1000,
+            gcTime: 5 * 60 * 1000,
+            refetchOnWindowFocus: true,
+            refetchOnReconnect: true,
+            retry: 2,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/frontend/src/components/CollateralCard.tsx
+++ b/frontend/src/components/CollateralCard.tsx
@@ -1,26 +1,16 @@
 "use client";
 import { useState } from "react";
+import { useLoan } from "@/hooks/use-queries";
 
 interface Props {
   walletAddress: string;
 }
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
-
 export default function CollateralCard({ walletAddress }: Props) {
   const [collateralId, setCollateralId] = useState("");
-  const [data, setData] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
 
-  async function lookup() {
-    setLoading(true);
-    try {
-      const res = await fetch(`${API}/api/loan/${collateralId}`);
-      setData(await res.json());
-    } finally {
-      setLoading(false);
-    }
-  }
+  const parsedId = collateralId ? Number(collateralId) : null;
+  const { data, isLoading: loading, error } = useLoan(parsedId);
 
   return (
     <div className="bg-white rounded-2xl p-6 shadow mb-4">
@@ -31,11 +21,15 @@ export default function CollateralCard({ walletAddress }: Props) {
           placeholder="Loan ID"
           value={collateralId}
           onChange={(e) => setCollateralId(e.target.value)}
+          type="number"
         />
-        <button onClick={lookup} disabled={loading} className="bg-brown text-cream px-4 py-2 rounded-lg hover:bg-brown/80 transition disabled:opacity-50">
-          {loading ? "…" : "Fetch"}
-        </button>
+        <div className="bg-brown text-cream px-4 py-2 rounded-lg min-w-[80px] text-center">
+          {loading ? "…" : "Ready"}
+        </div>
       </div>
+      {error && (
+        <p className="text-sm text-red-600 mt-2">{error.message}</p>
+      )}
       {data && (
         <pre className="mt-4 bg-cream rounded-lg p-3 text-xs overflow-auto">
           {JSON.stringify(data, null, 2)}

--- a/frontend/src/components/LoanForm.tsx
+++ b/frontend/src/components/LoanForm.tsx
@@ -2,13 +2,13 @@
 import { useState } from "react";
 import { signTransaction } from "@stellar/freighter-api";
 import { submitSignedXdr } from "@/lib/stellarUtils";
+import { useRegisterCollateral, useRequestLoan } from "@/hooks/use-queries";
 
 interface Props {
   walletAddress: string;
 }
 
 const ANIMAL_TYPES = ["cattle", "goat", "sheep"];
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
 export default function LoanForm({ walletAddress }: Props) {
   const [step, setStep] = useState<"collateral" | "loan">("collateral");
@@ -18,55 +18,43 @@ export default function LoanForm({ walletAddress }: Props) {
   const [collateralId, setCollateralId] = useState("");
   const [loanAmount, setLoanAmount] = useState("");
   const [status, setStatus] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+
+  const registerCollateralMutation = useRegisterCollateral();
+  const requestLoanMutation = useRequestLoan();
+
+  const loading = registerCollateralMutation.isPending || requestLoanMutation.isPending;
 
   async function registerCollateral() {
-    setLoading(true);
     setStatus(null);
     try {
-      const res = await fetch(`${API}/api/collateral/register`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          owner: walletAddress,
-          animal_type: animalType,
-          count: parseInt(count),
-          appraised_value: parseInt(appraisedValue),
-        }),
+      const { xdr } = await registerCollateralMutation.mutateAsync({
+        owner: walletAddress,
+        animal_type: animalType,
+        count: parseInt(count),
+        appraised_value: parseInt(appraisedValue),
       });
-      const { xdr } = await res.json();
       const { signedTxXdr } = await signTransaction(xdr, { network: process.env.NEXT_PUBLIC_NETWORK || "TESTNET" });
       const result = await submitSignedXdr(signedTxXdr);
       setStatus(`✅ Collateral registered! ID: ${result}`);
       setStep("loan");
     } catch (e: any) {
       setStatus(`❌ ${e.message}`);
-    } finally {
-      setLoading(false);
     }
   }
 
   async function requestLoan() {
-    setLoading(true);
     setStatus(null);
     try {
-      const res = await fetch(`${API}/api/loan/request`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          borrower: walletAddress,
-          collateral_id: parseInt(collateralId),
-          amount: parseInt(loanAmount),
-        }),
+      const { xdr } = await requestLoanMutation.mutateAsync({
+        borrower: walletAddress,
+        collateral_id: parseInt(collateralId),
+        amount: parseInt(loanAmount),
       });
-      const { xdr } = await res.json();
       const { signedTxXdr } = await signTransaction(xdr, { network: process.env.NEXT_PUBLIC_NETWORK || "TESTNET" });
       const result = await submitSignedXdr(signedTxXdr);
       setStatus(`✅ Loan disbursed! Loan ID: ${result}`);
     } catch (e: any) {
       setStatus(`❌ ${e.message}`);
-    } finally {
-      setLoading(false);
     }
   }
 

--- a/frontend/src/components/LoanRepaymentCalculator.tsx
+++ b/frontend/src/components/LoanRepaymentCalculator.tsx
@@ -1,26 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import HealthGauge from "@/components/HealthGauge";
+import { useLoans, useRepaymentPreview, RepaymentPreview } from "@/hooks/use-queries";
 
 interface Props {
   onProceed: (loanId: string, amount: string) => void;
 }
-
-interface RepaymentPreview {
-  loan_id: number;
-  repayment_amount: number;
-  breakdown: {
-    principal: number;
-    interest: number;
-    fees: number;
-    remaining_balance: number;
-  };
-  projected_health_factor_bps: number | null;
-  fully_repaid: boolean;
-}
-
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
 function formatAmount(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
@@ -29,81 +15,28 @@ function formatAmount(value: number): string {
 export default function LoanRepaymentCalculator({ onProceed }: Props) {
   const [loanId, setLoanId] = useState("");
   const [amount, setAmount] = useState("");
-  const [loanOptions, setLoanOptions] = useState<number[]>([]);
-  const [preview, setPreview] = useState<RepaymentPreview | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const parsedLoanId = useMemo(() => Number(loanId), [loanId]);
   const parsedAmount = useMemo(() => Number(amount), [amount]);
 
-  useEffect(() => {
-    let mounted = true;
+  const { data: loansData } = useLoans(1, 50);
+  const loanOptions = useMemo(() => {
+    if (!loansData?.data) return [];
+    return loansData.data
+      .map((item) => Number(item?.id))
+      .filter((id) => Number.isFinite(id));
+  }, [loansData]);
 
-    async function loadLoans() {
-      try {
-        const res = await fetch(`${API}/api/loans?page=1&pageSize=50`);
-        if (!res.ok) return;
-        const body = await res.json();
-        const ids = Array.isArray(body?.data)
-          ? body.data
-              .map((item: { id?: number | string }) => Number(item?.id))
-              .filter((id: number) => Number.isFinite(id))
-          : [];
-        if (mounted) {
-          setLoanOptions(ids);
-        }
-      } catch {
-        // Optional enhancement: loan options are non-blocking.
-      }
-    }
+  const {
+    data: preview,
+    isLoading: loading,
+    error,
+  } = useRepaymentPreview(
+    Number.isInteger(parsedLoanId) && parsedLoanId >= 0 ? parsedLoanId : null,
+    Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : null
+  );
 
-    void loadLoans();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (
-      !Number.isInteger(parsedLoanId) ||
-      parsedLoanId < 0 ||
-      !Number.isFinite(parsedAmount) ||
-      parsedAmount <= 0
-    ) {
-      setPreview(null);
-      setError(null);
-      return;
-    }
-
-    const timeout = setTimeout(async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const res = await fetch(`${API}/api/loan/repayment-preview`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ loan_id: parsedLoanId, amount: parsedAmount }),
-        });
-
-        const body = await res.json();
-        if (!res.ok) {
-          setPreview(null);
-          setError(body?.error || "Unable to calculate repayment preview");
-          return;
-        }
-
-        setPreview(body as RepaymentPreview);
-      } catch (e: any) {
-        setPreview(null);
-        setError(e?.message || "Unable to calculate repayment preview");
-      } finally {
-        setLoading(false);
-      }
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [parsedAmount, parsedLoanId]);
+  const errorMessage = error ? (error as Error).message : null;
 
   return (
     <div className="bg-white rounded-2xl p-6 shadow mb-4">

--- a/frontend/src/components/RepayPanel.tsx
+++ b/frontend/src/components/RepayPanel.tsx
@@ -2,14 +2,13 @@
 import { useEffect, useState } from "react";
 import { signTransaction } from "@stellar/freighter-api";
 import { submitSignedXdr } from "@/lib/stellarUtils";
+import { useRepayLoan } from "@/hooks/use-queries";
 
 interface Props {
   walletAddress: string;
   initialLoanId?: string;
   initialAmount?: string;
 }
-
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
 export default function RepayPanel({
   walletAddress,
@@ -19,7 +18,9 @@ export default function RepayPanel({
   const [loanId, setLoanId] = useState(initialLoanId);
   const [amount, setAmount] = useState(initialAmount);
   const [status, setStatus] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+
+  const repayMutation = useRepayLoan();
+  const loading = repayMutation.isPending;
 
   useEffect(() => {
     setLoanId(initialLoanId);
@@ -30,19 +31,13 @@ export default function RepayPanel({
   }, [initialAmount]);
 
   async function repay() {
-    setLoading(true);
     setStatus(null);
     try {
-      const res = await fetch(`${API}/api/loan/repay`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          borrower: walletAddress,
-          loan_id: parseInt(loanId),
-          amount: parseInt(amount),
-        }),
+      const { xdr } = await repayMutation.mutateAsync({
+        borrower: walletAddress,
+        loan_id: parseInt(loanId),
+        amount: parseInt(amount),
       });
-      const { xdr } = await res.json();
       const { signedTxXdr } = await signTransaction(xdr, {
         network: process.env.NEXT_PUBLIC_NETWORK || "TESTNET",
       });
@@ -50,8 +45,6 @@ export default function RepayPanel({
       setStatus("✅ Repayment submitted!");
     } catch (e: any) {
       setStatus(`❌ ${e.message}`);
-    } finally {
-      setLoading(false);
     }
   }
 

--- a/frontend/src/hooks/use-queries.ts
+++ b/frontend/src/hooks/use-queries.ts
@@ -1,0 +1,141 @@
+import {
+  useQuery,
+  useMutation,
+  UseQueryResult,
+  UseMutationResult,
+  QueryClient,
+} from "@tanstack/react-query";
+import {
+  fetchHealthFactor,
+  fetchLoan,
+  fetchLoans,
+  fetchRepaymentPreview,
+  registerCollateral,
+  requestLoan,
+  repayLoan,
+  HealthFactorResponse,
+  Loan,
+  LoansListResponse,
+  RepaymentPreview,
+  RegisterCollateralRequest,
+  RegisterCollateralResponse,
+  RequestLoanRequest,
+  RequestLoanResponse,
+  RepayLoanRequest,
+  RepayLoanResponse,
+} from "@/lib/api";
+
+export type { RepaymentPreview };
+
+const queryKeys = {
+  healthFactor: (loanId: string | number) => ["healthFactor", loanId],
+  loan: (loanId: string | number) => ["loan", loanId],
+  loans: (page: number, pageSize: number) => ["loans", page, pageSize],
+  repaymentPreview: (loanId: number, amount: number) =>
+    ["repaymentPreview", loanId, amount] as const,
+};
+
+const cacheConfig = {
+  healthFactor: {
+    staleTime: 30 * 1000,
+    gcTime: 2 * 60 * 1000,
+  },
+  loan: {
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+  },
+  loans: {
+    staleTime: 30 * 1000,
+    gcTime: 2 * 60 * 1000,
+  },
+  repaymentPreview: {
+    staleTime: 5 * 1000,
+    gcTime: 30 * 1000,
+  },
+};
+
+export function useHealthFactor(
+  loanId: string | number | null
+): UseQueryResult<HealthFactorResponse, Error> {
+  return useQuery({
+    queryKey: queryKeys.healthFactor(loanId ?? ""),
+    queryFn: () => fetchHealthFactor(loanId!),
+    enabled: !!loanId,
+    ...cacheConfig.healthFactor,
+  });
+}
+
+export function useLoan(
+  loanId: string | number | null
+): UseQueryResult<Loan, Error> {
+  return useQuery({
+    queryKey: queryKeys.loan(loanId ?? ""),
+    queryFn: () => fetchLoan(loanId!),
+    enabled: !!loanId,
+    ...cacheConfig.loan,
+  });
+}
+
+export function useLoans(
+  page = 1,
+  pageSize = 50
+): UseQueryResult<LoansListResponse, Error> {
+  return useQuery({
+    queryKey: queryKeys.loans(page, pageSize),
+    queryFn: () => fetchLoans(page, pageSize),
+    ...cacheConfig.loans,
+  });
+}
+
+export function useRepaymentPreview(
+  loanId: number | null,
+  amount: number | null
+): UseQueryResult<RepaymentPreview, Error> {
+  const enabled = !!loanId && !!amount && amount > 0;
+
+  return useQuery({
+    queryKey: queryKeys.repaymentPreview(loanId ?? 0, amount ?? 0),
+    queryFn: () => fetchRepaymentPreview(loanId!, amount!),
+    enabled,
+    ...cacheConfig.repaymentPreview,
+  });
+}
+
+export function useRegisterCollateral(
+  queryClient?: QueryClient
+): UseMutationResult<RegisterCollateralResponse, Error, RegisterCollateralRequest> {
+  return useMutation({
+    mutationFn: registerCollateral,
+    onSuccess: () => {
+      queryClient?.invalidateQueries({ queryKey: ["loans"] });
+    },
+  });
+}
+
+export function useRequestLoan(
+  queryClient?: QueryClient
+): UseMutationResult<RequestLoanResponse, Error, RequestLoanRequest> {
+  return useMutation({
+    mutationFn: requestLoan,
+    onSuccess: () => {
+      queryClient?.invalidateQueries({ queryKey: ["loans"] });
+    },
+  });
+}
+
+export function useRepayLoan(
+  queryClient?: QueryClient
+): UseMutationResult<RepayLoanResponse, Error, RepayLoanRequest> {
+  return useMutation({
+    mutationFn: repayLoan,
+    onSuccess: (_data: RepayLoanResponse, variables: RepayLoanRequest) => {
+      queryClient?.invalidateQueries({
+        queryKey: queryKeys.healthFactor(variables.loan_id),
+      });
+      queryClient?.invalidateQueries({ queryKey: ["loans"] });
+      queryClient?.invalidateQueries({
+        queryKey: queryKeys.loan(variables.loan_id),
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,151 @@
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+export interface Loan {
+  id: number;
+  borrower: string;
+  collateral_id: number;
+  amount: number;
+  status: string;
+}
+
+export interface Collateral {
+  id: number;
+  owner: string;
+  animal_type: string;
+  count: number;
+  appraised_value: number;
+}
+
+export interface HealthFactorResponse {
+  health_factor: number;
+  loan_id: number;
+}
+
+export interface RepaymentPreview {
+  loan_id: number;
+  repayment_amount: number;
+  breakdown: {
+    principal: number;
+    interest: number;
+    fees: number;
+    remaining_balance: number;
+  };
+  projected_health_factor_bps: number | null;
+  fully_repaid: boolean;
+}
+
+export interface RegisterCollateralRequest {
+  owner: string;
+  animal_type: string;
+  count: number;
+  appraised_value: number;
+}
+
+export interface RegisterCollateralResponse {
+  xdr: string;
+}
+
+export interface RequestLoanRequest {
+  borrower: string;
+  collateral_id: number;
+  amount: number;
+}
+
+export interface RequestLoanResponse {
+  xdr: string;
+}
+
+export interface RepayLoanRequest {
+  borrower: string;
+  loan_id: number;
+  amount: number;
+}
+
+export interface RepayLoanResponse {
+  xdr: string;
+}
+
+export interface LoansListResponse {
+  data: Loan[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export async function fetchHealthFactor(loanId: string | number): Promise<HealthFactorResponse> {
+  const res = await fetch(`${API}/api/health/${loanId}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch health factor: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function fetchLoan(loanId: string | number): Promise<Loan> {
+  const res = await fetch(`${API}/api/loan/${loanId}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch loan: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function fetchLoans(page = 1, pageSize = 50): Promise<LoansListResponse> {
+  const res = await fetch(`${API}/api/loans?page=${page}&pageSize=${pageSize}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch loans: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function fetchRepaymentPreview(
+  loanId: number,
+  amount: number
+): Promise<RepaymentPreview> {
+  const res = await fetch(`${API}/api/loan/repayment-preview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ loan_id: loanId, amount }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error || `Failed to fetch repayment preview: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function registerCollateral(
+  data: RegisterCollateralRequest
+): Promise<RegisterCollateralResponse> {
+  const res = await fetch(`${API}/api/collateral/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to register collateral: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function requestLoan(data: RequestLoanRequest): Promise<RequestLoanResponse> {
+  const res = await fetch(`${API}/api/loan/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to request loan: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function repayLoan(data: RepayLoanRequest): Promise<RepayLoanResponse> {
+  const res = await fetch(`${API}/api/loan/repay`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to repay loan: ${res.statusText}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
Closes #53

---

- Add @tanstack/react-query dependency

- Create QueryClient provider with stale-while-revalidate config

- Implement custom query hooks with cache TTL per data type

  - useHealthFactor: 30s stale time

  - useLoan: 60s stale time

  - useLoans: 30s stale time

  - useRepaymentPreview: 5s stale time

- Update all components to use React Query hooks

- Add cache invalidation for mutations