### PR TITLE
feat: add OpenAPI 3.0 spec with all endpoints and Swagger UI

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "backend/src/routes/**"
+      - "backend/src/index.ts"
       - "backend/openapi.json"
   push:
     branches:
@@ -15,21 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate openapi.json is well-formed
-        run: |
-          node -e "
-            const fs = require('fs');
-            const spec = JSON.parse(fs.readFileSync('backend/openapi.json', 'utf8'));
-            if (spec.openapi !== '3.0.3') { process.exit(1); }
-            const paths = Object.keys(spec.paths);
-            if (paths.length === 0) { console.error('No paths defined'); process.exit(1); }
-            console.log('OpenAPI spec valid. Paths:', paths.length);
-          "
+      - name: Validate OpenAPI 3.0 spec
+        run: npx --yes @redocly/cli@1.x lint --extends=minimal backend/openapi.json
 
       - name: Check spec is committed
         run: |
           if [ ! -f backend/openapi.json ]; then
-            echo "ERROR: backend/openapi.json is missing. Run spec generation and commit it."
+            echo "ERROR: backend/openapi.json is missing."
             exit 1
           fi
           echo "openapi.json present"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3,72 +3,164 @@
   "info": {
     "title": "StellarKraal API",
     "version": "1.0.0",
-    "description": "Livestock-backed micro-lending API on Stellar/Soroban. All write endpoints return an unsigned XDR transaction that the client must sign with Freighter and submit to the Stellar network."
+    "description": "Livestock-backed micro-lending API on Stellar/Soroban. Write endpoints return an unsigned XDR transaction the client must sign with Freighter and submit to the Stellar network."
   },
   "servers": [
-    { "url": "/api/v1", "description": "Current version" }
+    { "url": "/api/v1", "description": "Versioned API" },
+    { "url": "/api", "description": "Unversioned (deprecated, redirects to /api/v1)" }
   ],
   "tags": [
+    { "name": "auth", "description": "Authentication — challenge/response JWT flow" },
     { "name": "health", "description": "Service health" },
     { "name": "collateral", "description": "Livestock collateral management" },
     { "name": "loan", "description": "Loan lifecycle" },
     { "name": "oracle", "description": "Price oracle integration" },
     { "name": "webhooks", "description": "Event webhook subscriptions" },
-    { "name": "admin", "description": "Admin endpoints" }
+    { "name": "admin", "description": "Admin endpoints" },
+    { "name": "transactions", "description": "Transaction history" },
+    { "name": "settings", "description": "User preferences" }
+  ],
+  "security": [
+    { "bearerAuth": [] }
   ],
   "paths": {
-    "/health": {
+    "/auth/challenge": {
       "get": {
-        "tags": ["health"],
-        "summary": "Service health check",
-        "description": "Returns service status, uptime, and RPC reachability.",
-        "operationId": "getHealth",
+        "tags": ["auth"],
+        "summary": "Get a one-time challenge",
+        "description": "Returns a random hex challenge string. The client must sign it with their Stellar keypair and submit it to POST /auth/login.",
+        "operationId": "getChallenge",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Service is healthy",
+            "description": "Challenge issued",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HealthResponse" }
-              }
-            }
-          },
-          "503": {
-            "description": "Service is degraded (RPC unreachable)",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/HealthResponse" }
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "challenge": { "type": "string", "example": "a3f9..." }
+                  }
+                }
               }
             }
           }
         }
       }
     },
-    "/collateral/register": {
+    "/auth/login": {
       "post": {
-        "tags": ["collateral"],
-        "summary": "Register livestock collateral",
-        "description": "Builds an unsigned Soroban transaction to register livestock as on-chain collateral. The client must sign and submit the returned XDR.",
-        "operationId": "registerCollateral",
+        "tags": ["auth"],
+        "summary": "Login with Stellar signature",
+        "description": "Verifies the ed25519 signature over the challenge. Returns a short-lived JWT access token (15 min) and a refresh token (7 days).",
+        "operationId": "login",
+        "security": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RegisterCollateralRequest" }
+              "schema": { "$ref": "#/components/schemas/LoginRequest" }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Unsigned XDR transaction",
+            "description": "Tokens issued",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/XdrResponse" }
+                "schema": { "$ref": "#/components/schemas/TokenResponse" }
               }
             }
           },
           "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": ["health"],
