### PR TITLE
feat: add staging environment with Docker Compose override and CD pip…

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   test:
@@ -42,41 +42,30 @@ jobs:
         working-directory: ./backend
         run: npm test -- --watchAll=false
 
-  deploy-infrastructure:
-    name: Provision Staging Infrastructure
+  deploy-staging:
+    name: Deploy to Staging
     needs: test
     runs-on: ubuntu-latest
     environment: staging
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform Init
-        working-directory: ./terraform
-        run: terraform init
+      - name: Deploy with Docker Compose (staging)
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.staging.yml \
+            up -d --build
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Terraform Select Workspace
-        working-directory: ./terraform
-        run: terraform workspace select staging || terraform workspace new staging
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Terraform Apply
-        working-directory: ./terraform
-        run: terraform apply -auto-approve -var="environment=staging" -var="allowed_ips=${{ vars.ALLOWED_IPS }}"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          STAGING_RPC_URL: ${{ secrets.STAGING_RPC_URL }}
+          STAGING_CONTRACT_ID: ${{ secrets.STAGING_CONTRACT_ID }}
+          STAGING_API_URL: ${{ secrets.STAGING_API_URL }}
+          STAGING_FRONTEND_URL: ${{ secrets.STAGING_FRONTEND_URL }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
   notify:
     name: Slack Notification
-    needs: deploy-infrastructure
+    needs: deploy-staging
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -85,16 +74,16 @@ jobs:
         with:
           payload: |
             {
-              "text": "Staging Deployment Status: ${{ needs.deploy-infrastructure.result }}",
+              "text": "Staging Deployment Status: ${{ needs.deploy-staging.result }}",
               "attachments": [
                 {
-                  "color": "${{ needs.deploy-infrastructure.result == 'success' && '#36a64f' || '#ff0000' }}",
+                  "color": "${{ needs.deploy-staging.result == 'success' && '#36a64f' || '#ff0000' }}",
                   "blocks": [
                     {
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "*Project:* StellarKraal\n*Environment:* Staging\n*Status:* ${{ needs.deploy-infrastructure.result }}\n*Workflow:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                        "text": "*Project:* StellarKraal\n*Environment:* Staging\n*Status:* ${{ needs.deploy-staging.result }}\n*Workflow:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
                       }
                     }
                   ]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,32 @@ cd contracts/stellarkraal
 cargo test
 ```
 
+## Staging Environment
+
+The staging environment mirrors production and is deployed automatically on every merge to `main`.
+
+| Resource | URL |
+|---|---|
+| Frontend | `https://staging.stellarkraal.example.com` |
+| Backend API | `https://api-staging.stellarkraal.example.com` |
+
+Staging uses Stellar **testnet** RPC and a separate contract deployment. The following GitHub Actions secrets must be set under the `staging` environment (Settings → Environments → staging):
+
+| Secret | Description |
+|---|---|
+| `STAGING_RPC_URL` | Soroban testnet RPC endpoint |
+| `STAGING_CONTRACT_ID` | Staging contract deployment ID |
+| `STAGING_API_URL` | Staging backend API base URL |
+| `STAGING_FRONTEND_URL` | Staging frontend URL (for CORS) |
+| `JWT_SECRET` | JWT signing key for staging |
+| `SLACK_WEBHOOK_URL` | Slack webhook for deployment notifications |
+
+To run the staging stack locally:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+```
+
 ## Troubleshooting
 
 - `PORT already in use`: stop the process using the port or change `PORT` in `.env`.

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,34 @@
+# Staging environment Docker Compose override.
+# Uses Stellar testnet RPC and a separate staging contract deployment.
+# Staging secrets are stored as GitHub Actions environment secrets
+# under the "staging" environment (Settings → Environments → staging).
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+
+services:
+  backend:
+    environment:
+      - NODE_ENV=staging
+      - PORT=3001
+      - RPC_URL=${STAGING_RPC_URL:-https://soroban-testnet.stellar.org}
+      - CONTRACT_ID=${STAGING_CONTRACT_ID}
+      - JWT_SECRET=${JWT_SECRET}
+      - FRONTEND_URL=${STAGING_FRONTEND_URL:-https://staging.stellarkraal.example.com}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  frontend:
+    environment:
+      - NODE_ENV=staging
+      - NEXT_PUBLIC_NETWORK=testnet
+      - NEXT_PUBLIC_API_URL=${STAGING_API_URL:-https://api-staging.stellarkraal.example.com}
+      - NEXT_PUBLIC_RPC_URL=${STAGING_RPC_URL:-https://soroban-testnet.stellar.org}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
…eline

- Add docker-compose.staging.yml override: testnet RPC, staging contract, staging API/frontend URLs, log rotation (10m/3 files)
- Update deploy-staging.yml to trigger on push to main (not develop)
- Replace Terraform deploy step with docker compose staging deployment
- Inject staging secrets from GitHub Actions 'staging' environment
- Document staging URLs and required secrets in README

Closes #356

