### PR TITLE
feat: log-based alerting for critical errors (#90)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,7 +46,29 @@ import { asyncHandler } from "./utils/asyncHandler";
 import { stellarPublicKeySchema } from "./validators/stellar";
 import rpcClient from "./utils/rpcClient";
 import { registerWebhook, getWebhooks, getDeliveryLogs } from "./webhooks";
+import { fireAlert } from "./utils/alerting";
+import { rules } from "./utils/alertRules";
 const { Server } = SorobanRpc;
+
+// ── 5xx spike tracking (rolling 60s window) ───────────────────────────────────
+const fivexxTimestamps: number[] = [];
+const FIVEXX_WINDOW_MS = 60_000;
+const FIVEXX_THRESHOLD = 10;
+
+function track5xx() {
+  const now = Date.now();
+  fivexxTimestamps.push(now);
+  // evict old entries
+  while (fivexxTimestamps.length && fivexxTimestamps[0] < now - FIVEXX_WINDOW_MS) {
+    fivexxTimestamps.shift();
+  }
+  if (fivexxTimestamps.length >= FIVEXX_THRESHOLD) {
+    fireAlert(rules.fivexxSpike, `${fivexxTimestamps.length} 5xx errors in the last 60s`, {
+      count: fivexxTimestamps.length,
+      window: "60s",
+    });
+  }
+}
 
 // ── Idempotency cache (in-memory, 24h TTL) ───────────────────────────────────
 interface IdempotencyEntry {
@@ -674,6 +696,8 @@ app.delete("/api/loan/:id", (req: Request, res: Response) => {
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const reqLogger = (req as any).logger || logger;
   if (err instanceof PoolExhaustedError) {
+    track5xx();
+    fireAlert(rules.dbError, "Connection pool exhausted", { path: req.path });
     return res
       .status(503)
       .json({ error: "Service unavailable: connection pool exhausted" });
@@ -682,6 +706,7 @@ app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     error: err.message,
     stack: err.stack,
   });
+  track5xx();
   res.status(500).json({ error: err.message });
 });
 

--- a/backend/src/utils/alertRules.ts
+++ b/backend/src/utils/alertRules.ts
@@ -1,0 +1,52 @@
+import { AlertRule } from "./alerting";
+
+/**
+ * Alert rules — version-controlled source of truth.
+ * Cooldowns prevent alert fatigue; PagerDuty flag escalates critical issues.
+ */
+export const rules = {
+  rpcFailure: {
+    id: "rpc-failure",
+    name: "RPC Failure",
+    severity: "critical",
+    cooldownMs: 5 * 60 * 1000, // 5 min
+    runbook: "rpc-failure.md",
+    pagerduty: false,
+  },
+
+  rpcCircuitOpen: {
+    id: "rpc-circuit-open",
+    name: "RPC Circuit Breaker Opened",
+    severity: "critical",
+    cooldownMs: 10 * 60 * 1000,
+    runbook: "rpc-failure.md",
+    pagerduty: false,
+  },
+
+  dbError: {
+    id: "db-error",
+    name: "Database Error",
+    severity: "critical",
+    cooldownMs: 5 * 60 * 1000,
+    runbook: "db-error.md",
+    pagerduty: false,
+  },
+
+  liquidationFailure: {
+    id: "liquidation-failure",
+    name: "Liquidation Engine Failure",
+    severity: "critical",
+    cooldownMs: 2 * 60 * 1000,
+    runbook: "liquidation-failure.md",
+    pagerduty: false,
+  },
+
+  fivexxSpike: {
+    id: "5xx-spike",
+    name: "5xx Error Spike",
+    severity: "critical",
+    cooldownMs: 60 * 1000, // 1 min — tight window for spike detection
+    runbook: "5xx-spike.md",
+    pagerduty: true, // escalate: >10/min threshold
+  },
+} satisfies Record<string, AlertRule>;

--- a/backend/src/utils/alerting.ts
+++ b/backend/src/utils/alerting.ts
@@ -1,0 +1,103 @@
+import logger from "./logger";
+
+export type AlertSeverity = "warning" | "critical";
+
+export interface AlertRule {
+  id: string;
+  name: string;
+  severity: AlertSeverity;
+  cooldownMs: number; // dedup window
+  runbook: string;
+  pagerduty?: boolean; // escalate to PagerDuty
+}
+
+const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK_URL;
+const PAGERDUTY_KEY = process.env.PAGERDUTY_ROUTING_KEY;
+const RUNBOOK_BASE =
+  process.env.RUNBOOK_BASE_URL ||
+  "https://github.com/michaelvic123/StellarKraal-/blob/main/docs/runbooks";
+
+// in-memory dedup: ruleId -> last fired timestamp
+const lastFired = new Map<string, number>();
+
+function isCoolingDown(rule: AlertRule): boolean {
+  const last = lastFired.get(rule.id);
+  return last !== undefined && Date.now() - last < rule.cooldownMs;
+}
+
+async function sendSlack(rule: AlertRule, message: string, meta: object) {
+  if (!SLACK_WEBHOOK) return;
+
+  const color = rule.severity === "critical" ? "#dc2626" : "#ca8a04";
+  const payload = {
+    attachments: [
+      {
+        color,
+        title: `[${rule.severity.toUpperCase()}] ${rule.name}`,
+        text: message,
+        fields: [
+          { title: "Runbook", value: `${RUNBOOK_BASE}/${rule.runbook}`, short: false },
+          ...Object.entries(meta).map(([k, v]) => ({
+            title: k,
+            value: String(v),
+            short: true,
+          })),
+        ],
+        footer: "StellarKraal Alerting",
+        ts: Math.floor(Date.now() / 1000),
+      },
+    ],
+  };
+
+  try {
+    await fetch(SLACK_WEBHOOK, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    logger.warn("Failed to send Slack alert", { error: (err as Error).message });
+  }
+}
+
+async function sendPagerDuty(rule: AlertRule, message: string, meta: object) {
+  if (!PAGERDUTY_KEY || !rule.pagerduty) return;
+
+  const payload = {
+    routing_key: PAGERDUTY_KEY,
+    event_action: "trigger",
+    dedup_key: rule.id,
+    payload: {
+      summary: `[${rule.name}] ${message}`,
+      severity: "critical",
+      source: "stellarkraal-backend",
+      custom_details: { ...meta, runbook: `${RUNBOOK_BASE}/${rule.runbook}` },
+    },
+  };
+
+  try {
+    await fetch("https://events.pagerduty.com/v2/enqueue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    logger.warn("Failed to send PagerDuty alert", { error: (err as Error).message });
+  }
+}
+
+export async function fireAlert(
+  rule: AlertRule,
+  message: string,
+  meta: object = {}
+) {
+  if (isCoolingDown(rule)) return;
+
+  lastFired.set(rule.id, Date.now());
+  logger.error(`ALERT [${rule.id}]: ${message}`, { alertId: rule.id, ...meta });
+
+  await Promise.all([
+    sendSlack(rule, message, meta),
+    sendPagerDuty(rule, message, meta),
+  ]);
+}

--- a/backend/src/utils/rpcClient.ts
+++ b/backend/src/utils/rpcClient.ts
@@ -1,5 +1,7 @@
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import CircuitBreaker from "opossum";
+import { fireAlert } from "./alerting";
+import { rules } from "./alertRules";
 
 const { Server } = SorobanRpc;
 
@@ -124,7 +126,7 @@ const getHealthBreaker = new CircuitBreaker(
   circuitBreakerOptions
 );
 
-// Circuit breaker event logging
+// Circuit breaker event logging + alerting
 [
   getAccountBreaker,
   prepareTransactionBreaker,
@@ -133,6 +135,9 @@ const getHealthBreaker = new CircuitBreaker(
 ].forEach((breaker) => {
   breaker.on("open", () => {
     console.error(`Circuit breaker opened for ${breaker.name}`);
+    fireAlert(rules.rpcCircuitOpen, `Circuit breaker opened for ${breaker.name}`, {
+      breaker: breaker.name,
+    });
   });
 
   breaker.on("halfOpen", () => {
@@ -141,6 +146,13 @@ const getHealthBreaker = new CircuitBreaker(
 
   breaker.on("close", () => {
     console.info(`Circuit breaker closed for ${breaker.name}`);
+  });
+
+  breaker.on("failure", (error: Error) => {
+    fireAlert(rules.rpcFailure, `RPC call failed: ${error.message}`, {
+      breaker: breaker.name,
+      error: error.message,
+    });
   });
 });
 

--- a/env.example
+++ b/env.example
@@ -28,3 +28,12 @@ APPRAISAL_CACHE_TTL_MS=300000
 
 # JWT secret for signing access tokens (min 32 chars in production)
 JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars
+
+# Alerting — Slack incoming webhook URL
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
+
+# Alerting — PagerDuty Events API v2 routing key (critical alerts only)
+PAGERDUTY_ROUTING_KEY=your-pagerduty-routing-key
+
+# Base URL for runbook links included in alert messages
+RUNBOOK_BASE_URL=https://github.com/michaelvic123/StellarKraal-/blob/main/docs/runbooks


### PR DESCRIPTION
- Add alerting.ts: Slack + PagerDuty notifications with in-memory deduplication and per-rule cooldown periods to prevent alert fatigue
- Add alertRules.ts: version-controlled alert rules for RPC failures, circuit breaker open, DB/pool errors, liquidation failures, 5xx spikes
- Wire circuit breaker open/failure events to fire RPC alerts
- Track 5xx errors in a rolling 60s window; fire PagerDuty when >10/min
- Pool exhaustion errors now trigger db-error alert
- Runbook URL included in every alert message
- Add SLACK_WEBHOOK_URL, PAGERDUTY_ROUTING_KEY, RUNBOOK_BASE_URL to env.example

closes #90 