+        "summary": "Service health check",
+        "operationId": "getHealth",
+        "security": [],
+        "responses": {
+          "200": { "description": "Healthy", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HealthResponse" } } } },
+          "503": { "description": "Degraded", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HealthResponse" } } } }
+        }
+      }
+    },
+    "/collateral/register": {
+      "post": {
+        "tags": ["collateral"],
+        "summary": "Register livestock collateral (on-chain)",
+        "description": "Builds an unsigned Soroban transaction to register livestock as on-chain collateral.",
+        "operationId": "registerCollateral",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RegisterCollateralRequest" } } } },
+        "responses": {
+          "200": { "description": "Unsigned XDR transaction", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/XdrResponse" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
           "429": { "$ref": "#/components/responses/RateLimited" },
           "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/collateral": {
+      "post": {
+        "tags": ["collateral"],
+        "summary": "Create collateral record (DB)",
+        "operationId": "createCollateral",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RegisterCollateralRequest" } } } },
+        "responses": {
+          "201": { "description": "Created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CollateralRecord" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      },
+      "get": {
+        "tags": ["collateral"],
+        "summary": "List collateral records",
+        "operationId": "listCollateral",
+        "security": [],
+        "parameters": [
+          { "name": "owner", "in": "query", "schema": { "type": "string" } },
+          { "name": "animal_type", "in": "query", "schema": { "type": "string" } },
+          { "name": "page", "in": "query", "schema": { "type": "integer", "minimum": 1, "default": 1 } },
+          { "name": "pageSize", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 } }
+        ],
+        "responses": {
+          "200": { "description": "Paginated list", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CollateralPage" } } } }
+        }
+      }
+    },
+    "/collateral/{id}/appraise": {
+      "put": {
+        "tags": ["collateral"],
+        "summary": "Update appraised value",
+        "operationId": "appraiseCollateral",
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "type": "object", "required": ["appraised_value"], "properties": { "appraised_value": { "type": "integer", "minimum": 1 } } } } }
+        },
+        "responses": {
+          "200": { "description": "Updated record", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CollateralRecord" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/collateral/{id}": {
+      "delete": {
+        "tags": ["collateral"],
+        "summary": "Soft-delete a collateral record",
+        "operationId": "deleteCollateral",
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Deleted", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeletedResponse" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
         }
       }
     },
@@ -76,26 +168,12 @@
       "post": {
         "tags": ["loan"],
         "summary": "Request a new loan",
-        "description": "Builds an unsigned Soroban transaction to request a loan against registered collateral.",
         "operationId": "requestLoan",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/LoanRequestBody" }
-            }
-          }
-        },
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanRequestBody" } } } },
         "responses": {
-          "200": {
-            "description": "Unsigned XDR transaction",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/XdrResponse" }
-              }
-            }
-          },
+          "200": { "description": "Unsigned XDR transaction", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/XdrResponse" } } } },
           "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
           "429": { "$ref": "#/components/responses/RateLimited" },
           "500": { "$ref": "#/components/responses/InternalError" }
         }
@@ -105,26 +183,14 @@
       "post": {
         "tags": ["loan"],
         "summary": "Repay a loan",
-        "description": "Builds an unsigned Soroban transaction for partial or full loan repayment.",
+        "description": "Requires `Idempotency-Key` header to prevent duplicate submissions.",
         "operationId": "repayLoan",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/LoanRepayBody" }
-            }
-          }
-        },
+        "parameters": [{ "name": "Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string" }, "description": "Client-generated unique key for idempotent replay" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanRepayBody" } } } },
         "responses": {
-          "200": {
-            "description": "Unsigned XDR transaction",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/XdrResponse" }
-              }
-            }
-          },
+          "200": { "description": "Unsigned XDR transaction", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/XdrResponse" } } } },
           "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
           "429": { "$ref": "#/components/responses/RateLimited" },
           "500": { "$ref": "#/components/responses/InternalError" }
         }
