### PR TITLE
feat(ui): consistent Card, loading-state strategy, detail hierarchy

### DIFF
--- a/frontend/src/app/collateral/page.tsx
+++ b/frontend/src/app/collateral/page.tsx
@@ -3,6 +3,8 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import SearchFilterBar from "@/components/SearchFilterBar";
 import PageTransition from "@/components/PageTransition";
+import Card from "@/components/Card";
+import SkeletonCollateralCard from "@/components/SkeletonCollateralCard";
 
 interface Collateral {
   id: string;
@@ -53,28 +55,35 @@ function CollateralListContent() {
       />
 
       {loading ? (
-        <p className="text-brown/60 text-sm">Loading…</p>
+        <ul className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <li key={i}>
+              <SkeletonCollateralCard />
+            </li>
+          ))}
+        </ul>
       ) : filtered.length === 0 ? (
-        <p className="text-brown/60 text-sm">No collateral matches your filters.</p>
+        <p className="text-brown-500 text-sm">No collateral matches your filters.</p>
       ) : (
         <ul className="space-y-2">
           {filtered.map((col) => (
-            <li
-              key={col.id}
-              className="bg-white rounded-xl p-4 shadow-sm border border-brown/10 flex justify-between items-center"
-            >
-              <div>
-                <p className="font-semibold text-brown text-sm capitalize">
-                  {col.animal_type} — {col.count} head
-                </p>
-                <p className="text-xs text-brown/60 truncate max-w-xs">{col.owner}</p>
-              </div>
-              <div className="text-right">
-                <p className="text-sm font-medium text-brown">
-                  {col.appraised_value.toLocaleString()}
-                </p>
-                <p className="text-xs text-brown/50">ID: {col.id}</p>
-              </div>
+            <li key={col.id}>
+              <Card>
+                <div className="flex justify-between items-center">
+                  <div>
+                    <p className="font-semibold text-brown-700 text-sm capitalize">
+                      {col.animal_type} — {col.count} head
+                    </p>
+                    <p className="text-xs text-brown-500 truncate max-w-xs">{col.owner}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-medium text-brown-700">
+                      {col.appraised_value.toLocaleString()}
+                    </p>
+                    <p className="text-xs text-brown-500">ID: {col.id}</p>
+                  </div>
+                </div>
+              </Card>
             </li>
           ))}
         </ul>
@@ -86,12 +95,22 @@ function CollateralListContent() {
 export default function CollateralPage() {
   return (
     <PageTransition>
-    <main className="max-w-3xl mx-auto px-4 py-10">
-      <h1 className="text-3xl font-bold text-brown mb-6">Collateral</h1>
-      <Suspense fallback={<p className="text-brown/60 text-sm">Loading…</p>}>
-        <CollateralListContent />
-      </Suspense>
-    </main>
+      <main className="max-w-3xl mx-auto px-4 py-10">
+        <h1 className="text-3xl font-bold text-brown-700 mb-6">Collateral</h1>
+        <Suspense
+          fallback={
+            <ul className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <li key={i}>
+                  <SkeletonCollateralCard />
+                </li>
+              ))}
+            </ul>
+          }
+        >
+          <CollateralListContent />
+        </Suspense>
+      </main>
     </PageTransition>
   );
 }

