### PR TITLE
chore: set up Dependabot for npm and Cargo dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      backend-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "teslims2"
+    labels:
+      - "dependencies"
+      - "backend"
+    ignore:
+      # db-migrate pinned due to SQLite3 native binding compatibility
+      - dependency-name: "db-migrate"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "db-migrate-sqlite3"
+        update-types: ["version-update:semver-major"]
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "teslims2"
+    labels:
+      - "dependencies"
+      - "frontend"
+    ignore:
+      # Next.js major upgrades require manual migration
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+
+  # Rust / Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/contracts/stellarkraal"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "teslims2"
+    labels:
+      - "dependencies"
+      - "smart-contract"
+    ignore:
+      # soroban-sdk major bumps require contract re-audit
+      - dependency-name: "soroban-sdk"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Configures GitHub Dependabot to automatically create PRs for dependency updates across all three ecosystems in the repo.

## Changes
- `.github/dependabot.yml` — weekly grouped updates for:
  - `/backend` npm packages
  - `/frontend` npm packages
  - `/contracts/stellarkraal` Cargo packages

## Ignored packages (with justification)
| Package | Reason |
|---|---|
| `db-migrate`, `db-migrate-sqlite3` | Native SQLite3 binding compatibility — major bumps require manual testing |
| `next` | Major Next.js upgrades require manual migration guide review |
| `soroban-sdk` | Major bumps require smart contract re-audit before upgrade |

## Acceptance Criteria
- [x] Dependabot configured for npm (backend + frontend) and Cargo
- [x] Weekly grouped updates (one PR per ecosystem per week)
- [x] Reviewers assigned to `teslims2`
- [x] Ignored packages documented with justification
- [x] `.github/dependabot.yml` committed

Closes #92