### PR TITLE
fix: redact camelCase sensitive fields; add direct redact unit tests

### DIFF
--- a/backend/src/middleware/audit.test.ts
+++ b/backend/src/middleware/audit.test.ts
@@ -1,4 +1,4 @@
-import { auditMiddleware } from "./audit";
+import { auditMiddleware, redact } from "./audit";
 import { Request, Response, NextFunction } from "express";
 import { EventEmitter } from "events";
 
@@ -64,5 +64,40 @@ describe("redact (via middleware body)", () => {
     const res = makeRes();
     const req = makeReq({ body: null } as any);
     expect(() => auditMiddleware(req, res, next)).not.toThrow();
+  });
+});
+
+describe("redact (direct)", () => {
+  it("redacts known sensitive fields", () => {
+    const result = redact({
+      borrower: "GABC",
+      amount: 1000,
+      private_key: "secret123",
+      privateKey: "0xdeadbeef",
+      password: "hunter2",
+      apiKey: "key-abc",
+    }) as Record<string, unknown>;
+
+    expect(result.borrower).toBe("GABC");
+    expect(result.amount).toBe(1000);
+    expect(result.private_key).toBe("[REDACTED]");
+    expect(result.privateKey).toBe("[REDACTED]");
+    expect(result.password).toBe("[REDACTED]");
+    expect(result.apiKey).toBe("[REDACTED]");
+  });
+
+  it("redacts nested sensitive fields", () => {
+    const result = redact({
+      user: { password: "secret", name: "Alice" },
+    }) as any;
+
+    expect(result.user.password).toBe("[REDACTED]");
+    expect(result.user.name).toBe("Alice");
+  });
+
+  it("returns primitives unchanged", () => {
+    expect(redact("string")).toBe("string");
+    expect(redact(42)).toBe(42);
+    expect(redact(null)).toBe(null);
   });
 });

--- a/backend/src/middleware/audit.ts
+++ b/backend/src/middleware/audit.ts
@@ -5,12 +5,12 @@ import path from "path";
 
 // ── Sensitive fields to redact ────────────────────────────────────────────────
 const REDACTED_FIELDS = new Set([
-  "password", "secret", "private_key", "privateKey", "seed",
-  "mnemonic", "token", "authorization", "api_key", "apiKey",
-  "secret_key", "secretKey", "signing_key", "signingKey",
+  "password", "secret", "private_key", "privatekey", "seed",
+  "mnemonic", "token", "authorization", "api_key", "apikey",
+  "secret_key", "secretkey", "signing_key", "signingkey",
 ]);
 
-function redact(obj: unknown, depth = 0): unknown {
+export function redact(obj: unknown, depth = 0): unknown {
   if (depth > 5 || obj === null || typeof obj !== "object") return obj;
   const result: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {


### PR DESCRIPTION
Fix sensitive field redaction in audit middleware + add direct unit tests
  
  The redact() function used .toLowerCase() for key comparison but the REDACTED_FIELDS set contained camelCase entries
  (privateKey, apiKey, secretKey, etc.), meaning those fields were never actually redacted in logs.
  
  Changes:
  
  - Normalized all entries in REDACTED_FIELDS to lowercase so the case-insensitive lookup works correctly
  - Exported redact() to enable direct unit testing
  - Added 3 direct redact() tests that assert [REDACTED] output for sensitive fields, nested objects, and primitives
  
  Impact: Fields like privateKey, apiKey, signingKey are now properly redacted from audit logs as required for
  regulatory compliance.

closes #10 