### PR TITLE
feat: set up centralized log aggregation with Loki and Grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     environment:
       - PORT=3001
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "backend"
 
   frontend:
     build:
@@ -32,6 +36,48 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "frontend"
+
+  loki:
+    image: grafana/loki:2.9.4
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki-data:/loki
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:2.9.4
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./observability/promtail-config.yml:/etc/promtail/config.yml:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    ports:
+      - "3200:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./observability/grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./observability/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - loki
+    restart: unless-stopped
 
 volumes:
   cargo-cache:
+  loki-data:
+  grafana-data:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,79 @@
+# Observability: Log Aggregation with Loki & Grafana
+
+## Overview
+
+StellarKraal uses **Grafana Loki** for centralized log aggregation and **Promtail** to ship logs from all Docker containers. Grafana provides a pre-configured dashboard with useful log queries.
+
+---
+
+## Local Development
+
+All observability services are included in `docker-compose.yml`. Start everything with:
+
+```bash
+docker-compose up --build
+```
+
+| Service | URL |
+|---|---|
+| Grafana (dashboards) | http://localhost:3200 |
+| Loki (log ingestion API) | http://localhost:3100 |
+
+Grafana is pre-configured with anonymous viewer access — no login required in development.
+
+---
+
+## Architecture
+
+```
+backend  ──┐
+           ├─► Docker json-file logs ──► Promtail ──► Loki ──► Grafana
+frontend ──┘
+```
+
+- **Promtail** reads Docker container logs via the Docker socket and ships them to Loki.
+- **Loki** stores and indexes logs by labels (`service`, `container`, `level`, `stream`).
+- **Grafana** queries Loki and renders the pre-built dashboards.
+
+---
+
+## Pre-built Log Queries
+
+The `StellarKraal Logs` dashboard (`grafana/dashboards/logs.json`) includes:
+
+| Panel | LogQL Query | Purpose |
+|---|---|---|
+| All Logs | `{container=~"backend\|frontend"}` | Live tail of all service logs |
+| Errors | `{container=~"backend\|frontend"} \|= "error" \| level="error"` | Filter error-level entries |
+| Slow Requests | `{service="backend"} \| json \| duration > 1000` | Requests taking > 1 second |
+| RPC Failures | `{service="backend"} \|= "rpc" \|= "error"` | Soroban RPC call failures |
+
+---
+
+## Configuration Files
+
+| File | Purpose |
+|---|---|
+| `observability/promtail-config.yml` | Promtail scrape config — Docker socket discovery, label extraction |
+| `observability/grafana-datasources.yml` | Grafana provisioning — Loki datasource |
+| `observability/grafana-dashboards.yml` | Grafana provisioning — dashboard file provider |
+| `grafana/dashboards/logs.json` | Pre-built logs dashboard |
+
+---
+
+## Production Deployment
+
+In production, replace the Docker socket-based Promtail setup with a sidecar or a dedicated log shipper appropriate for your infrastructure (e.g., Promtail DaemonSet on Kubernetes, or a Loki-compatible agent on VMs).
+
+Key environment changes:
+1. Set `GF_AUTH_ANONYMOUS_ENABLED=false` and configure proper Grafana authentication.
+2. Point Promtail `clients[].url` to your production Loki endpoint.
+3. Use persistent volumes or object storage (S3/GCS) for Loki's `storage_config`.
+4. Restrict Loki's port (`3100`) to internal network only — do not expose publicly.
+
+---
+
+## Related
+
+- Prometheus metrics: [`docs/protocol/liquidation.md`](protocol/liquidation.md) *(see also `GET /metrics` endpoint)*
+- Backend logger: [`backend/src/utils/logger.ts`](../backend/src/utils/logger.ts)

--- a/grafana/dashboards/logs.json
+++ b/grafana/dashboards/logs.json
@@ -1,0 +1,57 @@
+{
+  "title": "StellarKraal Logs",
+  "uid": "stellarkraal-logs",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "All Logs",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "{container=~\"backend|frontend\"}",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Errors",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "{container=~\"backend|frontend\"} |= \"error\" | level=\"error\"",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Slow Requests (>1s)",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "{service=\"backend\"} | json | duration > 1000",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "RPC Failures",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "{service=\"backend\"} |= \"rpc\" |= \"error\"",
+          "legendFormat": ""
+        }
+      ]
+    }
+  ]
+}

--- a/observability/grafana-dashboards.yml
+++ b/observability/grafana-dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: StellarKraal
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana-datasources.yml
+++ b/observability/grafana-datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    jsonData:
+      maxLines: 1000

--- a/observability/promtail-config.yml
+++ b/observability/promtail-config.yml
@@ -1,0 +1,37 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_label_tag]
+        target_label: service
+      - source_labels: [__meta_docker_container_name]
+        regex: /(.*)
+        target_label: container
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: stream
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+            timestamp: timestamp
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: RFC3339Nano
+          fallback_formats:
+            - RFC3339
+            - UnixMs


### PR DESCRIPTION
## Summary

Adds Grafana Loki + Promtail to the Docker Compose stack for centralized log aggregation, with a pre-configured Grafana dashboard and full setup documentation.

## Changes

### `docker-compose.yml`
- **loki** (grafana/loki:2.9.4) — log storage and query API at http://localhost:3100
- **promtail** (grafana/promtail:2.9.4) — ships Docker container logs to Loki via Docker socket discovery
- **grafana** (grafana/grafana:10.4.2) — dashboards at http://localhost:3200 (anonymous viewer in dev)
- Added `logging: driver: json-file` tags to `backend` and `frontend` services

### `observability/` (new directory)
| File | Purpose |
|---|---|
| `promtail-config.yml` | Docker SD scrape config with label extraction (service, container, level) |
| `grafana-datasources.yml` | Provisions Loki as default Grafana datasource |
| `grafana-dashboards.yml` | Provisions dashboard file provider |

### `grafana/dashboards/logs.json` (new)
Pre-built dashboard with 4 panels:
- All Logs — live tail of backend + frontend
- Errors — `level="error"` filter
- Slow Requests — `duration > 1000ms`
- RPC Failures — `rpc` + `error` keyword filter

### `docs/observability.md` (new)
Setup guide covering local dev, architecture diagram, log query reference, config file index, and production deployment notes.

## Acceptance Criteria
- [x] Loki and Promtail added to docker-compose.yml
- [x] Backend and frontend logs shipped to Loki
- [x] Grafana pre-configured with a logs dashboard
- [x] Log queries for: errors, slow requests, RPC failures
- [x] Setup documented in docs/observability.md
- [x] Accessible at http://localhost:3100 in development

Closes #82