### PR TITLE
feat(frontend): add custom 404, 500, and maintenance error pages

### DIFF
--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,69 @@
+"use client";
+import Link from "next/link";
+
+interface Props {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: Props) {
+  const issueUrl = `https://github.com/teslims2/StellarKraal-/issues/new?title=${encodeURIComponent(
+    "500 Error: " + (error.message || "Unknown error")
+  )}&body=${encodeURIComponent(
+    `**Error digest:** ${error.digest ?? "N/A"}\n\n**Steps to reproduce:**\n\n`
+  )}`;
+
+  return (
+    <html lang="en">
+      <body className="bg-cream text-brown min-h-screen flex flex-col items-center justify-center px-4 text-center">
+        {/* Illustration */}
+        <div aria-hidden="true" className="mb-8">
+          <svg
+            width="120"
+            height="120"
+            viewBox="0 0 120 120"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle cx="60" cy="60" r="56" fill="#FDF6EC" stroke="#D4A017" strokeWidth="3" />
+            <text x="50%" y="54%" dominantBaseline="middle" textAnchor="middle" fontSize="52">
+              ⚠️
+            </text>
+          </svg>
+        </div>
+
+        <h1 className="text-6xl font-bold text-brown mb-2">500</h1>
+        <h2 className="text-2xl font-semibold text-brown mb-3">Something went wrong</h2>
+        <p className="text-brown/60 max-w-sm mb-2">
+          An unexpected error occurred on our end. You can try again or report the issue.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-brown/40 mb-8 font-mono">Error ID: {error.digest}</p>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <button
+            onClick={reset}
+            className="bg-brown text-cream font-semibold px-6 py-3 rounded-xl hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-gold"
+          >
+            Try again
+          </button>
+          <a
+            href={issueUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold"
+          >
+            Report issue
+          </a>
+          <Link
+            href="/"
+            className="border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold"
+          >
+            Go home
+          </Link>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/maintenance/page.tsx
+++ b/frontend/src/app/maintenance/page.tsx
@@ -1,0 +1,42 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+/**
+ * Maintenance mode page.
+ * Shown when NEXT_PUBLIC_MAINTENANCE_MODE=true is set.
+ * The middleware (middleware.ts) redirects all routes here when enabled.
+ */
+export default function MaintenancePage() {
+  return (
+    <main className="min-h-screen bg-cream flex flex-col items-center justify-center px-4 text-center">
+      <div aria-hidden="true" className="mb-8">
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 120 120"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="60" cy="60" r="56" fill="#FDF6EC" stroke="#D4A017" strokeWidth="3" />
+          <text x="50%" y="54%" dominantBaseline="middle" textAnchor="middle" fontSize="52">
+            🔧
+          </text>
+        </svg>
+      </div>
+
+      <h1 className="text-4xl font-bold text-brown mb-3">Under Maintenance</h1>
+      <p className="text-brown/60 max-w-sm mb-6">
+        StellarKraal is currently undergoing scheduled maintenance. We&apos;ll be back shortly.
+      </p>
+      <p className="text-xs text-brown/40">
+        If you need urgent assistance, contact{" "}
+        <a
+          href="mailto:support@stellarkraal.io"
+          className="underline hover:text-brown transition"
+        >
+          support@stellarkraal.io
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-cream flex flex-col items-center justify-center px-4 text-center">
+      {/* Illustration */}
+      <div aria-hidden="true" className="mb-8">
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 120 120"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          role="img"
+          aria-label="Lost cow illustration"
+        >
+          <circle cx="60" cy="60" r="56" fill="#FDF6EC" stroke="#D4A017" strokeWidth="3" />
+          <text x="50%" y="54%" dominantBaseline="middle" textAnchor="middle" fontSize="52">
+            🐄
+          </text>
+        </svg>
+      </div>
+
+      <h1 className="text-6xl font-bold text-brown mb-2">404</h1>
+      <h2 className="text-2xl font-semibold text-brown mb-3">Page not found</h2>
+      <p className="text-brown/60 max-w-sm mb-8">
+        Looks like this page wandered off the pasture. Let&apos;s get you back on track.
+      </p>
+
+      {/* Navigation suggestions */}
+      <nav aria-label="Suggested pages" className="flex flex-col sm:flex-row gap-3">
+        <Link
+          href="/"
+          className="bg-brown text-cream font-semibold px-6 py-3 rounded-xl hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-gold"
+        >
+          Go home
+        </Link>
+        <Link
+          href="/dashboard"
+          className="border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold"
+        >
+          Dashboard
+        </Link>
+        <Link
+          href="/help/faq"
+          className="border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold"
+        >
+          FAQ
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const MAINTENANCE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === "true";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow the maintenance page itself and static assets through
+  if (
+    MAINTENANCE &&
+    pathname !== "/maintenance" &&
+    !pathname.startsWith("/_next") &&
+    !pathname.startsWith("/favicon")
+  ) {
+    return NextResponse.redirect(new URL("/maintenance", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
- Custom 404 (not-found.tsx) with cow illustration and nav suggestions (home, dashboard, FAQ)
- Custom 500 (global-error.tsx) with retry button, error digest display, and GitHub issue report link
- Maintenance mode page with wrench illustration and support contact
- Middleware redirects all routes to /maintenance when NEXT_PUBLIC_MAINTENANCE_MODE=true
- All pages use the brown/gold/cream design system and are responsive
- Pages are accessible with proper aria labels and focus rings

Closes #76

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
