### PR TITLE
feat(frontend): add search/filter UI to loan and collateral list pages

### DIFF
--- a/frontend/src/app/collateral/page.tsx
+++ b/frontend/src/app/collateral/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import SearchFilterBar from "@/components/SearchFilterBar";
+
+interface Collateral {
+  id: string;
+  owner: string;
+  animal_type: string;
+  count: number;
+  appraised_value: number;
+}
+
+const STATUS_OPTIONS: string[] = [];
+const TYPE_OPTIONS = ["cattle", "goat", "sheep", "pig", "poultry"];
+
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+function CollateralListContent() {
+  const searchParams = useSearchParams();
+  const [items, setItems] = useState<Collateral[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`${API}/api/collateral`)
+      .then((r) => r.json())
+      .then((data) => setItems(Array.isArray(data) ? data : []))
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const q = (searchParams.get("q") ?? "").toLowerCase();
+  const types = searchParams.getAll("type");
+
+  const filtered = items.filter((col) => {
+    const matchesQuery =
+      !q ||
+      col.id.toLowerCase().includes(q) ||
+      col.owner.toLowerCase().includes(q) ||
+      col.animal_type.toLowerCase().includes(q);
+    const matchesType = types.length === 0 || types.includes(col.animal_type);
+    return matchesQuery && matchesType;
+  });
+
+  return (
+    <div className="space-y-4">
+      <SearchFilterBar
+        statusOptions={STATUS_OPTIONS}
+        typeOptions={TYPE_OPTIONS}
+        searchPlaceholder="Search by ID, owner, or animal type…"
+      />
+
+      {loading ? (
+        <p className="text-brown/60 text-sm">Loading…</p>
+      ) : filtered.length === 0 ? (
+        <p className="text-brown/60 text-sm">No collateral matches your filters.</p>
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((col) => (
+            <li
+              key={col.id}
+              className="bg-white rounded-xl p-4 shadow-sm border border-brown/10 flex justify-between items-center"
+            >
+              <div>
+                <p className="font-semibold text-brown text-sm capitalize">
+                  {col.animal_type} — {col.count} head
+                </p>
+                <p className="text-xs text-brown/60 truncate max-w-xs">{col.owner}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-medium text-brown">
+                  {col.appraised_value.toLocaleString()}
+                </p>
+                <p className="text-xs text-brown/50">ID: {col.id}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function CollateralPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold text-brown mb-6">Collateral</h1>
+      <Suspense fallback={<p className="text-brown/60 text-sm">Loading…</p>}>
+        <CollateralListContent />
+      </Suspense>
+    </main>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,6 +16,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <nav className="flex gap-4 px-6 py-3 text-sm border-b border-brown/10">
           <Link href="/" className="font-semibold text-brown hover:text-brown/70">StellarKraal</Link>
           <span className="flex-1" />
+          <Link href="/loans" className="text-brown/70 hover:text-brown">Loans</Link>
+          <Link href="/collateral" className="text-brown/70 hover:text-brown">Collateral</Link>
           <Link href="/help/faq" className="text-brown/70 hover:text-brown">FAQ</Link>
           <Link href="/settings" className="text-brown/70 hover:text-brown">Settings</Link>
         </nav>

--- a/frontend/src/app/loans/page.tsx
+++ b/frontend/src/app/loans/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import SearchFilterBar from "@/components/SearchFilterBar";
+
+interface Loan {
+  id: string;
+  borrower: string;
+  amount: number;
+  status: string;
+  createdAt: string;
+}
+
+const STATUS_OPTIONS = ["active", "repaid", "liquidated", "pending"];
+const TYPE_OPTIONS: string[] = [];
+
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+function LoanListContent() {
+  const searchParams = useSearchParams();
+  const [loans, setLoans] = useState<Loan[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`${API}/api/loans`)
+      .then((r) => r.json())
+      .then((data) => setLoans(Array.isArray(data) ? data : []))
+      .catch(() => setLoans([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const q = (searchParams.get("q") ?? "").toLowerCase();
+  const statuses = searchParams.getAll("status");
+
+  const filtered = loans.filter((loan) => {
+    const matchesQuery =
+      !q ||
+      loan.id.toLowerCase().includes(q) ||
+      loan.borrower.toLowerCase().includes(q) ||
+      loan.status.toLowerCase().includes(q);
+    const matchesStatus = statuses.length === 0 || statuses.includes(loan.status);
+    return matchesQuery && matchesStatus;
+  });
+
+  return (
+    <div className="space-y-4">
+      <SearchFilterBar
+        statusOptions={STATUS_OPTIONS}
+        typeOptions={TYPE_OPTIONS}
+        searchPlaceholder="Search by loan ID, borrower, or status…"
+      />
+
+      {loading ? (
+        <p className="text-brown/60 text-sm">Loading…</p>
+      ) : filtered.length === 0 ? (
+        <p className="text-brown/60 text-sm">No loans match your filters.</p>
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((loan) => (
+            <li
+              key={loan.id}
+              className="bg-white rounded-xl p-4 shadow-sm border border-brown/10 flex justify-between items-center"
+            >
+              <div>
+                <p className="font-semibold text-brown text-sm">Loan #{loan.id}</p>
+                <p className="text-xs text-brown/60 truncate max-w-xs">{loan.borrower}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-medium text-brown">{loan.amount.toLocaleString()}</p>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                    loan.status === "active"
+                      ? "bg-green-100 text-green-800"
+                      : loan.status === "repaid"
+                      ? "bg-blue-100 text-blue-800"
+                      : loan.status === "liquidated"
+                      ? "bg-red-100 text-red-800"
+                      : "bg-gray-100 text-gray-700"
+                  }`}
+                >
+                  {loan.status}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function LoansPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold text-brown mb-6">Loans</h1>
+      <Suspense fallback={<p className="text-brown/60 text-sm">Loading…</p>}>
+        <LoanListContent />
+      </Suspense>
+    </main>
+  );
+}

--- a/frontend/src/components/SearchFilterBar.tsx
+++ b/frontend/src/components/SearchFilterBar.tsx
@@ -1,0 +1,135 @@
+"use client";
+import { useSearchFilter } from "@/hooks/useSearchFilter";
+
+interface Props {
+  statusOptions: string[];
+  typeOptions: string[];
+  searchPlaceholder?: string;
+}
+
+/**
+ * Reusable search + filter bar with debounced search, multi-select filter panel,
+ * active filter chips, and a clear-all button.
+ */
+export default function SearchFilterBar({
+  statusOptions,
+  typeOptions,
+  searchPlaceholder = "Search…",
+}: Props) {
+  const {
+    filters,
+    setQuery,
+    toggleStatus,
+    toggleType,
+    removeStatus,
+    removeType,
+    clearAll,
+    hasActiveFilters,
+  } = useSearchFilter();
+
+  return (
+    <div className="space-y-3">
+      {/* Search input */}
+      <div className="flex gap-2">
+        <input
+          type="search"
+          aria-label="Search"
+          placeholder={searchPlaceholder}
+          value={filters.query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="flex-1 border border-brown/30 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-gold"
+        />
+        {hasActiveFilters && (
+          <button
+            onClick={clearAll}
+            className="text-sm text-brown/60 hover:text-brown px-3 py-2 rounded-lg border border-brown/20 hover:border-brown/40 transition"
+            aria-label="Clear all filters"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Filter panel */}
+      <div className="flex flex-wrap gap-4">
+        {statusOptions.length > 0 && (
+          <fieldset>
+            <legend className="text-xs font-semibold text-brown/60 uppercase tracking-wide mb-1">
+              Status
+            </legend>
+            <div className="flex flex-wrap gap-1">
+              {statusOptions.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => toggleStatus(s)}
+                  aria-pressed={filters.statuses.includes(s)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium border transition ${
+                    filters.statuses.includes(s)
+                      ? "bg-brown text-cream border-brown"
+                      : "bg-white text-brown border-brown/30 hover:border-brown/60"
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        )}
+
+        {typeOptions.length > 0 && (
+          <fieldset>
+            <legend className="text-xs font-semibold text-brown/60 uppercase tracking-wide mb-1">
+              Type
+            </legend>
+            <div className="flex flex-wrap gap-1">
+              {typeOptions.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => toggleType(t)}
+                  aria-pressed={filters.types.includes(t)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium border transition ${
+                    filters.types.includes(t)
+                      ? "bg-gold text-brown border-gold"
+                      : "bg-white text-brown border-brown/30 hover:border-brown/60"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        )}
+      </div>
+
+      {/* Active filter chips */}
+      {hasActiveFilters && (
+        <div className="flex flex-wrap gap-2" aria-label="Active filters">
+          {filters.query && (
+            <Chip label={`"${filters.query}"`} onRemove={() => setQuery("")} />
+          )}
+          {filters.statuses.map((s) => (
+            <Chip key={s} label={s} onRemove={() => removeStatus(s)} />
+          ))}
+          {filters.types.map((t) => (
+            <Chip key={t} label={t} onRemove={() => removeType(t)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Chip({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1 bg-gold/20 text-brown text-xs font-medium px-2 py-1 rounded-full">
+      {label}
+      <button
+        onClick={onRemove}
+        aria-label={`Remove filter ${label}`}
+        className="hover:text-brown/60 transition"
+      >
+        ×
+      </button>
+    </span>
+  );
+}

--- a/frontend/src/hooks/useSearchFilter.ts
+++ b/frontend/src/hooks/useSearchFilter.ts
@@ -1,0 +1,118 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+export interface FilterState {
+  query: string;
+  statuses: string[];
+  types: string[];
+}
+
+const EMPTY: FilterState = { query: "", statuses: [], types: [] };
+
+/**
+ * Hook that manages search/filter state with 300ms debounce and URL sync.
+ * State is preserved on back navigation via URL query params.
+ */
+export function useSearchFilter(debounceMs = 300) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Initialise from URL
+  const [filters, setFilters] = useState<FilterState>(() => ({
+    query: searchParams.get("q") ?? "",
+    statuses: searchParams.getAll("status"),
+    types: searchParams.getAll("type"),
+  }));
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync filters → URL (debounced for query, immediate for chips)
+  const syncUrl = useCallback(
+    (next: FilterState, immediate = false) => {
+      const apply = () => {
+        const params = new URLSearchParams();
+        if (next.query) params.set("q", next.query);
+        next.statuses.forEach((s) => params.append("status", s));
+        next.types.forEach((t) => params.append("type", t));
+        const qs = params.toString();
+        router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      };
+
+      if (immediate) {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        apply();
+      } else {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(apply, debounceMs);
+      }
+    },
+    [router, pathname, debounceMs]
+  );
+
+  const setQuery = useCallback(
+    (query: string) => {
+      const next = { ...filters, query };
+      setFilters(next);
+      syncUrl(next, false);
+    },
+    [filters, syncUrl]
+  );
+
+  const toggleStatus = useCallback(
+    (status: string) => {
+      const statuses = filters.statuses.includes(status)
+        ? filters.statuses.filter((s) => s !== status)
+        : [...filters.statuses, status];
+      const next = { ...filters, statuses };
+      setFilters(next);
+      syncUrl(next, true);
+    },
+    [filters, syncUrl]
+  );
+
+  const toggleType = useCallback(
+    (type: string) => {
+      const types = filters.types.includes(type)
+        ? filters.types.filter((t) => t !== type)
+        : [...filters.types, type];
+      const next = { ...filters, types };
+      setFilters(next);
+      syncUrl(next, true);
+    },
+    [filters, syncUrl]
+  );
+
+  const removeStatus = useCallback(
+    (status: string) => toggleStatus(status),
+    [toggleStatus]
+  );
+
+  const removeType = useCallback(
+    (type: string) => toggleType(type),
+    [toggleType]
+  );
+
+  const clearAll = useCallback(() => {
+    setFilters(EMPTY);
+    syncUrl(EMPTY, true);
+  }, [syncUrl]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
+
+  const hasActiveFilters =
+    filters.query !== "" || filters.statuses.length > 0 || filters.types.length > 0;
+
+  return {
+    filters,
+    setQuery,
+    toggleStatus,
+    toggleType,
+    removeStatus,
+    removeType,
+    clearAll,
+    hasActiveFilters,
+  };
+}


### PR DESCRIPTION
- Add useSearchFilter hook with 300ms debounce and URL query param sync
- Add SearchFilterBar component with multi-select status/type filters
- Active filters shown as removable chips with clear-all button
- URL params updated on every filter change (shareable links)
- State preserved on back navigation via URL
- Add /loans and /collateral list pages using the new components
- Add nav links for Loans and Collateral in layout

Closes #74

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
