### PR TITLE
feat: add XLM local currency conversion display

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Link from "next/link";
 import OfflineBanner from "@/components/OfflineBanner";
 
 export const metadata: Metadata = {
@@ -12,6 +13,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body className="bg-cream text-brown min-h-screen">
         <OfflineBanner />
+        <nav className="flex gap-4 px-6 py-3 text-sm border-b border-brown/10">
+          <Link href="/" className="font-semibold text-brown hover:text-brown/70">StellarKraal</Link>
+          <span className="flex-1" />
+          <Link href="/help/faq" className="text-brown/70 hover:text-brown">FAQ</Link>
+          <Link href="/settings" className="text-brown/70 hover:text-brown">Settings</Link>
+        </nav>
         {children}
       </body>
     </html>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,14 @@
+import CurrencySettings from "@/components/CurrencySettings";
+import Link from "next/link";
+
+export default function SettingsPage() {
+  return (
+    <main className="max-w-lg mx-auto px-4 py-10">
+      <div className="flex items-center gap-3 mb-6">
+        <Link href="/" className="text-brown/60 hover:text-brown text-sm">← Home</Link>
+        <h1 className="text-3xl font-bold text-brown">Settings</h1>
+      </div>
+      <CurrencySettings />
+    </main>
+  );
+}

--- a/frontend/src/components/CurrencySettings.tsx
+++ b/frontend/src/components/CurrencySettings.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { Currency } from "@/hooks/useCurrencyConversion";
+import { useCurrencySettings } from "@/hooks/useCurrencySettings";
+
+const CURRENCIES: Currency[] = ["KES", "NGN", "GHS", "USD"];
+
+export default function CurrencySettings() {
+  const { currency, setCurrency, enabled, setEnabled } = useCurrencySettings();
+
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow space-y-4">
+      <h2 className="text-xl font-semibold text-brown">Currency Display</h2>
+
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          className="w-4 h-4 accent-brown"
+        />
+        <span className="text-sm">Show local currency equivalent</span>
+      </label>
+
+      {enabled && (
+        <div>
+          <label className="block text-sm font-medium text-brown/70 mb-1">
+            Preferred currency
+          </label>
+          <select
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value as Currency)}
+            className="border border-brown/30 rounded-lg px-3 py-2 w-full"
+          >
+            {CURRENCIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/XlmAmount.tsx
+++ b/frontend/src/components/XlmAmount.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useCurrencyConversion, Currency } from "@/hooks/useCurrencyConversion";
+import { useCurrencySettings } from "@/hooks/useCurrencySettings";
+
+interface Props {
+  /** Amount in XLM (not stroops) */
+  xlm: number;
+  className?: string;
+}
+
+const SYMBOLS: Record<Currency, string> = {
+  KES: "KSh",
+  NGN: "₦",
+  GHS: "GH₵",
+  USD: "$",
+};
+
+export default function XlmAmount({ xlm, className = "" }: Props) {
+  const { currency, enabled } = useCurrencySettings();
+  const { convert, isStale, loading } = useCurrencyConversion();
+
+  const local = enabled ? convert(xlm, currency) : null;
+
+  return (
+    <span className={className}>
+      {xlm.toLocaleString(undefined, { maximumFractionDigits: 7 })} XLM
+      {enabled && (
+        <span className="text-brown/60 text-sm ml-1">
+          {loading && !local ? (
+            "…"
+          ) : local !== null ? (
+            <>
+              ({SYMBOLS[currency]}
+              {local.toLocaleString(undefined, { maximumFractionDigits: 2 })})
+              {isStale && (
+                <span
+                  title="Rate may be outdated (>10 min)"
+                  className="ml-1 text-amber-500 text-xs"
+                >
+                  ⚠
+                </span>
+              )}
+            </>
+          ) : null}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useCurrencyConversion.ts
+++ b/frontend/src/hooks/useCurrencyConversion.ts
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+
+export type Currency = "KES" | "NGN" | "GHS" | "USD";
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const STALE_TTL = 10 * 60 * 1000; // 10 minutes
+
+interface RateCache {
+  rates: Record<Currency, number>;
+  fetchedAt: number;
+}
+
+let cache: RateCache | null = null;
+
+async function fetchRates(): Promise<Record<Currency, number>> {
+  const res = await fetch(
+    "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=kes,ngn,ghs,usd"
+  );
+  if (!res.ok) throw new Error("Failed to fetch rates");
+  const data = await res.json();
+  return {
+    KES: data.stellar.kes,
+    NGN: data.stellar.ngn,
+    GHS: data.stellar.ghs,
+    USD: data.stellar.usd,
+  };
+}
+
+export function useCurrencyConversion() {
+  const [rates, setRates] = useState<Record<Currency, number> | null>(
+    cache ? cache.rates : null
+  );
+  const [fetchedAt, setFetchedAt] = useState<number | null>(
+    cache ? cache.fetchedAt : null
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (force = false) => {
+    const now = Date.now();
+    if (!force && cache && now - cache.fetchedAt < CACHE_TTL) {
+      setRates(cache.rates);
+      setFetchedAt(cache.fetchedAt);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetchRates();
+      cache = { rates: r, fetchedAt: now };
+      setRates(r);
+      setFetchedAt(now);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const isStale = fetchedAt ? Date.now() - fetchedAt > STALE_TTL : false;
+
+  function convert(xlmAmount: number, currency: Currency): number | null {
+    if (!rates) return null;
+    return xlmAmount * rates[currency];
+  }
+
+  return { rates, loading, error, isStale, fetchedAt, convert, refresh };
+}

--- a/frontend/src/hooks/useCurrencySettings.ts
+++ b/frontend/src/hooks/useCurrencySettings.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Currency } from "./useCurrencyConversion";
+
+const KEY_CURRENCY = "sk_currency";
+const KEY_ENABLED = "sk_currency_enabled";
+
+export function useCurrencySettings() {
+  const [currency, setCurrencyState] = useState<Currency>("KES");
+  const [enabled, setEnabledState] = useState(true);
+
+  useEffect(() => {
+    const c = localStorage.getItem(KEY_CURRENCY) as Currency | null;
+    const e = localStorage.getItem(KEY_ENABLED);
+    if (c) setCurrencyState(c);
+    if (e !== null) setEnabledState(e === "true");
+  }, []);
+
+  function setCurrency(c: Currency) {
+    setCurrencyState(c);
+    localStorage.setItem(KEY_CURRENCY, c);
+  }
+
+  function setEnabled(v: boolean) {
+    setEnabledState(v);
+    localStorage.setItem(KEY_ENABLED, String(v));
+  }
+
+  return { currency, setCurrency, enabled, setEnabled };
+}


### PR DESCRIPTION
- useCurrencyConversion hook: fetches XLM rates from CoinGecko, 5-minute in-memory cache, stale indicator after 10 minutes
- useCurrencySettings hook: persists preferred currency and toggle to localStorage
- XlmAmount component: renders XLM value with local equivalent in parentheses and stale-rate warning icon
- CurrencySettings component: select KES/NGN/GHS/USD, toggle off
- /settings page wired to CurrencySettings
- Nav links for Settings and FAQ added to root layout

Closes #77 