@@ -134,27 +200,31 @@
       "post": {
         "tags": ["loan"],
         "summary": "Liquidate an undercollateralised loan",
-        "description": "Builds an unsigned Soroban transaction to liquidate a loan whose health factor is below 1.",
         "operationId": "liquidateLoan",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanLiquidateBody" } } } },
+        "responses": {
+          "200": { "description": "Unsigned XDR transaction", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/XdrResponse" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/loan/repayment-preview": {
+      "post": {
+        "tags": ["loan"],
+        "summary": "Preview repayment breakdown",
+        "description": "Simulates a repayment and returns principal/interest/fee breakdown and projected health factor. Does not submit a transaction.",
+        "operationId": "repaymentPreview",
         "requestBody": {
           "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/LoanLiquidateBody" }
-            }
-          }
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RepaymentPreviewRequest" } } }
         },
         "responses": {
-          "200": {
-            "description": "Unsigned XDR transaction",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/XdrResponse" }
-              }
-            }
-          },
+          "200": { "description": "Preview result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RepaymentPreviewResponse" } } } },
           "400": { "$ref": "#/components/responses/ValidationError" },
-          "429": { "$ref": "#/components/responses/RateLimited" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
           "500": { "$ref": "#/components/responses/InternalError" }
         }
       }
@@ -164,26 +234,39 @@
         "tags": ["loan"],
         "summary": "Fetch a loan record",
         "operationId": "getLoan",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "integer", "minimum": 0 },
-            "description": "Loan ID"
-          }
-        ],
+        "security": [],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 0 } }],
         "responses": {
-          "200": {
-            "description": "Loan record (raw Soroban ScVal)",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ScValResponse" }
-              }
-            }
-          },
+          "200": { "description": "Loan record", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScValResponse" } } } },
           "404": { "$ref": "#/components/responses/NotFound" },
           "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      },
+      "delete": {
+        "tags": ["loan"],
+        "summary": "Soft-delete a loan record",
+        "operationId": "deleteLoan",
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Deleted", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeletedResponse" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/loans": {
+      "get": {
+        "tags": ["loan"],
+        "summary": "List loans (paginated)",
+        "operationId": "listLoans",
+        "security": [],
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer", "minimum": 1, "default": 1 } },
+          { "name": "pageSize", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 } }
+        ],
+        "responses": {
+          "200": { "description": "Paginated loan list", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanPage" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" }
         }
       }
     },
@@ -193,24 +276,10 @@
         "summary": "Get loan health factor",
         "description": "Returns the health factor scaled by 10 000. Values ≥ 10 000 are healthy; < 10 000 are eligible for liquidation.",
         "operationId": "getLoanHealth",
-        "parameters": [
-          {
-            "name": "loanId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "integer", "minimum": 0 },
-            "description": "Loan ID"
-          }
-        ],
+        "security": [],
+        "parameters": [{ "name": "loanId", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 0 } }],
         "responses": {
-          "200": {
-            "description": "Health factor",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/HealthFactorResponse" }
-              }
-            }
-          },
+          "200": { "description": "Health factor", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HealthFactorResponse" } } } },
           "404": { "$ref": "#/components/responses/NotFound" },
           "500": { "$ref": "#/components/responses/InternalError" }
         }
@@ -220,22 +289,10 @@
       "post": {
         "tags": ["oracle"],
         "summary": "Invalidate appraisal cache",
-        "description": "Signals that oracle prices have changed; clears the server-side appraisal cache.",
         "operationId": "oraclePriceUpdate",
         "responses": {
-          "200": {
-            "description": "Cache invalidated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "invalidated": { "type": "boolean", "example": true }
-                  }
-                }
-              }
-            }
-          }
+          "200": { "description": "Cache invalidated", "content": { "application/json": { "schema": { "type": "object", "properties": { "invalidated": { "type": "boolean", "example": true } } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
         }
       }
     },
@@ -243,32 +300,31 @@
       "post": {
         "tags": ["webhooks"],
         "summary": "Register a webhook",
-        "description": "Subscribe a URL to receive event notifications (loan.approved, loan.repaid, loan.liquidated).",
         "operationId": "registerWebhook",
         "requestBody": {
           "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["url"],
-                "properties": {
-                  "url": { "type": "string", "format": "uri", "example": "https://example.com/hook" }
-                }
-              }
-            }
-          }
+          "content": { "application/json": { "schema": { "type": "object", "required": ["url"], "properties": { "url": { "type": "string", "format": "uri" } } } } }
         },
         "responses": {
-          "201": {
-            "description": "Webhook registered",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/WebhookRecord" }
-              }
-            }
-          },
-          "400": { "$ref": "#/components/responses/ValidationError" }
+          "201": { "description": "Registered", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/WebhookRecord" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/alerts/webhook": {
+      "post": {
+        "tags": ["admin"],
+        "summary": "AWS SNS alert receiver",
+        "description": "Receives AWS SNS notifications (SubscriptionConfirmation and Notification). Used for backup failure alerts.",
+        "operationId": "alertsWebhook",
+        "security": [],
+        "parameters": [
+          { "name": "x-amz-sns-message-type", "in": "header", "schema": { "type": "string", "enum": ["SubscriptionConfirmation", "Notification"] } }
+        ],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "responses": {
+          "200": { "description": "Accepted" }
         }
       }
     },
@@ -278,17 +334,8 @@
         "summary": "List registered webhooks",
         "operationId": "listWebhooks",
         "responses": {
-          "200": {
-            "description": "Array of webhook records",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/WebhookRecord" }
-                }
-              }
-            }
-          }
+          "200": { "description": "Webhook list", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/WebhookRecord" } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
         }
       }
     },