--- a/frontend/src/app/dashboard/collateral/[id]/page.tsx
+++ b/frontend/src/app/dashboard/collateral/[id]/page.tsx
@@ -2,6 +2,8 @@
 import { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import WalletConnect from "@/components/WalletConnect";
+import Card from "@/components/Card";
+import Skeleton from "@/components/Skeleton";
 
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
@@ -28,6 +30,27 @@ const ANIMAL_ICONS: Record<string, string> = {
   sheep: "🐑",
 };
 
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6" aria-busy="true" aria-label="Loading collateral details">
+      <Card>
+        <div className="space-y-4">
+          <Skeleton className="h-16 w-16 rounded-xl" />
+          <Skeleton className="h-8 w-48" />
+          <div className="grid grid-cols-2 gap-4 pt-4">
+            <Skeleton className="h-20 w-full rounded-xl" />
+            <Skeleton className="h-20 w-full rounded-xl" />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
 export default function CollateralDetailPage() {
   const router = useRouter();
   const params = useParams();
@@ -49,9 +72,7 @@ export default function CollateralDetailPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(
-        `${API}/api/collateral/${collateralId}?owner=${wallet}`
-      );
+      const res = await fetch(`${API}/api/collateral/${collateralId}?owner=${wallet}`);
       if (!res.ok) throw new Error("Failed to fetch collateral details");
       const data = await res.json();
       setCollateral(data.collateral);
@@ -66,7 +87,7 @@ export default function CollateralDetailPage() {
   if (!wallet) {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
-        <h1 className="text-3xl font-bold text-brown mb-6">Collateral Details</h1>
+        <h1 className="text-3xl font-bold text-brown-700 mb-6">Collateral Details</h1>
         <WalletConnect onConnect={setWallet} />
       </main>
     );
@@ -75,10 +96,7 @@ export default function CollateralDetailPage() {
   if (loading) {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
-        <div className="animate-pulse space-y-4">
-          <div className="h-12 bg-brown/10 rounded" />
-          <div className="h-64 bg-brown/10 rounded" />
-        </div>
+        <DetailSkeleton />
       </main>
     );
   }
@@ -86,15 +104,12 @@ export default function CollateralDetailPage() {
   if (error || !collateral) {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
-        <button
-          onClick={() => router.back()}
-          className="text-brown hover:text-brown/70 mb-6 font-semibold"
-        >
+        <button onClick={() => router.back()} className="text-brown-600 hover:text-brown-700 mb-6 font-semibold">
           ← Back
         </button>
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-red-700">
-          {error || "Collateral not found"}
-        </div>
+        <Card variant="warning">
+          <p className="text-error-dark">{error || "Collateral not found"}</p>
+        </Card>
       </main>
     );
   }
@@ -103,66 +118,115 @@ export default function CollateralDetailPage() {
   const usdValue = (parseFloat(xlmValue) * 0.12).toFixed(2);
   const icon = ANIMAL_ICONS[collateral.animal_type] || "🐾";
 
+  // Derive outstanding balance and a simple health factor from loans
+  const totalOutstanding = loans.reduce((sum, l) => sum + l.amount, 0);
+  const outstandingXlm = (totalOutstanding / 1e7).toFixed(2);
+  // Health factor: collateral value / outstanding balance (in bps, 10000 = 1.0)
+  const healthFactorBps =
+    totalOutstanding > 0
+      ? Math.round((collateral.appraised_value / totalOutstanding) * 10000)
+      : null;
+  const isAtRisk = healthFactorBps !== null && healthFactorBps < 12000;
+
   return (
     <main className="max-w-2xl mx-auto px-4 py-10">
-      <button
-        onClick={() => router.back()}
-        className="text-brown hover:text-brown/70 mb-6 font-semibold"
-      >
+      <button onClick={() => router.back()} className="text-brown-600 hover:text-brown-700 mb-6 font-semibold">
         ← Back to Collateral
       </button>
 
-      <div className="bg-white rounded-2xl p-8 shadow mb-6">
-        <div className="flex items-start justify-between mb-6">
-          <div>
-            <div className="text-6xl mb-4">{icon}</div>
-            <h1 className="text-3xl font-bold text-brown capitalize">
+      {/* At-risk banner — visually prominent */}
+      {isAtRisk && (
+        <Card variant="warning" className="mb-4">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl" aria-hidden="true">⚠️</span>
+            <div>
+              <p className="font-bold text-warning-dark">Liquidation Risk</p>
+              <p className="text-sm text-warning-dark/80">
+                Health factor is below 1.2. Repay part of your loan to reduce risk.
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Primary metrics — large, prominent */}
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <Card variant={isAtRisk ? "warning" : "highlighted"}>
+          <p className="text-xs font-medium text-brown-500 uppercase tracking-wide mb-1">
+            Health Factor
+          </p>
+          {healthFactorBps !== null ? (
+            <>
+              <p className="text-4xl font-bold text-brown-700 dark:text-cream-50">
+                {(healthFactorBps / 10000).toFixed(2)}
+              </p>
+              <p className="text-xs text-brown-500 mt-1">
+                {healthFactorBps >= 15000 ? "Healthy" : healthFactorBps >= 12000 ? "Moderate" : "At Risk"}
+              </p>
+            </>
+          ) : (
+            <p className="text-2xl font-bold text-brown-700 dark:text-cream-50">—</p>
+          )}
+        </Card>
+
+        <Card variant="highlighted">
+          <p className="text-xs font-medium text-brown-500 uppercase tracking-wide mb-1">
+            Outstanding Balance
+          </p>
+          <p className="text-4xl font-bold text-brown-700 dark:text-cream-50">
+            {outstandingXlm}
+          </p>
+          <p className="text-xs text-brown-500 mt-1">XLM</p>
+        </Card>
+      </div>
+
+      {/* Collateral overview */}
+      <Card
+        className="mb-4"
+        header={
+          <div className="flex items-center gap-3">
+            <span className="text-4xl">{icon}</span>
+            <h1 className="text-2xl font-bold text-brown-700 dark:text-cream-50 capitalize">
               {collateral.animal_type}
+              <span className="ml-2 text-base font-normal text-brown-500">× {collateral.count}</span>
             </h1>
           </div>
-          <span className="bg-brown/10 text-brown text-lg font-semibold px-4 py-2 rounded-full">
-            {collateral.count}x
-          </span>
-        </div>
-
-        <div className="grid grid-cols-2 gap-6 pt-6 border-t border-brown/10">
+        }
+      >
+        {/* Secondary details — visually subordinate */}
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
           <div>
-            <p className="text-brown/60 text-sm mb-2">Appraised Value</p>
-            <p className="text-2xl font-bold text-brown">{xlmValue} XLM</p>
-            <p className="text-sm text-brown/50">${usdValue} USD</p>
+            <p className="text-brown-500 mb-0.5">Appraised Value</p>
+            <p className="font-semibold text-brown-700 dark:text-cream-50">{xlmValue} XLM</p>
+            <p className="text-xs text-brown-400">${usdValue} USD</p>
           </div>
-
           <div>
-            <p className="text-brown/60 text-sm mb-2">Registered Date</p>
-            <p className="text-lg font-semibold text-brown">
+            <p className="text-brown-500 mb-0.5">Registered</p>
+            <p className="font-semibold text-brown-700 dark:text-cream-50">
               {new Date(collateral.createdAt).toLocaleDateString()}
             </p>
-            <p className="text-sm text-brown/50">
+            <p className="text-xs text-brown-400">
               {new Date(collateral.createdAt).toLocaleTimeString()}
             </p>
           </div>
-
           <div>
-            <p className="text-brown/60 text-sm mb-2">Collateral ID</p>
-            <p className="font-mono text-sm text-brown break-all">
+            <p className="text-brown-500 mb-0.5">Collateral ID</p>
+            <p className="font-mono text-xs text-brown-600 dark:text-brown-300 break-all">
               {collateral.id}
             </p>
           </div>
-
           <div>
-            <p className="text-brown/60 text-sm mb-2">Owner Address</p>
-            <p className="font-mono text-sm text-brown break-all">
+            <p className="text-brown-500 mb-0.5">Owner</p>
+            <p className="font-mono text-xs text-brown-600 dark:text-brown-300">
               {collateral.owner.slice(0, 8)}…{collateral.owner.slice(-6)}
             </p>
           </div>
         </div>
-      </div>
+      </Card>
 
-      {loans.length > 0 && (
-        <div className="bg-white rounded-2xl p-8 shadow">
-          <h2 className="text-xl font-semibold text-brown mb-4">
-            Associated Loans
-          </h2>
+      {/* Associated loans */}
+      {loans.length > 0 ? (
+        <Card header={<h2 className="text-lg font-semibold text-brown-700 dark:text-cream-50">Associated Loans</h2>}>
           <div className="space-y-3">
             {loans.map((loan) => {
               const loanXlm = (loan.amount / 1e7).toFixed(2);
@@ -170,34 +234,35 @@ export default function CollateralDetailPage() {
               return (
                 <div
                   key={loan.id}
-                  className="border border-brown/10 rounded-lg p-4 hover:bg-brown/5 transition"
+                  className="border border-brown-100 dark:border-brown-700 rounded-lg p-4 hover:bg-brown-50 dark:hover:bg-brown-700/40 transition"
                 >
-                  <div className="flex justify-between items-start mb-2">
-                    <p className="font-semibold text-brown">Loan #{loan.id}</p>
-                    <span className="text-sm text-brown/60">
+                  <div className="flex justify-between items-start">
+                    <p className="font-semibold text-brown-700 dark:text-cream-50 text-sm">
+                      Loan #{loan.id}
+                    </p>
+                    <span className="text-xs text-brown-500">
                       {new Date(loan.createdAt).toLocaleDateString()}
                     </span>
                   </div>
-                  <p className="text-lg font-bold text-brown">
-                    {loanXlm} XLM <span className="text-sm text-brown/50">(${loanUsd})</span>
+                  <p className="text-lg font-bold text-brown-700 dark:text-cream-50 mt-1">
+                    {loanXlm} XLM{" "}
+                    <span className="text-sm font-normal text-brown-500">(${loanUsd})</span>
                   </p>
                 </div>
               );
             })}
           </div>
-        </div>
-      )}
-
-      {loans.length === 0 && (
-        <div className="bg-cream rounded-2xl p-8 text-center border border-brown/10">
-          <p className="text-brown/60 mb-4">No loans associated with this collateral</p>
+        </Card>
+      ) : (
+        <Card className="text-center">
+          <p className="text-brown-500 mb-4">No loans associated with this collateral</p>
           <button
             onClick={() => router.push("/borrow")}
-            className="bg-brown text-cream px-6 py-2 rounded-lg font-semibold hover:bg-brown/80 transition"
+            className="bg-brown-600 text-cream-50 px-6 py-2 rounded-lg font-semibold hover:bg-brown-700 transition"
           >
             Request a Loan
           </button>
-        </div>
+        </Card>
       )}
     </main>
   );

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import TransactionHistory from "@/components/TransactionHistory";
 import SkeletonHealthDashboard from "@/components/SkeletonHealthDashboard";
 import HelpMenu from "@/components/HelpMenu";
 import OnboardingModal from "@/components/OnboardingModal";
+import Card from "@/components/Card";
 import { useHealthFactor } from "@/hooks/useHealthFactor";
 import { useOnboarding } from "@/hooks/useOnboarding";
 
@@ -19,7 +20,7 @@ export default function Dashboard() {
   const router = useRouter();
   const [wallet, setWallet] = useState<string | null>(null);
   const [loanId, setLoanId] = useState("");
-  const { showOnboarding, openOnboarding, closeOnboarding } = useOnboarding();
+  const { showOnboarding, openOnboarding, closeOnboarding } = useOnboarding(wallet);
   const { healthFactor, loading: isHealthLoading, refresh: refreshHealth } = useHealthFactor(loanId);
 
   function handleProceedToRepay(nextLoanId: string, _nextAmount: string) {
@@ -58,26 +59,30 @@ export default function Dashboard() {
           {isHealthLoading ? (
             <SkeletonHealthDashboard />
           ) : (
-            <div className="mt-8 rounded-2xl bg-white p-6 shadow">
-              <h2 className="mb-3 text-xl font-semibold text-brown">
-                <GlossaryTerm termKey="healthFactor" />
-              </h2>
+            <Card
+              className="mt-8"
+              header={
+                <h2 className="text-xl font-semibold text-brown-700">
+                  <GlossaryTerm termKey="healthFactor" />
+                </h2>
+              }
+            >
               <div className="flex items-center gap-2">
                 <input
-                  className="flex-1 rounded-lg border border-brown/30 px-3 py-2"
+                  className="flex-1 rounded-lg border border-brown-300 px-3 py-2"
                   placeholder="Loan ID"
                   value={loanId}
                   onChange={(e) => setLoanId(e.target.value)}
                 />
                 <button
                   onClick={refreshHealth}
-                  className="rounded-lg bg-gold px-4 py-2 font-semibold text-brown transition hover:bg-gold/80"
+                  className="rounded-lg bg-gold-500 px-4 py-2 font-semibold text-cream-50 transition hover:bg-gold-600 flex items-center gap-2"
                 >
                   Check
                 </button>
               </div>
               {healthFactor !== null && <HealthGauge value={healthFactor} />}
-            </div>
+            </Card>
           )}
         </>
       )}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,40 +1,30 @@
 import type { Metadata } from "next";
 import "./globals.css";
-<<<<<<< HEAD
 import Link from "next/link";
 import OfflineBanner from "@/components/OfflineBanner";
-import Navbar from "@/components/Navbar";
-=======
 import { ToastProvider, ToastContainer } from "@/components/toast";
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
 
-import { ToastProvider } from "@/context/ToastContext";
 export const metadata: Metadata = {
   title: "StellarKraal — Livestock Micro-Lending",
   description: "Livestock-backed micro-lending on Stellar/Soroban",
 };
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-<<<<<<< HEAD
       <body className="bg-cream text-brown min-h-screen overflow-x-hidden px-4">
         <ToastProvider>
           <OfflineBanner />
           <nav className="flex gap-4 px-6 py-3 text-sm border-b border-brown/10">
-          <Link href="/" className="font-semibold text-brown hover:text-brown/70">StellarKraal</Link>
-          <span className="flex-1" />
-          <Link href="/loans" className="text-brown/70 hover:text-brown">Loans</Link>
-          <Link href="/collateral" className="text-brown/70 hover:text-brown">Collateral</Link>
-          <Link href="/help/faq" className="text-brown/70 hover:text-brown">FAQ</Link>
-          <Link href="/settings" className="text-brown/70 hover:text-brown">Settings</Link>
-        </nav>
-        {children}
-=======
-      <body className="bg-cream text-brown min-h-screen">
-        <ToastProvider>
+            <Link href="/" className="font-semibold text-brown hover:text-brown/70">StellarKraal</Link>
+            <span className="flex-1" />
+            <Link href="/loans" className="text-brown/70 hover:text-brown">Loans</Link>
+            <Link href="/collateral" className="text-brown/70 hover:text-brown">Collateral</Link>
+            <Link href="/help/faq" className="text-brown/70 hover:text-brown">FAQ</Link>
+            <Link href="/settings" className="text-brown/70 hover:text-brown">Settings</Link>
+          </nav>
           {children}
           <ToastContainer />
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
         </ToastProvider>
       </body>
     </html>

--- a/frontend/src/app/loans/page.tsx
+++ b/frontend/src/app/loans/page.tsx
@@ -4,6 +4,8 @@ import { useSearchParams } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import SearchFilterBar from "@/components/SearchFilterBar";
 import PageTransition from "@/components/PageTransition";
+import Card from "@/components/Card";
+import SkeletonLoanCard from "@/components/SkeletonLoanCard";
 import { badgeVariants } from "@/lib/animations";
 
 interface Loan {
@@ -56,40 +58,47 @@ function LoanListContent() {
       />
 
       {loading ? (
-        <p className="text-brown/60 text-sm">Loading…</p>
+        <ul className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <li key={i}>
+              <SkeletonLoanCard />
+            </li>
+          ))}
+        </ul>
       ) : filtered.length === 0 ? (
-        <p className="text-brown/60 text-sm">No loans match your filters.</p>
+        <p className="text-brown-500 text-sm">No loans match your filters.</p>
       ) : (
         <ul className="space-y-2">
           {filtered.map((loan) => (
-            <li
-              key={loan.id}
-              className="bg-white rounded-xl p-4 shadow-sm border border-brown/10 flex justify-between items-center"
-            >
-              <div>
-                <p className="font-semibold text-brown text-sm">Loan #{loan.id}</p>
-                <p className="text-xs text-brown/60 truncate max-w-xs">{loan.borrower}</p>
-              </div>
-              <div className="text-right">
-                <p className="text-sm font-medium text-brown">{loan.amount.toLocaleString()}</p>
-                <motion.span
-                  key={loan.status}
-                  variants={reduced ? undefined : badgeVariants}
-                  initial="initial"
-                  animate="animate"
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                    loan.status === "active"
-                      ? "bg-green-100 text-green-800"
-                      : loan.status === "repaid"
-                      ? "bg-blue-100 text-blue-800"
-                      : loan.status === "liquidated"
-                      ? "bg-red-100 text-red-800"
-                      : "bg-gray-100 text-gray-700"
-                  }`}
-                >
-                  {loan.status}
-                </motion.span>
-              </div>
+            <li key={loan.id}>
+              <Card>
+                <div className="flex justify-between items-center">
+                  <div>
+                    <p className="font-semibold text-brown-700 text-sm">Loan #{loan.id}</p>
+                    <p className="text-xs text-brown-500 truncate max-w-xs">{loan.borrower}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-medium text-brown-700">{loan.amount.toLocaleString()}</p>
+                    <motion.span
+                      key={loan.status}
+                      variants={reduced ? undefined : badgeVariants}
+                      initial="initial"
+                      animate="animate"
+                      className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                        loan.status === "active"
+                          ? "bg-success-light text-success-dark"
+                          : loan.status === "repaid"
+                          ? "bg-blue-100 text-blue-800"
+                          : loan.status === "liquidated"
+                          ? "bg-error-light text-error-dark"
+                          : "bg-brown-100 text-brown-700"
+                      }`}
+                    >
+                      {loan.status}
+                    </motion.span>
+                  </div>
+                </div>
+              </Card>
             </li>
           ))}
         </ul>
@@ -101,12 +110,22 @@ function LoanListContent() {
 export default function LoansPage() {
   return (
     <PageTransition>
-    <main className="max-w-3xl mx-auto px-4 py-10">
-      <h1 className="text-3xl font-bold text-brown mb-6">Loans</h1>
-      <Suspense fallback={<p className="text-brown/60 text-sm">Loading…</p>}>
-        <LoanListContent />
-      </Suspense>
-    </main>
+      <main className="max-w-3xl mx-auto px-4 py-10">
+        <h1 className="text-3xl font-bold text-brown-700 mb-6">Loans</h1>
+        <Suspense
+          fallback={
+            <ul className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <li key={i}>
+                  <SkeletonLoanCard />
+                </li>
+              ))}
+            </ul>
+          }
+        >
+          <LoanListContent />
+        </Suspense>
+      </main>
     </PageTransition>
   );
 }

--- a/frontend/src/components/Card.stories.tsx
+++ b/frontend/src/components/Card.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Card from "./Card";
+
+/**
+ * `Card` is the single container for all data display across the dashboard.
+ * It standardises padding, border radius, shadow, and header/footer styling so
+ * every data surface looks consistent in both light and dark mode.
+ *
+ * **Slots**
+ * - `header` — optional title row (rendered above a divider)
+ * - `children` — the body (always present)
+ * - `footer` — optional meta row (rendered below a divider, subtly tinted)
+ *
+ * **Variants**
+ * - `default` — standard surface for most data
+ * - `highlighted` — gold-tinted, for featured/primary metrics
+ * - `warning` — amber-tinted, for risk indicators (e.g. liquidation risk)
+ *
+ * Any extra props (`aria-busy`, `aria-label`, `id`, …) are forwarded to the
+ * underlying element, which is how the skeleton variants mark themselves busy.
+ */
+const meta: Meta<typeof Card> = {
+  title: "Components/Card",
+  component: Card,
+  parameters: { layout: "padded" },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "highlighted", "warning"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "Standard card body — used for most data surfaces.",
+  },
+};
+
+export const Highlighted: Story = {
+  args: {
+    variant: "highlighted",
+    children: "Highlighted card — for featured or primary metrics.",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+    children: "Warning card — for risk indicators like liquidation risk.",
+  },
+};
+
+export const WithHeaderAndFooter: Story = {
+  args: {
+    header: <h2 className="text-xl font-semibold text-brown-700">Loan #42</h2>,
+    children: (
+      <div className="space-y-1">
+        <p className="text-brown-700 font-semibold">1,250.00 XLM</p>
+        <p className="text-sm text-brown-500">Borrowed against 3 cattle</p>
+      </div>
+    ),
+    footer: <p className="text-xs text-brown-500 font-mono">ID: 8f3a91c2…</p>,
+  },
+};
+
+/** All three variants side by side for quick visual comparison. */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <Card header={<span className="font-semibold text-brown-700">Default</span>}>
+        Standard data surface.
+      </Card>
+      <Card
+        variant="highlighted"
+        header={<span className="font-semibold text-brown-700">Highlighted</span>}
+      >
+        Featured / primary metric.
+      </Card>
+      <Card
+        variant="warning"
+        header={<span className="font-semibold text-warning-dark">Warning</span>}
+      >
+        Risk indicator.
+      </Card>
+    </div>
+  ),
+};
+
+/**
+ * Dark mode — Tailwind uses `darkMode: "class"`, so wrapping in `.dark`
+ * activates every dark variant the Card defines.
+ */
+export const DarkMode: Story = {
+  render: () => (
+    <div className="dark bg-brown-900 p-6 rounded-2xl">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card header={<span className="font-semibold text-cream-50">Default</span>}>
+          <span className="text-cream-50">Standard data surface.</span>
+        </Card>
+        <Card
+          variant="highlighted"
+          header={<span className="font-semibold text-cream-50">Highlighted</span>}
+        >
+          <span className="text-cream-50">Featured / primary metric.</span>
+        </Card>
+        <Card
+          variant="warning"
+          header={<span className="font-semibold text-warning-dark">Warning</span>}
+        >
+          <span className="text-cream-50">Risk indicator.</span>
+        </Card>
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,63 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type CardVariant = "default" | "highlighted" | "warning";
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant;
+  header?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+const variantClasses: Record<CardVariant, string> = {
+  default:
+    "bg-cream-50 dark:bg-brown-800 border border-brown-100 dark:border-brown-700 shadow",
+  highlighted:
+    "bg-gold-50 dark:bg-brown-700 border border-gold-500 dark:border-gold-600 shadow-md",
+  warning:
+    "bg-warning-light dark:bg-brown-700 border border-warning dark:border-warning-dark shadow",
+};
+
+/**
+ * Card — consistent data display container.
+ *
+ * Variants:
+ * - `default`     — standard white card
+ * - `highlighted` — gold-tinted card for featured data
+ * - `warning`     — amber-tinted card for risk indicators
+ *
+ * Slots: `header`, `children` (body), `footer`
+ */
+export default function Card({
+  variant = "default",
+  header,
+  footer,
+  children,
+  className,
+  ...rest
+}: CardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl overflow-hidden",
+        variantClasses[variant],
+        className
+      )}
+      {...rest}
+    >
+      {header && (
+        <div className="px-6 py-4 border-b border-brown-100 dark:border-brown-700">
+          {header}
+        </div>
+      )}
+      <div className="px-6 py-5">{children}</div>
+      {footer && (
+        <div className="px-6 py-4 border-t border-brown-100 dark:border-brown-700 bg-brown-50/40 dark:bg-brown-900/30">
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CollateralCard.tsx
+++ b/frontend/src/components/CollateralCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useState } from "react";
 import { colors } from "@/lib/design-tokens";
-import SkeletonCollateralCard from "@/components/SkeletonCollateralCard";
+import Card from "@/components/Card";
+import Spinner from "@/components/Spinner";
 
 interface Props {
   walletAddress: string;
@@ -24,11 +25,11 @@ export default function CollateralCard({ walletAddress }: Props) {
     }
   }
 
-  if (loading && !data) return <SkeletonCollateralCard />;
-
   return (
-    <div className={`${colors.background.card} rounded-2xl p-6 shadow mb-4`}>
-      <h2 className={`text-xl font-semibold ${colors.text.primary} mb-3`}>Loan Lookup</h2>
+    <Card
+      className="mb-4"
+      header={<h2 className={`text-xl font-semibold ${colors.text.primary}`}>Loan Lookup</h2>}
+    >
       <div className="flex gap-2">
         <input
           className={`${colors.form.input} rounded-lg px-3 py-2 flex-1 ${colors.text.primary} ${colors.form.placeholder}`}
@@ -36,12 +37,17 @@ export default function CollateralCard({ walletAddress }: Props) {
           value={collateralId}
           onChange={(e) => setCollateralId(e.target.value)}
         />
-        <button 
-          onClick={lookup} 
-          disabled={loading} 
-          className={`${colors.primary.bg} ${colors.primary.text} px-4 py-2 rounded-lg ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus}`}
+        <button
+          onClick={lookup}
+          disabled={loading}
+          className={`${colors.primary.bg} ${colors.primary.text} px-4 py-2 rounded-lg ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center gap-2`}
         >
-          {loading ? "…" : "Fetch"}
+          {loading ? (
+            <>
+              <Spinner />
+              <span>Fetching…</span>
+            </>
+          ) : "Fetch"}
         </button>
       </div>
       {data && (
@@ -49,6 +55,6 @@ export default function CollateralCard({ walletAddress }: Props) {
           {JSON.stringify(data, null, 2)}
         </pre>
       )}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/CollateralGrid.tsx
+++ b/frontend/src/components/CollateralGrid.tsx
@@ -1,4 +1,6 @@
 "use client";
+import Card from "@/components/Card";
+import SkeletonCollateralCard from "@/components/SkeletonCollateralCard";
 
 interface Collateral {
   id: string;
@@ -20,23 +22,12 @@ const ANIMAL_ICONS: Record<string, string> = {
   sheep: "🐑",
 };
 
-export default function CollateralGrid({
-  collaterals,
-  loading,
-  onCardClick,
-}: Props) {
+export default function CollateralGrid({ collaterals, loading, onCardClick }: Props) {
   if (loading) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {[...Array(3)].map((_, i) => (
-          <div
-            key={i}
-            className="bg-white rounded-2xl p-6 shadow animate-pulse"
-          >
-            <div className="h-12 bg-brown/10 rounded mb-4" />
-            <div className="h-6 bg-brown/10 rounded mb-3" />
-            <div className="h-6 bg-brown/10 rounded" />
-          </div>
+          <SkeletonCollateralCard key={i} />
         ))}
       </div>
     );
@@ -53,39 +44,41 @@ export default function CollateralGrid({
           <button
             key={collateral.id}
             onClick={() => onCardClick(collateral.id)}
-            className="bg-white rounded-2xl p-6 shadow hover:shadow-lg hover:scale-105 transition-all duration-200 text-left cursor-pointer border border-transparent hover:border-brown/20"
+            className="text-left hover:scale-105 transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-brown-600 focus:ring-offset-2 rounded-2xl"
           >
-            <div className="flex items-start justify-between mb-4">
-              <div className="text-4xl">{icon}</div>
-              <span className="bg-brown/10 text-brown text-xs font-semibold px-3 py-1 rounded-full">
-                {collateral.count}x
-              </span>
-            </div>
-
-            <h3 className="text-lg font-semibold text-brown mb-1 capitalize">
-              {collateral.animal_type}
-            </h3>
-
-            <div className="space-y-3 mt-4 pt-4 border-t border-brown/10">
-              <div>
-                <p className="text-xs text-brown/60 mb-1">Appraised Value</p>
-                <p className="font-semibold text-brown">{xlmValue} XLM</p>
-                <p className="text-xs text-brown/50">${usdValue} USD</p>
-              </div>
-
-              <div>
-                <p className="text-xs text-brown/60 mb-1">Registered</p>
-                <p className="text-xs text-brown/70">
-                  {new Date(collateral.createdAt).toLocaleDateString()}
+            <Card
+              variant="default"
+              header={
+                <div className="flex items-center justify-between">
+                  <span className="text-3xl">{icon}</span>
+                  <span className="bg-brown-100 dark:bg-brown-700 text-brown-700 dark:text-brown-200 text-xs font-semibold px-3 py-1 rounded-full">
+                    {collateral.count}x
+                  </span>
+                </div>
+              }
+              footer={
+                <p className="text-xs text-brown-500 font-mono">
+                  ID: {collateral.id.slice(0, 8)}…
                 </p>
+              }
+            >
+              <h3 className="text-lg font-semibold text-brown-700 dark:text-cream-50 mb-3 capitalize">
+                {collateral.animal_type}
+              </h3>
+              <div className="space-y-2">
+                <div>
+                  <p className="text-xs text-brown-500 mb-0.5">Appraised Value</p>
+                  <p className="font-semibold text-brown-700 dark:text-cream-50">{xlmValue} XLM</p>
+                  <p className="text-xs text-brown-500">${usdValue} USD</p>
+                </div>
+                <div>
+                  <p className="text-xs text-brown-500 mb-0.5">Registered</p>
+                  <p className="text-xs text-brown-600 dark:text-brown-300">
+                    {new Date(collateral.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
               </div>
-            </div>
-
-            <div className="mt-4 pt-4 border-t border-brown/10">
-              <p className="text-xs text-brown/50">
-                ID: {collateral.id.slice(0, 8)}…
-              </p>
-            </div>
+            </Card>
           </button>
         );
       })}

--- a/frontend/src/components/CollateralRegistrationForm.tsx
+++ b/frontend/src/components/CollateralRegistrationForm.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { signTransaction } from "@/lib/freighterClient";
 import { submitSignedXdr } from "@/lib/stellarUtils";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import Spinner from "@/components/Spinner";
 import { motion, useReducedMotion } from "framer-motion";
 import { submitVariants } from "@/lib/animations";
 
@@ -367,9 +368,16 @@ export default function CollateralRegistrationForm({ walletAddress, onSuccess }:
           disabled={loading || Object.keys(errors).some((key) => errors[key as keyof FormErrors])}
           variants={reduced ? undefined : submitVariants}
           animate={loading ? "loading" : "idle"}
-          className="w-full bg-brown text-cream py-2.5 rounded-xl font-semibold hover:bg-brown/80 transition disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full bg-brown text-cream py-2.5 rounded-xl font-semibold hover:bg-brown/80 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
         >
-          {loading ? "Processing…" : "Register Collateral"}
+          {loading ? (
+            <>
+              <Spinner />
+              Processing…
+            </>
+          ) : (
+            "Register Collateral"
+          )}
         </motion.button>
       </form>
 

--- a/frontend/src/components/LoadingStates.stories.tsx
+++ b/frontend/src/components/LoadingStates.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Spinner from "./Spinner";
+import SkeletonCollateralCard from "./SkeletonCollateralCard";
+import SkeletonLoanCard from "./SkeletonLoanCard";
+
+/**
+ * # Loading-state guidelines
+ *
+ * StellarKraal uses exactly two loading affordances. Choosing the right one
+ * keeps the app feeling fast and avoids the "spinner soup" / blank-screen
+ * problems that motivated this guideline.
+ *
+ * ## Use a **Skeleton** for initial data loads
+ * When a page or section is mounting and has *no data yet*, render a skeleton
+ * that mirrors the shape of the content that will appear. This preserves layout,
+ * communicates structure, and prevents a blank white screen on page entry.
+ *
+ * - Page entry / first fetch → skeleton (e.g. `SkeletonCollateralCard`,
+ *   `SkeletonLoanCard`, `SkeletonHealthDashboard`).
+ * - Render one skeleton per expected item (we show 3 placeholder rows).
+ * - Skeletons set `aria-busy="true"` and an `aria-label` describing what is
+ *   loading; the shimmer bars themselves are `aria-hidden`.
+ *
+ * ## Use a **Spinner** for inline actions
+ * When the user triggers an action and we are waiting on a *response*
+ * (button click, filter change, on-chain submit, wallet connect), show a
+ * `Spinner` inside the control that triggered it and keep the surrounding
+ * layout intact.
+ *
+ * - Button submits → spinner + verb in progress ("Processing…", "Submitting…").
+ * - The spinner inherits `currentColor`, so it matches the control it sits in
+ *   and works in light and dark mode without extra styling.
+ * - Disable the control while its spinner is showing to prevent double submits.
+ *
+ * ## Rules
+ * 1. **Never both** — a section shows a skeleton *or* an inline spinner, not both.
+ * 2. **Never neither** — no page may show a blank white screen during a load;
+ *    if data is loading on entry, a skeleton must be visible.
+ * 3. **Initial vs. refresh** — first load = skeleton; refreshing already-visible
+ *    data in response to an action = spinner (keep the stale data on screen).
+ */
+const meta: Meta = {
+  title: "Guidelines/Loading States",
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Skeletons — for initial loads. One placeholder per expected item. */
+export const SkeletonsForInitialLoad: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div>
+        <p className="text-sm font-semibold text-brown-700 mb-2">Collateral grid (page entry)</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {[...Array(3)].map((_, i) => (
+            <SkeletonCollateralCard key={i} />
+          ))}
+        </div>
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-brown-700 mb-2">Loan list (page entry)</p>
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <SkeletonLoanCard key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+/** Spinners — for inline actions inside the control that triggered them. */
+export const SpinnersForInlineActions: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 max-w-xs">
+      <button
+        disabled
+        className="bg-brown-600 text-cream-50 py-2.5 rounded-xl font-semibold flex items-center justify-center gap-2 opacity-90"
+      >
+        <Spinner />
+        Processing…
+      </button>
+      <button
+        disabled
+        className="bg-gold-600 text-cream-50 py-2.5 rounded-xl font-semibold flex items-center justify-center gap-2 opacity-90"
+      >
+        <Spinner />
+        Submitting…
+      </button>
+      <p className="text-xs text-brown-500">
+        Spinner inherits the button text colour and the control is disabled while busy.
+      </p>
+    </div>
+  ),
+};

--- a/frontend/src/components/LoanForm.tsx
+++ b/frontend/src/components/LoanForm.tsx
@@ -2,11 +2,8 @@
 import { useState } from "react";
 import { signTransaction } from "@/lib/freighterClient";
 import { submitSignedXdr } from "@/lib/stellarUtils";
-<<<<<<< HEAD
 import { colors } from "@/lib/design-tokens";
-=======
-import { useToast } from "@/components/toast";
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
+import Spinner from "@/components/Spinner";
 
 interface Props {
   walletAddress: string;
@@ -24,10 +21,11 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
   const [collateralId, setCollateralId] = useState(initialCollateralId || "");
   const [loanAmount, setLoanAmount] = useState("");
   const [loading, setLoading] = useState(false);
-  const toast = useToast();
+  const [status, setStatus] = useState<string | null>(null);
 
   async function registerCollateral() {
     setLoading(true);
+    setStatus(null);
     try {
       const res = await fetch(`${API}/api/collateral/register`, {
         method: "POST",
@@ -42,10 +40,10 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
       const { xdr } = await res.json();
       const { signedTxXdr } = await signTransaction(xdr, { network: process.env.NEXT_PUBLIC_NETWORK || "TESTNET" });
       const result = await submitSignedXdr(signedTxXdr);
-      toast.success(`Collateral registered! ID: ${result}`);
+      setStatus(`✅ Collateral registered! ID: ${result}`);
       setStep("loan");
     } catch (e: any) {
-      toast.error(e.message);
+      setStatus(`❌ ${e.message}`);
     } finally {
       setLoading(false);
     }
@@ -53,11 +51,7 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
 
   async function requestLoan() {
     setLoading(true);
-<<<<<<< HEAD
     setStatus(null);
-    setLoading(true);
-=======
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
     try {
       const res = await fetch(`${API}/api/loan/request`, {
         method: "POST",
@@ -71,15 +65,13 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
       const { xdr } = await res.json();
       const { signedTxXdr } = await signTransaction(xdr, { network: process.env.NEXT_PUBLIC_NETWORK || "TESTNET" });
       const result = await submitSignedXdr(signedTxXdr);
-      toast.success(`Loan disbursed! Loan ID: ${result}`);
+      setStatus(`✅ Loan disbursed! Loan ID: ${result}`);
     } catch (e: any) {
-      toast.error(e.message);
+      setStatus(`❌ ${e.message}`);
     } finally {
       setLoading(false);
     }
   }
-
-  if (loading && step === "collateral") return null;
 
   return (
     <div className={`${colors.background.card} rounded-2xl p-6 shadow mt-6 space-y-4`}>
@@ -107,12 +99,19 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
             onChange={(e) => setAppraisedValue(e.target.value)} 
             type="number" 
           />
-          <button 
-            onClick={registerCollateral} 
-            disabled={loading} 
-            className={`w-full ${colors.primary.bg} ${colors.primary.text} py-2.5 rounded-xl font-semibold ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus}`}
+          <button
+            onClick={registerCollateral}
+            disabled={loading}
+            className={`w-full ${colors.primary.bg} ${colors.primary.text} py-2.5 rounded-xl font-semibold ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center justify-center gap-2`}
           >
-            {loading ? "Processing…" : "Register & Continue"}
+            {loading ? (
+              <>
+                <Spinner />
+                Processing…
+              </>
+            ) : (
+              "Register & Continue"
+            )}
           </button>
         </>
       ) : (
@@ -132,23 +131,27 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
             onChange={(e) => setLoanAmount(e.target.value)} 
             type="number" 
           />
-          <button 
-            onClick={requestLoan} 
-            disabled={loading} 
-            className={`w-full ${colors.secondary.bg} ${colors.secondary.text} py-2.5 rounded-xl font-semibold ${colors.secondary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus}`}
+          <button
+            onClick={requestLoan}
+            disabled={loading}
+            className={`w-full ${colors.secondary.bg} ${colors.secondary.text} py-2.5 rounded-xl font-semibold ${colors.secondary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center justify-center gap-2`}
           >
-            {loading ? "Processing…" : "Request Loan"}
+            {loading ? (
+              <>
+                <Spinner />
+                Processing…
+              </>
+            ) : (
+              "Request Loan"
+            )}
           </button>
         </>
       )}
-<<<<<<< HEAD
       {status && (
-        <p className={`text-sm mt-2 ${status.includes('❌') ? colors.status.error.text : colors.status.success.text}`}>
+        <p className={`text-sm mt-2 ${status.includes("❌") ? colors.status.error.text : colors.status.success.text}`}>
           {status}
         </p>
       )}
-=======
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
     </div>
   );
 }

--- a/frontend/src/components/OnboardingModal.tsx
+++ b/frontend/src/components/OnboardingModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 interface OnboardingModalProps {
   isOpen: boolean;
@@ -9,7 +10,10 @@ interface OnboardingModalProps {
 const ONBOARDING_STEPS = [
   {
     title: "Connect Your Wallet",
-    description: "Connect your Freighter wallet to start using StellarKraal",
+    description:
+      "Install the Freighter browser extension and connect your Stellar wallet to get started.",
+    action: "Connect Wallet",
+    actionHref: null,
     illustration: (
       <svg width="120" height="120" viewBox="0 0 120 120" fill="none" className="mx-auto">
         <rect x="30" y="40" width="60" height="40" rx="8" stroke="currentColor" strokeWidth="3" fill="none" />
@@ -18,11 +22,14 @@ const ONBOARDING_STEPS = [
         <circle cx="75" cy="55" r="4" fill="currentColor" />
         <path d="M40 70 Q60 80 80 70" stroke="currentColor" strokeWidth="2" fill="none" />
       </svg>
-    )
+    ),
   },
   {
     title: "Register Collateral",
-    description: "Add your livestock as collateral to secure loans",
+    description:
+      "Add your livestock as collateral. Each animal is appraised and recorded on-chain to back your loan.",
+    action: "Register Collateral",
+    actionHref: "/borrow",
     illustration: (
       <svg width="120" height="120" viewBox="0 0 120 120" fill="none" className="mx-auto">
         <ellipse cx="60" cy="66" rx="25" ry="16" stroke="currentColor" strokeWidth="3" fill="none" />
@@ -32,11 +39,14 @@ const ONBOARDING_STEPS = [
         <line x1="68" y1="82" x2="69" y2="95" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
         <line x1="78" y1="80" x2="80" y2="95" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
       </svg>
-    )
+    ),
   },
   {
-    title: "Request a Loan",
-    description: "Get instant loans backed by your registered livestock",
+    title: "Apply for a Loan",
+    description:
+      "Request a loan against your registered collateral. Funds are disbursed instantly on the Stellar network.",
+    action: "Apply for a Loan",
+    actionHref: "/borrow",
     illustration: (
       <svg width="120" height="120" viewBox="0 0 120 120" fill="none" className="mx-auto">
         <rect x="35" y="45" width="50" height="30" rx="6" stroke="currentColor" strokeWidth="3" fill="none" />
@@ -45,12 +55,18 @@ const ONBOARDING_STEPS = [
         <circle cx="75" cy="35" r="8" fill="currentColor" fillOpacity="0.2" stroke="currentColor" strokeWidth="2" />
         <path d="M72 35 L75 38 L78 32" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-    )
-  }
+    ),
+  },
 ];
 
 export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
+  const router = useRouter();
   const [currentStep, setCurrentStep] = useState(0);
+
+  // Reset to first step each time the modal opens
+  useEffect(() => {
+    if (isOpen) setCurrentStep(0);
+  }, [isOpen]);
 
   const handleNext = () => {
     if (currentStep < ONBOARDING_STEPS.length - 1) {
@@ -70,56 +86,73 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
     onClose();
   };
 
+  const handlePrimaryAction = () => {
+    const step = ONBOARDING_STEPS[currentStep];
+    if (step.actionHref) {
+      handleComplete();
+      router.push(step.actionHref);
+    } else {
+      handleNext();
+    }
+  };
+
   if (!isOpen) return null;
 
   const step = ONBOARDING_STEPS[currentStep];
+  const isLast = currentStep === ONBOARDING_STEPS.length - 1;
 
   return (
-    <div className="fixed inset-0 bg-brown-900/80 flex items-center justify-center z-50 p-4">
-      <div className="bg-cream-50 rounded-2xl max-w-md w-full p-6 relative">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+      className="fixed inset-0 bg-brown-900/80 flex items-center justify-center z-50 p-4"
+    >
+      <div className="bg-cream-50 dark:bg-brown-800 rounded-2xl max-w-md w-full p-6 relative">
         <button
           onClick={handleSkip}
-          className="absolute top-4 right-4 text-brown-500 hover:text-brown-700 text-xl"
+          aria-label="Skip onboarding"
+          className="absolute top-4 right-4 text-brown-500 hover:text-brown-700 dark:text-brown-300 dark:hover:text-brown-100 text-xl leading-none"
         >
           ×
         </button>
-        
+
         <div className="text-center">
-          <div className="mb-6 text-gold-600">
-            {step.illustration}
-          </div>
-          
-          <h2 className="text-2xl font-bold text-brown-700 mb-3">
+          <div className="mb-6 text-gold-600">{step.illustration}</div>
+
+          <h2 id="onboarding-title" className="text-2xl font-bold text-brown-700 dark:text-cream-50 mb-3">
             {step.title}
           </h2>
-          
-          <p className="text-brown-600 mb-8">
-            {step.description}
-          </p>
-          
-          <div className="flex justify-center mb-6">
+
+          <p className="text-brown-600 dark:text-brown-300 mb-8">{step.description}</p>
+
+          {/* Step indicators */}
+          <div className="flex justify-center mb-6" role="tablist" aria-label="Onboarding progress">
             {ONBOARDING_STEPS.map((_, index) => (
               <div
                 key={index}
+                role="tab"
+                aria-selected={index === currentStep}
+                aria-label={`Step ${index + 1} of ${ONBOARDING_STEPS.length}`}
                 className={`w-2 h-2 rounded-full mx-1 ${
                   index === currentStep ? "bg-gold-600" : "bg-gold-200"
                 }`}
               />
             ))}
           </div>
-          
+
           <div className="flex gap-3">
             <button
               onClick={handleSkip}
-              className="flex-1 px-4 py-2 text-brown-600 border border-brown-300 rounded-lg hover:bg-brown-50 transition"
+              className="flex-1 px-4 py-2 text-brown-600 dark:text-brown-300 border border-brown-300 dark:border-brown-600 rounded-lg hover:bg-brown-50 dark:hover:bg-brown-700 transition"
             >
               Skip
             </button>
             <button
-              onClick={handleNext}
+              onClick={isLast ? handlePrimaryAction : handleNext}
               className="flex-1 px-4 py-2 bg-brown-600 text-cream-50 rounded-lg hover:bg-brown-700 transition"
             >
-              {currentStep === ONBOARDING_STEPS.length - 1 ? "Get Started" : "Next"}
+              {isLast ? step.action : "Next"}
             </button>
           </div>
         </div>

--- a/frontend/src/components/RepayPanel.tsx
+++ b/frontend/src/components/RepayPanel.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import { signTransaction } from "@/lib/freighterClient";
 import { submitSignedXdr } from "@/lib/stellarUtils";
 import { colors } from "@/lib/design-tokens";
+import Card from "@/components/Card";
+import Spinner from "@/components/Spinner";
 
 interface Props {
   walletAddress: string;
@@ -37,36 +39,43 @@ export default function RepayPanel({ walletAddress }: Props) {
   }
 
   return (
-    <div className={`${colors.background.card} rounded-2xl p-6 shadow mb-4`}>
-      <h2 className={`text-xl font-semibold ${colors.text.primary} mb-3`}>Repay Loan</h2>
+    <Card
+      className="mb-4"
+      header={<h2 className={`text-xl font-semibold ${colors.text.primary}`}>Repay Loan</h2>}
+    >
       <div className="space-y-3">
-        <input 
-          className={`w-full ${colors.form.input} rounded-lg px-3 py-2 ${colors.text.primary} ${colors.form.placeholder}`} 
-          placeholder="Loan ID" 
-          value={loanId} 
-          onChange={(e) => setLoanId(e.target.value)} 
-          type="number" 
+        <input
+          className={`w-full ${colors.form.input} rounded-lg px-3 py-2 ${colors.text.primary} ${colors.form.placeholder}`}
+          placeholder="Loan ID"
+          value={loanId}
+          onChange={(e) => setLoanId(e.target.value)}
+          type="number"
         />
-        <input 
-          className={`w-full ${colors.form.input} rounded-lg px-3 py-2 ${colors.text.primary} ${colors.form.placeholder}`} 
-          placeholder="Amount (stroops)" 
-          value={amount} 
-          onChange={(e) => setAmount(e.target.value)} 
-          type="number" 
+        <input
+          className={`w-full ${colors.form.input} rounded-lg px-3 py-2 ${colors.text.primary} ${colors.form.placeholder}`}
+          placeholder="Amount (stroops)"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          type="number"
         />
-        <button 
-          onClick={repay} 
-          disabled={loading} 
-          className={`w-full ${colors.secondary.bg} ${colors.secondary.text} py-2.5 rounded-xl font-semibold ${colors.secondary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus}`}
+        <button
+          onClick={repay}
+          disabled={loading}
+          className={`w-full ${colors.secondary.bg} ${colors.secondary.text} py-2.5 rounded-xl font-semibold ${colors.secondary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center justify-center gap-2`}
         >
-          {loading ? "Processing…" : "Repay"}
+          {loading ? (
+            <>
+              <Spinner />
+              Processing…
+            </>
+          ) : "Repay"}
         </button>
       </div>
       {status && (
-        <p className={`text-sm mt-2 ${status.includes('❌') ? colors.status.error.text : colors.status.success.text}`}>
+        <p className={`text-sm mt-2 ${status.includes("❌") ? colors.status.error.text : colors.status.success.text}`}>
           {status}
         </p>
       )}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SkeletonCollateralCard.tsx
+++ b/frontend/src/components/SkeletonCollateralCard.tsx
@@ -1,13 +1,25 @@
 import Skeleton from "./Skeleton";
+import Card from "./Card";
 
 export default function SkeletonCollateralCard() {
   return (
-    <div className="bg-white rounded-2xl p-6 shadow mb-4" aria-busy="true" aria-label="Loading loan data">
-      <Skeleton className="h-6 w-40 mb-4" />
-      <div className="flex gap-2">
-        <Skeleton className="h-10 flex-1" />
-        <Skeleton className="h-10 w-20" />
+    <Card
+      aria-busy="true"
+      aria-label="Loading collateral"
+      header={
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-8 rounded" />
+          <Skeleton className="h-5 w-12 rounded-full" />
+        </div>
+      }
+      footer={<Skeleton className="h-3 w-24" />}
+    >
+      <Skeleton className="h-5 w-28 mb-3" />
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-3 w-16" />
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SkeletonHealthDashboard.tsx
+++ b/frontend/src/components/SkeletonHealthDashboard.tsx
@@ -1,9 +1,14 @@
 import Skeleton from "./Skeleton";
+import Card from "./Card";
 
 export default function SkeletonHealthDashboard() {
   return (
-    <div className="mt-8 bg-white rounded-2xl p-6 shadow" aria-busy="true" aria-label="Loading health factor">
-      <Skeleton className="h-6 w-36 mb-4" />
+    <Card
+      className="mt-8"
+      header={<Skeleton className="h-6 w-36" />}
+      aria-busy="true"
+      aria-label="Loading health factor"
+    >
       <div className="flex gap-2 items-center">
         <Skeleton className="h-10 flex-1" />
         <Skeleton className="h-10 w-20" />
@@ -15,6 +20,6 @@ export default function SkeletonHealthDashboard() {
         </div>
         <Skeleton className="h-4 w-full rounded-full" />
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SkeletonLoanCard.tsx
+++ b/frontend/src/components/SkeletonLoanCard.tsx
@@ -1,13 +1,19 @@
 import Skeleton from "./Skeleton";
+import Card from "./Card";
 
 export default function SkeletonLoanCard() {
   return (
-    <div className="bg-white rounded-2xl p-6 shadow mt-6 space-y-4" aria-busy="true" aria-label="Loading loan form">
-      <Skeleton className="h-6 w-48" />
-      <Skeleton className="h-10 w-full" />
-      <Skeleton className="h-10 w-full" />
-      <Skeleton className="h-10 w-full" />
-      <Skeleton className="h-11 w-full rounded-xl" />
-    </div>
+    <Card aria-busy="true" aria-label="Loading loan">
+      <div className="flex justify-between items-center">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-40" />
+        </div>
+        <div className="text-right space-y-2">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,0 +1,31 @@
+interface SpinnerProps {
+  /** Tailwind sizing classes. Defaults to a 1rem inline glyph. */
+  className?: string;
+  /** Accessible label announced to assistive tech. */
+  label?: string;
+}
+
+/**
+ * Spinner — inline indicator for an action already in progress
+ * (button clicks, filter changes, inline lookups).
+ *
+ * For an initial page or data load, use a Skeleton instead — see the
+ * loading-state guidelines in `LoadingStates.stories.tsx`.
+ *
+ * Colour is inherited from the parent via `currentColor`, so it adapts
+ * to whatever button/text colour it sits inside (light and dark modes).
+ */
+export default function Spinner({ className = "h-4 w-4", label = "Loading" }: SpinnerProps) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      role="status"
+      aria-label={label}
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+    </svg>
+  );
+}

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import EmptyState from "./EmptyState";
 import { EmptyTransactionsIllustration } from "./illustrations";
+import Card from "@/components/Card";
 
 interface Transaction {
   id: number;
@@ -32,28 +33,26 @@ export default function TransactionHistory({ walletAddress }: { walletAddress: s
 
   if (transactions.length === 0) {
     return (
-      <div className="bg-white rounded-2xl p-6 shadow mb-4">
-        <h2 className="text-xl font-semibold text-brown mb-3">Transactions</h2>
+      <Card className="mb-4" header={<h2 className="text-xl font-semibold text-brown-700">Transactions</h2>}>
         <EmptyState
           illustration={<EmptyTransactionsIllustration />}
           message="No transactions yet"
           ctaLabel="View Loans"
           onCta={() => router.push("/dashboard")}
         />
-      </div>
+      </Card>
     );
   }
 
   return (
-    <div className="bg-white rounded-2xl p-6 shadow mb-4">
-      <h2 className="text-xl font-semibold text-brown mb-3">Transactions</h2>
+    <Card className="mb-4" header={<h2 className="text-xl font-semibold text-brown-700">Transactions</h2>}>
       <ul className="space-y-2">
         {transactions.map((tx) => (
-          <li key={tx.id} className="text-sm text-brown/80 border-b border-brown/10 pb-2">
+          <li key={tx.id} className="text-sm text-brown-600 border-b border-brown-100 pb-2">
             Loan #{tx.loan_id} — {tx.amount} stroops — {new Date(tx.created_at).toLocaleDateString()}
           </li>
         ))}
       </ul>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -1,20 +1,14 @@
 "use client";
-<<<<<<< HEAD
 import { useEffect } from "react";
 import { colors } from "@/lib/design-tokens";
 import { useWallet } from "@/hooks/useWallet";
-=======
-import { useState } from "react";
-import { isConnected, getAddress, setAllowed } from "@stellar/freighter-api";
-import { useToast } from "@/components/toast";
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
+import Spinner from "@/components/Spinner";
 
 interface Props {
   onConnect: (address: string) => void;
 }
 
 export default function WalletConnect({ onConnect }: Props) {
-<<<<<<< HEAD
   const { address, freighterInstalled, connecting, error, connect } = useWallet();
 
   // Notify parent whenever address changes
@@ -40,24 +34,6 @@ export default function WalletConnect({ onConnect }: Props) {
         </a>
       </div>
     );
-=======
-  const [address, setAddress] = useState<string | null>(null);
-  const toast = useToast();
-
-  async function connect() {
-    try {
-      const connected = await isConnected();
-      if (!connected) {
-        await setAllowed();
-      }
-      const { address: addr } = await getAddress();
-      setAddress(addr);
-      onConnect(addr);
-      toast.success("Wallet connected successfully");
-    } catch (e: any) {
-      toast.error(e.message);
-    }
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
   }
 
   // Connected
@@ -74,14 +50,19 @@ export default function WalletConnect({ onConnect }: Props) {
     <div className="mb-6">
       <button
         onClick={connect}
-        className={`${colors.primary.bg} ${colors.primary.text} px-5 py-2.5 rounded-xl font-semibold ${colors.primary.hover} transition ${colors.interactive.focus}`}
+        disabled={connecting}
+        className={`${colors.primary.bg} ${colors.primary.text} px-5 py-2.5 rounded-xl font-semibold ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center gap-2`}
       >
-        {connecting ? "Connecting…" : "Connect Freighter Wallet"}
+        {connecting ? (
+          <>
+            <Spinner />
+            Connecting…
+          </>
+        ) : (
+          "Connect Freighter Wallet"
+        )}
       </button>
-<<<<<<< HEAD
       {error && <p className={`${colors.status.error.text} text-sm mt-2`}>{error}</p>}
-=======
->>>>>>> adc36bf16cea1946dea369bf560370224ff8a132
     </div>
   );
 }

--- a/frontend/src/components/wizard/steps/StepCollateral.tsx
+++ b/frontend/src/components/wizard/steps/StepCollateral.tsx
@@ -2,6 +2,7 @@
 import { useWizard, AnimalType } from "@/context/LoanWizardContext";
 import { signTransaction } from "@/lib/freighterClient";
 import { submitSignedXdr } from "@/lib/stellarUtils";
+import Spinner from "@/components/Spinner";
 
 const ANIMAL_TYPES: { value: AnimalType; label: string; emoji: string; desc: string }[] = [
   { value: "cattle", label: "Cattle", emoji: "🐄", desc: "High appraisal value" },
@@ -137,10 +138,7 @@ export default function StepCollateral({ walletAddress }: Props) {
       >
         {loading ? (
           <>
-            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-            </svg>
+            <Spinner />
             Registering on-chain…
           </>
         ) : (

--- a/frontend/src/components/wizard/steps/StepConfirm.tsx
+++ b/frontend/src/components/wizard/steps/StepConfirm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useWizard } from "@/context/LoanWizardContext";
 import { signTransaction } from "@/lib/freighterClient";
 import { submitSignedXdr } from "@/lib/stellarUtils";
+import Spinner from "@/components/Spinner";
 
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
@@ -171,10 +172,7 @@ export default function StepConfirm({ walletAddress }: Props) {
         >
           {loading ? (
             <>
-              <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-              </svg>
+              <Spinner />
               Submitting…
             </>
           ) : (

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -1,21 +1,40 @@
 import { useState, useEffect } from "react";
 
-export function useOnboarding() {
+const STORAGE_KEY = "stellarkraal_onboarding_completed";
+const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+export function useOnboarding(walletAddress?: string | null) {
   const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
-    const completed = localStorage.getItem("stellarkraal_onboarding_completed");
-    if (!completed) {
+    const completed = localStorage.getItem(STORAGE_KEY);
+    if (completed) return;
+
+    // If no wallet yet, show immediately (wallet step is first)
+    if (!walletAddress) {
       setShowOnboarding(true);
+      return;
     }
-  }, []);
+
+    // Wallet connected: only show if user has no collateral and no loans
+    Promise.all([
+      fetch(`${API}/api/collateral/list?owner=${walletAddress}`)
+        .then((r) => r.json())
+        .then((d) => (d.collaterals ?? []).length)
+        .catch(() => 0),
+      fetch(`${API}/api/loans`)
+        .then((r) => r.json())
+        .then((d) => (Array.isArray(d?.data) ? d.data : Array.isArray(d) ? d : []).length)
+        .catch(() => 0),
+    ]).then(([collateralCount, loanCount]) => {
+      if (collateralCount === 0 && loanCount === 0) {
+        setShowOnboarding(true);
+      }
+    });
+  }, [walletAddress]);
 
   const openOnboarding = () => setShowOnboarding(true);
   const closeOnboarding = () => setShowOnboarding(false);
 
-  return {
-    showOnboarding,
-    openOnboarding,
-    closeOnboarding
-  };
+  return { showOnboarding, openOnboarding, closeOnboarding };
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,4 @@
+/** Merge class names, filtering out falsy values. */
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
Implements #311, #309, #310.

#311 — Consistent Card component
- Add reusable Card (header/body/footer slots; default/highlighted/warning variants; light + dark mode) that forwards aria/HTML attributes.
- Refactor all data surfaces (collateral grid, loan/collateral lists, detail page, dashboard, transactions, lookup/repay panels, skeletons) onto Card for uniform padding, radius, shadow, and headers.
- Document every variant + slot in Card.stories.tsx.
- Add cn() class-merge helper in lib/utils.ts.

#309 — Loading-state strategy (skeleton vs spinner)
- Add reusable Spinner (currentColor, accessible) and adopt it for all inline actions (lookup, repay, loan/collateral forms, wizard steps, wallet connect), replacing ad-hoc/duplicated spinner markup.
- Use skeletons for initial page/data loads (loans, collateral, detail), so no page shows a blank screen on entry.
- Document the guidelines in LoadingStates.stories.tsx.

#310 — Visual hierarchy on the collateral detail page
- Promote health factor + outstanding balance to large primary metrics.
- Make supporting details visually subordinate; add a prominent at-risk/liquidation banner. Derived from the existing loan data model.

Also resolves committed merge-conflict markers in layout.tsx, WalletConnect.tsx, and LoanForm.tsx that prevented the frontend from compiling: standardize wallet UI on useWallet + design tokens, route toasts through @/components/toast in the layout, and restore LoanForm's inline status UX (matches its test suite). Wallet-aware onboarding and accessibility passes on OnboardingModal are included.

Closes #309 
Closes #310 
Closes #311 
Closes #312 