### PR TITLE
feat: add Docker log rotation to production services

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,11 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   frontend:
     build:
@@ -32,3 +37,8 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"

--- a/docs/deployment/deployment-guide.md
+++ b/docs/deployment/deployment-guide.md
@@ -1,0 +1,27 @@
+# Production Deployment Guide
+
+## Starting the Production Stack
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+## Container Log Rotation
+
+All services in `docker-compose.prod.yml` use the `json-file` log driver with rotation configured:
+
+```yaml
+logging:
+  driver: json-file
+  options:
+    max-size: "10m"   # rotate when a log file reaches 10 MB
+    max-file: "5"     # keep at most 5 rotated files per container
+```
+
+This caps each container's log footprint at **50 MB** (5 × 10 MB). Older files are deleted automatically by the Docker daemon when the limit is reached.
+
+> **Note on existing logs**: Applying this configuration to a running container requires a container restart (`docker compose -f docker-compose.prod.yml up -d --force-recreate`). Existing log files on disk are not deleted — they remain until Docker's rotation removes them naturally as new log data is written.
+
+## Accessing and Searching Container Logs
+
+See the [ops runbook — container logs](../runbooks/container-logs.md) for commands to view, follow, and search logs in production.

--- a/docs/runbooks/container-logs.md
+++ b/docs/runbooks/container-logs.md
@@ -1,0 +1,67 @@
+# Runbook: Accessing and Searching Container Logs
+
+## View live logs (follow)
+
+```bash
+# All services
+docker compose -f docker-compose.prod.yml logs -f
+
+# Single service
+docker compose -f docker-compose.prod.yml logs -f backend
+docker compose -f docker-compose.prod.yml logs -f frontend
+```
+
+## View recent logs (last N lines)
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=200 backend
+```
+
+## Search logs for a pattern
+
+```bash
+# Errors in the last 500 lines
+docker compose -f docker-compose.prod.yml logs --tail=500 backend | grep -i error
+
+# Requests to a specific path
+docker compose -f docker-compose.prod.yml logs backend | grep '/api/v1/loans'
+```
+
+## Access raw JSON log files on the host
+
+Docker stores `json-file` logs at:
+
+```
+/var/lib/docker/containers/<container-id>/<container-id>-json.log
+```
+
+Find the container ID:
+
+```bash
+docker ps --filter name=backend --format '{{.ID}}'
+```
+
+Then read the file directly (requires root or docker group membership):
+
+```bash
+sudo tail -f /var/lib/docker/containers/<container-id>/<container-id>-json.log | jq .
+```
+
+## Log rotation configuration
+
+Rotation is configured in `docker-compose.prod.yml`:
+
+- **max-size**: `10m` — each log file rotates at 10 MB
+- **max-file**: `5` — at most 5 files are kept per container (max 50 MB per service)
+
+Rotation is handled automatically by the Docker daemon. No manual intervention is needed under normal operation.
+
+## Applying log rotation to a running container
+
+Log driver options only take effect when a container is (re)created. To apply changes to a running stack:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --force-recreate
+```
+
+Existing log files are not deleted by this operation.


### PR DESCRIPTION
- Add json-file logging with max-size=10m and max-file=5 to all services in docker-compose.prod.yml (caps each service at 50 MB)
- Document log rotation config in docs/deployment/deployment-guide.md
- Add docs/runbooks/container-logs.md with commands to view, follow, and search container logs and notes on applying rotation to live containers

Closes #353