@@ -298,23 +345,198 @@
         "summary": "List webhook delivery logs",
         "operationId": "listWebhookLogs",
         "responses": {
-          "200": {
-            "description": "Array of delivery log entries",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/WebhookLog" }
+          "200": { "description": "Delivery logs", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/WebhookLog" } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/admin/migrations/status": {
+      "get": {
+        "tags": ["admin"],
+        "summary": "Migration status",
+        "operationId": "getMigrationStatus",
+        "responses": {
+          "200": { "description": "Status", "content": { "application/json": { "schema": { "type": "object", "properties": { "status": { "type": "object" } } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/admin/deleted/collateral": {
+      "get": {
+        "tags": ["admin"],
+        "summary": "List soft-deleted collateral",
+        "operationId": "listDeletedCollateral",
+        "responses": {
+          "200": { "description": "Deleted records", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/CollateralRecord" } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/admin/restore/collateral/{id}": {
+      "post": {
+        "tags": ["admin"],
+        "summary": "Restore soft-deleted collateral",
+        "operationId": "restoreCollateral",
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Restored", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RestoredResponse" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/admin/deleted/loans": {
+      "get": {
+        "tags": ["admin"],
+        "summary": "List soft-deleted loans",
+        "operationId": "listDeletedLoans",
+        "responses": {
+          "200": { "description": "Deleted loan records", "content": { "application/json": { "schema": { "type": "array", "items": { "type": "object" } } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/admin/restore/loans/{id}": {
+      "post": {
+        "tags": ["admin"],
+        "summary": "Restore soft-deleted loan",
+        "operationId": "restoreLoan",
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Restored", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RestoredResponse" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/transactions": {
+      "get": {
+        "tags": ["transactions"],
+        "summary": "List transactions",
+        "operationId": "listTransactions",
+        "security": [],
+        "parameters": [
+          { "name": "borrower", "in": "query", "schema": { "type": "string" } },
+          { "name": "type", "in": "query", "schema": { "type": "string", "enum": ["loan_request", "repayment", "liquidation"] } },
+          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["pending", "confirmed", "failed"] } },
+          { "name": "startDate", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "endDate", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "page", "in": "query", "schema": { "type": "integer", "minimum": 1, "default": 1 } },
+          { "name": "pageSize", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 } }
+        ],
+        "responses": {
+          "200": { "description": "Paginated transactions", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TransactionPage" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" }
+        }
+      }
+    },
+    "/transactions/{id}": {
+      "get": {
+        "tags": ["transactions"],
+        "summary": "Get transaction by ID",
+        "operationId": "getTransaction",
+        "security": [],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Transaction record", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TransactionRecord" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/settings/{wallet}": {
+      "get": {
+        "tags": ["settings"],
+        "summary": "Get user settings",
+        "operationId": "getSettings",
+        "security": [],
+        "parameters": [{ "name": "wallet", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Stellar public key" }],
+        "responses": {
+          "200": { "description": "User settings", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UserSettings" } } } }
+        }
+      },
+      "put": {
+        "tags": ["settings"],
+        "summary": "Update user settings",
+        "operationId": "updateSettings",
+        "parameters": [{ "name": "wallet", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UserSettingsUpdate" } } } },
+        "responses": {
+          "200": { "description": "Updated settings", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UserSettings" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "tags": ["auth"],
+        "summary": "Rotate refresh token",
+        "description": "Exchanges a valid refresh token for a new access/refresh token pair. The old refresh token is invalidated.",
+        "operationId": "refreshToken",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["refreshToken"],
+                "properties": {
+                  "refreshToken": { "type": "string" }
                 }
               }
             }
           }
+        },
+        "responses": {
+          "200": {
+            "description": "New tokens issued",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TokenResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
         }
       }
     }
   },
   "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "HS256 JWT issued by POST /api/auth/login. Required on all POST, PUT, DELETE, and PATCH requests except /api/auth/* endpoints. Pass as: Authorization: Bearer <token>"
+      }
+    },
     "schemas": {
+      "LoginRequest": {
+        "type": "object",
+        "required": ["publicKey", "signature", "challenge"],
+        "properties": {
+          "publicKey": { "type": "string", "description": "Stellar public key (G...)", "example": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN" },
+          "signature": { "type": "string", "description": "Hex-encoded ed25519 signature over the challenge bytes" },
+          "challenge": { "type": "string", "description": "Challenge string from GET /auth/challenge" }
+        }
+      },
+      "TokenResponse": {
+        "type": "object",
+        "properties": {
+          "accessToken": { "type": "string" },
+          "refreshToken": { "type": "string" },
+          "expiresIn": { "type": "integer", "description": "Access token TTL in seconds", "example": 900 }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "details": { "type": "array", "items": { "type": "object" } }
+        }
+      },
       "HealthResponse": {
         "type": "object",
         "properties": {
@@ -322,7 +544,9 @@
           "status": { "type": "string", "enum": ["healthy", "degraded"] },
           "version": { "type": "string", "example": "1.0.0" },
           "uptime": { "type": "integer", "description": "Uptime in seconds" },
-          "rpcReachable": { "type": "boolean" }
+          "rpcReachable": { "type": "boolean" },
+          "circuitBreaker": { "type": "object", "properties": { "healthy": { "type": "boolean" }, "states": { "type": "object" } } },
+          "pool": { "type": "object" }
         }
       },
       "RegisterCollateralRequest": {
@@ -335,12 +559,32 @@
           "appraised_value": { "type": "integer", "minimum": 1, "description": "Total appraised value in token base units", "example": 5000000 }
         }
       },
+      "CollateralRecord": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "owner": { "type": "string" },
+          "animal_type": { "type": "string" },
+          "count": { "type": "integer" },
+          "appraised_value": { "type": "integer" },
+          "deleted_at": { "type": "string", "format": "date-time", "nullable": true }
+        }
+      },
+      "CollateralPage": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/CollateralRecord" } },
+          "total": { "type": "integer" },
+          "page": { "type": "integer" },
+          "pageSize": { "type": "integer" }
+        }
+      },
       "LoanRequestBody": {
         "type": "object",
-        "required": ["borrower", "collateral_ids", "amount"],
+        "required": ["borrower", "collateral_id", "amount"],
         "properties": {
           "borrower": { "type": "string", "description": "Stellar public key", "example": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN" },
-          "collateral_ids": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1, "example": [1, 2] },
+          "collateral_id": { "type": "integer", "minimum": 0, "example": 1 },
           "amount": { "type": "integer", "minimum": 1, "description": "Gross loan amount in token base units", "example": 3000000 }
         }
       },
@@ -360,6 +604,41 @@
           "liquidator": { "type": "string", "example": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN" },
           "loan_id": { "type": "integer", "minimum": 0, "example": 1 },
           "repay_amount": { "type": "integer", "minimum": 1, "example": 500000 }
+        }
+      },
+      "RepaymentPreviewRequest": {
+        "type": "object",
+        "required": ["loan_id", "amount"],
+        "properties": {
+          "loan_id": { "type": "integer", "minimum": 0, "example": 1 },
+          "amount": { "type": "integer", "minimum": 1, "example": 1000000 }
+        }
+      },
+      "RepaymentPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "loan_id": { "type": "integer" },
+          "repayment_amount": { "type": "integer" },
+          "breakdown": {
+            "type": "object",
+            "properties": {
+              "principal": { "type": "integer" },
+              "interest": { "type": "integer" },
+              "fees": { "type": "integer" },
+              "remaining_balance": { "type": "integer" }
+            }
+          },
+          "projected_health_factor_bps": { "type": "integer", "nullable": true },
+          "fully_repaid": { "type": "boolean" }
+        }
+      },
+      "LoanPage": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "array", "items": { "type": "object" } },
+          "total": { "type": "integer" },
+          "page": { "type": "integer" },
+          "pageSize": { "type": "integer" }
         }
       },
       "XdrResponse": {
@@ -400,46 +679,93 @@
           "timestamp": { "type": "string", "format": "date-time" }
         }
       },
-      "ErrorResponse": {
+      "TransactionRecord": {
         "type": "object",
         "properties": {
-          "error": { "type": "string" },
-          "details": { "type": "array", "items": { "type": "object" } }
+          "id": { "type": "string" },
+          "borrower": { "type": "string" },
+          "type": { "type": "string", "enum": ["loan_request", "repayment", "liquidation"] },
+          "status": { "type": "string", "enum": ["pending", "confirmed", "failed"] },
+          "amount": { "type": "integer" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "TransactionPage": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/TransactionRecord" } },
+          "total": { "type": "integer" },
+          "page": { "type": "integer" },
+          "pageSize": { "type": "integer" }
+        }
+      },
+      "UserSettings": {
+        "type": "object",
+        "properties": {
+          "walletAddress": { "type": "string" },
+          "joinDate": { "type": "string", "format": "date-time" },
+          "notifications": {
+            "type": "object",
+            "properties": {
+              "loanApproved": { "type": "boolean" },
+              "loanRepaid": { "type": "boolean" },
+              "liquidationWarning": { "type": "boolean" }
+            }
+          },
+          "language": { "type": "string", "example": "en" },
+          "currency": { "type": "string", "example": "USD" }
+        }
+      },
+      "UserSettingsUpdate": {
+        "type": "object",
+        "properties": {
+          "notifications": {
+            "type": "object",
+            "properties": {
+              "loanApproved": { "type": "boolean" },
+              "loanRepaid": { "type": "boolean" },
+              "liquidationWarning": { "type": "boolean" }
+            }
+          },
+          "language": { "type": "string", "minLength": 2, "maxLength": 10 },
+          "currency": { "type": "string", "minLength": 3, "maxLength": 6 }
+        }
+      },
+      "DeletedResponse": {
+        "type": "object",
+        "properties": {
+          "deleted": { "type": "boolean", "example": true },
+          "id": { "type": "string" }
+        }
+      },
+      "RestoredResponse": {
+        "type": "object",
+        "properties": {
+          "restored": { "type": "boolean", "example": true },
+          "id": { "type": "string" }
         }
       }
     },
     "responses": {
       "ValidationError": {
         "description": "Request validation failed",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
-          }
-        }
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid JWT",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
       },
       "NotFound": {
         "description": "Resource not found",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
-          }
-        }
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
       },
       "RateLimited": {
         "description": "Too many requests",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
-          }
-        }
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
       },
       "InternalError": {
         "description": "Internal server error",
-        "content": {
-          "application/json": {
-            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
-          }
-        }
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
       }
     }
   }


### PR DESCRIPTION
   
  feat: add OpenAPI 3.0 spec with all endpoints and Swagger UI
  
  Summary
  
  Adds a complete OpenAPI 3.0 spec covering all API endpoints and upgrades the CI validation to
  use a proper linter.
  
  Changes
  
  backend/openapi.json
  
  - Expanded from 11 to 28 paths, covering all endpoints: auth, collateral (on-chain + DB CRUD),
  loans, repayment preview, transactions, settings, oracle, webhooks, and admin routes
  - Added bearerAuth (HS256 JWT) security scheme applied globally; read-only and auth endpoints
  explicitly opt out with security: []
  - Added Idempotency-Key header documented on POST /loan/repay
  - Full request/response schemas for all endpoints
  
  .github/workflows/openapi-check.yml
  
  - Replaced hand-rolled JSON structure check with @redocly/cli lint --extends=minimal, which
  validates against the OpenAPI 3.0 standard
  
  Notes
  
  - Swagger UI is already served at /api/docs in development via swagger-ui-express (no code
  change needed)
  - Spec validated locally with zero errors before commit
  
  Tested
  
  - npx @redocly/cli lint backend/openapi.json → ✅ valid

▸ Closes #330 