### PR TITLE
feat: fail CI on CRITICAL vulnerabilities and upload Trivy scan artif…

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -27,9 +27,19 @@ jobs:
       - name: Build backend image
         run: docker build -t stellarkraal-backend:${{ github.sha }} ./backend
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        continue-on-error: true
+      - name: Run Trivy vulnerability scanner (CRITICAL — fail build)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: stellarkraal-backend:${{ github.sha }}
+          format: table
+          severity: CRITICAL
+          exit-code: 1
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Run Trivy vulnerability scanner (SARIF upload)
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: stellarkraal-backend:${{ github.sha }}
           format: sarif
@@ -39,12 +49,20 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
 
-      - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
         if: always() && hashFiles('trivy-backend-results.sarif') != ''
         with:
           sarif_file: trivy-backend-results.sarif
           category: backend-image
+
+      - name: Upload Trivy scan results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-backend-results
+          path: trivy-backend-results.sarif
+          retention-days: 30
 
   scan-frontend:
     runs-on: ubuntu-latest
@@ -58,9 +76,19 @@ jobs:
       - name: Build frontend image
         run: docker build -t stellarkraal-frontend:${{ github.sha }} ./frontend
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        continue-on-error: true
+      - name: Run Trivy vulnerability scanner (CRITICAL — fail build)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: stellarkraal-frontend:${{ github.sha }}
+          format: table
+          severity: CRITICAL
+          exit-code: 1
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Run Trivy vulnerability scanner (SARIF upload)
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: stellarkraal-frontend:${{ github.sha }}
           format: sarif
@@ -70,9 +98,17 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
 
-      - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
         if: always() && hashFiles('trivy-frontend-results.sarif') != ''
         with:
           sarif_file: trivy-frontend-results.sarif
           category: frontend-image
+
+      - name: Upload Trivy scan results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-frontend-results
+          path: trivy-frontend-results.sarif
+          retention-days: 30

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,13 @@
 # Trivy Vulnerability Suppression File
-# Add CVE IDs here that are accepted false positives or have been risk-accepted
-# Format: CVE-YYYY-NNNNN
-# Example: CVE-2023-12345
+# Format: CVE-YYYY-NNNNN  [optional comment]
+#
+# Only add entries here after a formal risk-acceptance review.
+# Each entry must include a comment explaining:
+#   - Why it is a false positive or accepted risk
+#   - Who approved the acceptance and when
+#   - When the entry should be re-evaluated (e.g., next release)
+#
+# Example:
+# CVE-2023-12345  # FP: only affects feature X not used here. Accepted by @alice 2026-01-15. Re-evaluate 2026-07-15.
 
-# Add your suppressions below with justification comments
+# Add accepted suppressions below:


### PR DESCRIPTION
…acts

- Set exit-code: 1 on CRITICAL severity to block merges with critical CVEs
- Pin trivy-action to 0.28.0 for reproducibility
- Add second scan step (exit-code: 0) to always produce SARIF for upload
- Upload SARIF to GitHub Security tab via codeql-action/upload-sarif
- Upload raw SARIF as downloadable CI artifact (30-day retention)
- Scan runs for both backend and frontend images
- Update .trivyignore with instructions for risk-accepted suppressions

Closes #354

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
