### PR TITLE
feat: add CORS configuration for frontend origin (#18)

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -22,6 +22,8 @@ const envSchema = z.object({
   APPRAISAL_CACHE_TTL_MS: z.string().default("300000"),
   // JWT secret (min 32 chars recommended)
   JWT_SECRET: z.string().min(16).optional(),
+  // Frontend origin for CORS (required in production)
+  FRONTEND_URL: z.string().url().optional(),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -285,4 +285,59 @@ describe("StellarKraal API", () => {
       );
     });
   });
+
+  describe("CORS middleware", () => {
+    const FRONTEND = "http://localhost:3000";
+
+    beforeEach(() => {
+      delete process.env.FRONTEND_URL;
+      process.env.NODE_ENV = "test";
+    });
+
+    afterEach(() => {
+      delete process.env.FRONTEND_URL;
+    });
+
+    it("reflects allowed origin when FRONTEND_URL matches", async () => {
+      process.env.FRONTEND_URL = FRONTEND;
+      const res = await request(app)
+        .get("/api/health")
+        .set("Origin", FRONTEND);
+      expect(res.headers["access-control-allow-origin"]).toBe(FRONTEND);
+    });
+
+    it("sets Access-Control-Max-Age: 86400 on preflight", async () => {
+      process.env.FRONTEND_URL = FRONTEND;
+      const res = await request(app)
+        .options("/api/loan/request")
+        .set("Origin", FRONTEND)
+        .set("Access-Control-Request-Method", "POST");
+      expect(res.headers["access-control-max-age"]).toBe("86400");
+    });
+
+    it("allows credentials on authenticated routes", async () => {
+      process.env.FRONTEND_URL = FRONTEND;
+      const res = await request(app)
+        .options("/api/loan/request")
+        .set("Origin", FRONTEND)
+        .set("Access-Control-Request-Method", "POST");
+      expect(res.headers["access-control-allow-credentials"]).toBe("true");
+    });
+
+    it("does not allow credentials on /api/health", async () => {
+      process.env.FRONTEND_URL = FRONTEND;
+      const res = await request(app)
+        .get("/api/health")
+        .set("Origin", FRONTEND);
+      expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+    });
+
+    it("uses wildcard origin in development when FRONTEND_URL is unset", async () => {
+      process.env.NODE_ENV = "development";
+      const res = await request(app)
+        .get("/api/health")
+        .set("Origin", "http://any-origin.example");
+      expect(res.headers["access-control-allow-origin"]).toBe("*");
+    });
+  });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,7 +16,7 @@ import {
   restoreLoan,
   listDeletedLoans,
 } from "./db/store";
-import cors from "cors";
+import { corsMiddleware } from "./middleware/cors";
 import {
   Networks,
   TransactionBuilder,
@@ -71,29 +71,8 @@ function setIdempotencyEntry(key: string, status: number, body: unknown): void {
 
 const app = express();
 
-const isProduction = process.env.NODE_ENV === "production";
-const FRONTEND_URL = process.env.FRONTEND_URL;
-
-// Startup warning for CORS misconfiguration
-if (isProduction && !FRONTEND_URL) {
-  logger.warn(
-    "CORS misconfiguration: FRONTEND_URL is not set in production environment. Requests may be blocked.",
-  );
-}
-
 // Secure CORS configuration
-app.use((req: Request, res: Response, next: NextFunction) => {
-  // Allow credentials only for authenticated routes (e.g., API endpoints excluding health check)
-  const isAuthRoute = req.path.startsWith("/api") && req.path !== "/api/health";
-
-  const corsOptions: cors.CorsOptions = {
-    origin: isProduction ? FRONTEND_URL || false : isAuthRoute ? true : "*",
-    credentials: isAuthRoute,
-    maxAge: 86400, // Cache preflight requests for 24 hours
-  };
-
-  cors(corsOptions)(req, res, next);
-});
+app.use(corsMiddleware);
 app.use(express.json());
 app.use(globalLimiter);
 app.use(timeoutMiddleware(parseInt(config.TIMEOUT_GLOBAL_MS, 10)));

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,0 +1,35 @@
+import cors from "cors";
+import { RequestHandler, Request, Response, NextFunction } from "express";
+import logger from "../utils/logger";
+
+// Warn at startup if FRONTEND_URL is missing in production
+if (process.env.NODE_ENV === "production" && !process.env.FRONTEND_URL) {
+  logger.warn(
+    "CORS misconfiguration: FRONTEND_URL is not set in production. Requests from the frontend will be blocked.",
+  );
+}
+
+// Authenticated routes require credentials; wildcard origin is incompatible with credentials.
+function isAuthRoute(path: string): boolean {
+  return path.startsWith("/api") && path !== "/api/health";
+}
+
+export const corsMiddleware: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const isProduction = process.env.NODE_ENV === "production";
+  const frontendUrl = process.env.FRONTEND_URL;
+  const authRoute = isAuthRoute(req.path);
+
+  const origin: cors.CorsOptions["origin"] = isProduction
+    ? frontendUrl || false
+    : frontendUrl || (authRoute ? true : "*");
+
+  cors({
+    origin,
+    credentials: authRoute,
+    maxAge: 86400,
+  })(req, res, next);
+};

--- a/env.example
+++ b/env.example
@@ -28,3 +28,6 @@ APPRAISAL_CACHE_TTL_MS=300000
 
 # JWT secret for signing access tokens (min 32 chars in production)
 JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars
+
+# Frontend origin for CORS (required in production; defaults to wildcard in development)
+FRONTEND_URL=http://localhost:3000


### PR DESCRIPTION
- Extract CORS logic to backend/src/middleware/cors.ts
- Restrict origin to FRONTEND_URL in production
- Allow wildcard only in development when FRONTEND_URL unset
- Set Access-Control-Max-Age: 86400 for preflight caching
- Enable credentials only on authenticated routes
- Warn at startup if FRONTEND_URL missing in production
- Add FRONTEND_URL to config schema and env.example
- Add 5 CORS tests covering all acceptance criteria

closes #18 