### PR TITLE
feat: store secrets in GitHub Actions secrets and document rotation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Run tests with coverage
         env:
           NODE_ENV: test
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: npm run test:coverage -- --coverageReporters=json-summary --coverageReporters=text
 
       - name: Upload coverage artifact

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           node-version: '20'
 
-      # Cache node_modules and .next for faster subsequent runs
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -62,8 +61,10 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NEXT_PUBLIC_NETWORK: testnet
-          NEXT_PUBLIC_API_URL: http://localhost:3001
+          NEXT_PUBLIC_NETWORK: ${{ secrets.NEXT_PUBLIC_NETWORK }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          CONTRACT_ID: ${{ secrets.CONTRACT_ID }}
+          RPC_URL: ${{ secrets.RPC_URL }}
 
   lighthouse:
     name: Lighthouse CI
@@ -93,8 +94,10 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NEXT_PUBLIC_NETWORK: testnet
-          NEXT_PUBLIC_API_URL: http://localhost:3001
+          NEXT_PUBLIC_NETWORK: ${{ secrets.NEXT_PUBLIC_NETWORK }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          CONTRACT_ID: ${{ secrets.CONTRACT_ID }}
+          RPC_URL: ${{ secrets.RPC_URL }}
 
       - name: Run Lighthouse CI
         run: npx @lhci/cli@0.14.x autorun

--- a/docs/security/secrets-rotation.md
+++ b/docs/security/secrets-rotation.md
@@ -1,0 +1,80 @@
+# Secrets Rotation Procedure
+
+All production secrets are stored as GitHub Actions repository secrets and injected into workflows at runtime. No secret value is ever committed to the repository or printed in workflow logs.
+
+## Required GitHub Secrets
+
+| Secret Name | Description | Used In |
+|---|---|---|
+| `JWT_SECRET` | JWT signing key (min 32 chars) | backend-ci, deploy |
+| `CONTRACT_ID` | Deployed Soroban contract ID | frontend-ci, deploy |
+| `RPC_URL` | Soroban JSON-RPC endpoint | frontend-ci, deploy |
+| `NEXT_PUBLIC_NETWORK` | Stellar network (`testnet`/`mainnet`) | frontend-ci, deploy |
+| `NEXT_PUBLIC_API_URL` | Frontend → backend base URL | frontend-ci, deploy |
+| `WEBHOOK_SECRET` | HMAC secret for webhook validation | deploy |
+| `ADMIN_API_KEY` | Admin endpoint API key | deploy |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook for alerts | deploy, deploy-staging |
+| `PAGERDUTY_ROUTING_KEY` | PagerDuty Events API v2 routing key | deploy |
+| `AWS_ACCESS_KEY_ID` | AWS credentials for Terraform | terraform, deploy-staging |
+| `AWS_SECRET_ACCESS_KEY` | AWS credentials for Terraform | terraform, deploy-staging |
+| `LHCI_GITHUB_APP_TOKEN` | Lighthouse CI GitHub App token | frontend-ci |
+
+Staging-specific secrets use the same names but are scoped to the `staging` environment in GitHub (Settings → Environments → staging).
+
+## Rotation Schedule
+
+| Secret | Rotation Frequency |
+|---|---|
+| `JWT_SECRET` | Every 90 days or immediately after suspected compromise |
+| `WEBHOOK_SECRET` | Every 90 days |
+| `ADMIN_API_KEY` | Every 90 days |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Every 90 days |
+| `SLACK_WEBHOOK_URL` | On team member offboarding |
+| `PAGERDUTY_ROUTING_KEY` | On team member offboarding |
+| `CONTRACT_ID` / `RPC_URL` | On contract redeployment |
+
+## Rotation Steps
+
+### 1. Generate a new secret value
+
+```bash
+# For random secrets (JWT_SECRET, WEBHOOK_SECRET, ADMIN_API_KEY):
+openssl rand -base64 48
+```
+
+### 2. Update the GitHub secret
+
+1. Go to **Settings → Secrets and variables → Actions** in the repository.
+2. Click the secret name → **Update**.
+3. Paste the new value and save.
+4. For staging secrets, repeat under **Settings → Environments → staging**.
+
+### 3. Deploy to pick up the new value
+
+Trigger a new workflow run (push a commit or use **Actions → Re-run**). The new secret is injected automatically — no code change is needed.
+
+### 4. Revoke the old value
+
+- **JWT_SECRET**: After rotating, existing JWTs signed with the old key will be invalid. Users will need to log in again. Coordinate with the team before rotating in production.
+- **AWS keys**: Deactivate the old IAM access key in the AWS console after confirming the new key works.
+- **WEBHOOK_SECRET**: Update the secret on the webhook provider side (e.g., GitHub webhook settings) to match the new value before the old one is revoked.
+
+### 5. Verify
+
+Run the relevant CI workflow and confirm it passes. Check that no secret values appear in the workflow logs — GitHub automatically masks registered secrets, but verify manually if in doubt.
+
+## Emergency Rotation (Suspected Compromise)
+
+1. Immediately rotate the compromised secret following steps 1–3 above.
+2. Revoke the old value at the source (AWS console, Slack, PagerDuty, etc.).
+3. Review recent workflow logs for any accidental exposure.
+4. File an internal incident report in `#security`.
+5. If a JWT secret was compromised, invalidate all active sessions by rotating the secret and notifying users.
+
+## Verifying No Secrets in Logs
+
+GitHub automatically redacts registered secret values from logs. To verify:
+
+1. Open a completed workflow run in GitHub Actions.
+2. Search the logs for any known secret substring — it should appear as `***`.
+3. If a secret appears in plain text, rotate it immediately and investigate how it was exposed (e.g., `echo $SECRET` in a run step).

--- a/env.example
+++ b/env.example
@@ -1,11 +1,37 @@
+# ============================================================
+# StellarKraal Environment Variables
+# Copy this file to .env and fill in values for local dev.
+#
+# Variables marked [GitHub Secret: NAME] must be stored as
+# GitHub Actions repository secrets (Settings → Secrets and
+# variables → Actions) and are injected by CI/CD workflows.
+# Never commit real values to version control.
+# ============================================================
+
+# Stellar network to use (testnet | mainnet)
+# [GitHub Secret: NEXT_PUBLIC_NETWORK]
 NEXT_PUBLIC_NETWORK=testnet
+
+# Soroban JSON-RPC endpoint
+# [GitHub Secret: RPC_URL]
 RPC_URL=https://soroban-testnet.stellar.org
+
+# Public RPC URL exposed to the frontend
+# [GitHub Secret: RPC_URL] (same value)
 NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
+
+# Deployed Soroban contract ID
+# [GitHub Secret: CONTRACT_ID]
 CONTRACT_ID=your_deployed_contract_id
+
+# Backend service port
 PORT=3001
+
+# Frontend API base URL
+# [GitHub Secret: NEXT_PUBLIC_API_URL]
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
-# Node environment (development, production, test)
+# Node environment (development | production | test)
 NODE_ENV=development
 
 # Frontend URL for CORS (required in production)
@@ -19,12 +45,12 @@ RATE_LIMIT_WRITE=10
 TIMEOUT_GLOBAL_MS=30000
 TIMEOUT_WRITE_MS=15000
 
-# Webhook HMAC signing secret
-# Path in Vault/AWS: stellarkraal/webhook_secret
+# Webhook HMAC signing secret — min 32 random bytes
+# [GitHub Secret: WEBHOOK_SECRET]
 # WEBHOOK_SECRET=
 
 # Admin API key for /api/admin/* endpoints
-# Path in Vault/AWS: stellarkraal/admin_api_key
+# [GitHub Secret: ADMIN_API_KEY]
 # ADMIN_API_KEY=
 
 # RPC connection pool size
@@ -35,13 +61,16 @@ POOL_MAX=10
 APPRAISAL_CACHE_TTL_MS=300000
 
 # JWT secret for signing access tokens (min 32 chars in production)
+# [GitHub Secret: JWT_SECRET]
 JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars
 
 # Alerting — Slack incoming webhook URL
+# [GitHub Secret: SLACK_WEBHOOK_URL]
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
 
 # Alerting — PagerDuty Events API v2 routing key (critical alerts only)
+# [GitHub Secret: PAGERDUTY_ROUTING_KEY]
 PAGERDUTY_ROUTING_KEY=your-pagerduty-routing-key
 
 # Base URL for runbook links included in alert messages
-RUNBOOK_BASE_URL=https://github.com/michaelvic123/StellarKraal-/blob/main/docs/runbooks
+RUNBOOK_BASE_URL=https://github.com/teslims2/StellarKraal-/blob/main/docs/runbooks


### PR DESCRIPTION
- Inject JWT_SECRET, CONTRACT_ID, RPC_URL, NEXT_PUBLIC_NETWORK, NEXT_PUBLIC_API_URL via secrets context in CI workflows
- Remove hardcoded testnet values from frontend-ci.yml build steps
- Update env.example to annotate each variable with its GitHub secret name
- Add docs/security/secrets-rotation.md with rotation schedule and steps

Closes #355


