### PR TITLE
docs: document all env vars with inline comments grouped by service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,76 +1,174 @@
 # ============================================================
-# StellarKraal Environment Variables
-# Copy this file to .env and fill in values for local dev.
+# StellarKraal — Environment Variables
+# ============================================================
+# Copy this file to .env and fill in values for local dev:
+#   cp .env.example .env
 #
-# Variables marked [GitHub Secret: NAME] must be stored as
-# GitHub Actions repository secrets (Settings → Secrets and
-# variables → Actions) and are injected by CI/CD workflows.
-# Never commit real values to version control.
+# Variables marked [Required] must be set before the service
+# will start. Variables marked [Optional] have safe defaults.
+#
+# Variables marked [GitHub Secret: NAME] must also be stored
+# as GitHub Actions repository secrets (Settings → Secrets
+# and variables → Actions) so CI/CD workflows can inject them.
+# Never commit real secrets to version control.
 # ============================================================
 
-# Stellar network to use (testnet | mainnet)
-# [GitHub Secret: NEXT_PUBLIC_NETWORK]
+
+# ------------------------------------------------------------
+# SHARED — used by both frontend and backend
+# ------------------------------------------------------------
+
+# Stellar network to connect to.
+# Format : "testnet" | "mainnet"
+# Required. [GitHub Secret: NEXT_PUBLIC_NETWORK]
 NEXT_PUBLIC_NETWORK=testnet
 
-# Soroban JSON-RPC endpoint
-# [GitHub Secret: RPC_URL]
+# Soroban JSON-RPC endpoint for the chosen network.
+# Format : HTTPS URL
+# Required. [GitHub Secret: RPC_URL]
 RPC_URL=https://soroban-testnet.stellar.org
 
-# Public RPC URL exposed to the frontend
-# [GitHub Secret: RPC_URL] (same value)
-NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
+# Deployed Soroban contract address (C... or G... format).
+# Obtain this after running `stellar contract deploy`.
+# Format : 56-character Stellar contract/account ID
+# Required. [GitHub Secret: CONTRACT_ID]
+CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
 
-# Deployed Soroban contract ID
-# [GitHub Secret: CONTRACT_ID]
-CONTRACT_ID=your_deployed_contract_id
 
-# Backend service port
-PORT=3001
+# ------------------------------------------------------------
+# FRONTEND — Next.js (NEXT_PUBLIC_* vars are bundled at build)
+# ------------------------------------------------------------
 
-# Frontend API base URL
-# [GitHub Secret: NEXT_PUBLIC_API_URL]
+# Base URL of the backend API, used by the Next.js frontend.
+# Must be reachable from the browser in production.
+# Format : HTTP(S) URL, no trailing slash
+# Required. [GitHub Secret: NEXT_PUBLIC_API_URL]
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
-# Node environment (development | production | test)
+# Public Soroban RPC URL exposed to browser-side SDK calls.
+# Usually the same value as RPC_URL.
+# Format : HTTPS URL
+# Required. [GitHub Secret: NEXT_PUBLIC_RPC_URL]
+NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
+
+
+# ------------------------------------------------------------
+# BACKEND — Node.js / Express API
+# ------------------------------------------------------------
+
+# TCP port the Express server listens on.
+# Format : integer 1–65535
+# Optional. Default: 3001
+PORT=3001
+
+# Node.js runtime environment. Controls logging verbosity,
+# error detail, and certain security defaults.
+# Format : "development" | "production" | "test"
+# Optional. Default: development
 NODE_ENV=development
 
-# Frontend URL for CORS (required in production)
+# Allowed origin for CORS. Set to the frontend URL in
+# production to prevent cross-origin requests from other hosts.
+# Format : HTTP(S) URL, no trailing slash
+# Optional (required in production). [GitHub Secret: FRONTEND_URL]
 FRONTEND_URL=http://localhost:3000
 
-# Rate limiting (requests per minute per IP)
-RATE_LIMIT_GLOBAL=60
-RATE_LIMIT_WRITE=10
-
-# Request timeouts in milliseconds
-TIMEOUT_GLOBAL_MS=30000
-TIMEOUT_WRITE_MS=15000
-
-# Webhook HMAC signing secret — min 32 random bytes
-# [GitHub Secret: WEBHOOK_SECRET]
-# WEBHOOK_SECRET=
-
-# Admin API key for /api/admin/* endpoints
-# [GitHub Secret: ADMIN_API_KEY]
-# ADMIN_API_KEY=
-
-# RPC connection pool size
-POOL_MIN=2
-POOL_MAX=10
-
-# Appraisal cache TTL in milliseconds (default 5 minutes)
-APPRAISAL_CACHE_TTL_MS=300000
-
-# JWT secret for signing access tokens (min 32 chars in production)
-# [GitHub Secret: JWT_SECRET]
+# JWT secret used to sign and verify access tokens.
+# Must be at least 32 characters in production.
+# Generate with: openssl rand -hex 32
+# Format : arbitrary string, min 32 chars recommended
+# Required in production. [GitHub Secret: JWT_SECRET]
 JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars
 
-# Alerting — Slack incoming webhook URL
-# [GitHub Secret: SLACK_WEBHOOK_URL]
+# HMAC secret for verifying incoming webhook payloads.
+# Must be at least 16 random bytes (32+ recommended).
+# Generate with: openssl rand -hex 32
+# Format : hex or arbitrary string, min 16 chars
+# Optional (webhooks disabled if unset). [GitHub Secret: WEBHOOK_SECRET]
+# WEBHOOK_SECRET=
+
+# API key that grants access to /api/admin/* endpoints.
+# Keep this secret; rotate immediately if compromised.
+# Generate with: openssl rand -hex 16
+# Format : arbitrary string, min 8 chars
+# Optional (admin routes disabled if unset). [GitHub Secret: ADMIN_API_KEY]
+# ADMIN_API_KEY=
+
+# --- Rate limiting (requests per minute per IP) ---
+
+# Global rate limit applied to every route.
+# Format : positive integer
+# Optional. Default: 60
+RATE_LIMIT_GLOBAL=60
+
+# Rate limit for authentication routes (/auth/*).
+# Lower than global to slow brute-force attempts.
+# Format : positive integer
+# Optional. Default: 10
+RATE_LIMIT_AUTH=10
+
+# Rate limit for read-only routes (GET requests).
+# Format : positive integer
+# Optional. Default: 100
+RATE_LIMIT_READ=100
+
+# Rate limit for state-changing routes (POST/PUT/DELETE).
+# Format : positive integer
+# Optional. Default: 10
+RATE_LIMIT_WRITE=10
+
+# --- Request timeouts ---
+
+# Maximum time in milliseconds for any request before the
+# server responds with 408 Request Timeout.
+# Format : positive integer (milliseconds)
+# Optional. Default: 30000
+TIMEOUT_GLOBAL_MS=30000
+
+# Maximum time in milliseconds for write operations
+# (loan origination, collateral updates, etc.).
+# Format : positive integer (milliseconds)
+# Optional. Default: 15000
+TIMEOUT_WRITE_MS=15000
+
+# --- RPC connection pool ---
+
+# Minimum number of persistent RPC connections to maintain.
+# Format : positive integer, must be ≤ POOL_MAX
+# Optional. Default: 2
+POOL_MIN=2
+
+# Maximum number of concurrent RPC connections allowed.
+# Format : positive integer, must be ≥ POOL_MIN
+# Optional. Default: 10
+POOL_MAX=10
+
+# --- Caching ---
+
+# Time-to-live for cached collateral appraisal results.
+# Increase to reduce RPC calls; decrease for fresher prices.
+# Format : positive integer (milliseconds)
+# Optional. Default: 300000 (5 minutes)
+APPRAISAL_CACHE_TTL_MS=300000
+
+
+# ------------------------------------------------------------
+# ALERTING — Slack & PagerDuty (backend alert dispatcher)
+# ------------------------------------------------------------
+
+# Slack incoming webhook URL for deployment and alert messages.
+# Create one at https://api.slack.com/messaging/webhooks
+# Format : https://hooks.slack.com/services/T.../B.../...
+# Optional (Slack alerts disabled if unset). [GitHub Secret: SLACK_WEBHOOK_URL]
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
 
-# Alerting — PagerDuty Events API v2 routing key (critical alerts only)
-# [GitHub Secret: PAGERDUTY_ROUTING_KEY]
+# PagerDuty Events API v2 routing key for critical-severity alerts.
+# Find this in PagerDuty under Services → Integrations.
+# Format : 32-character alphanumeric string
+# Optional (PagerDuty alerts disabled if unset). [GitHub Secret: PAGERDUTY_ROUTING_KEY]
 PAGERDUTY_ROUTING_KEY=your-pagerduty-routing-key
 
-# Base URL for runbook links included in alert messages
+# Base URL prepended to runbook paths in alert messages.
+# Format : HTTPS URL, no trailing slash
+# Optional. Default shown below.
 RUNBOOK_BASE_URL=https://github.com/teslims2/StellarKraal-/blob/main/docs/runbooks

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -1,0 +1,265 @@
+# Environment Variables
+
+This guide documents every environment variable used by StellarKraal. Copy `.env.example` to `.env` and fill in the values before starting any service.
+
+```bash
+cp .env.example .env
+```
+
+Variables marked **Required** must be set or the service will refuse to start. Variables marked **Optional** have safe defaults that work for local development.
+
+> **Security note:** Never commit real secrets to version control. Variables marked with a GitHub Secret name must be stored in GitHub Actions (Settings → Secrets and variables → Actions) for CI/CD.
+
+---
+
+## Shared
+
+These variables are consumed by both the frontend build and the backend runtime.
+
+### `NEXT_PUBLIC_NETWORK`
+
+| | |
+|---|---|
+| Required | Yes |
+| Format | `testnet` \| `mainnet` |
+| Default | `testnet` |
+| GitHub Secret | `NEXT_PUBLIC_NETWORK` |
+
+Selects the Stellar network. Use `testnet` for all non-production environments. Changing this to `mainnet` without updating `RPC_URL` and `CONTRACT_ID` to matching production values will cause all contract calls to fail.
+
+### `RPC_URL`
+
+| | |
+|---|---|
+| Required | Yes |
+| Format | HTTPS URL |
+| Example | `https://soroban-testnet.stellar.org` |
+| GitHub Secret | `RPC_URL` |
+
+Soroban JSON-RPC endpoint the backend uses to submit transactions and query contract state. The public testnet endpoint is `https://soroban-testnet.stellar.org`. For mainnet use `https://soroban-mainnet.stellar.org` or a private RPC provider.
+
+### `CONTRACT_ID`
+
+| | |
+|---|---|
+| Required | Yes |
+| Format | 56-character Stellar contract/account ID (`C...`) |
+| GitHub Secret | `CONTRACT_ID` |
+
+The deployed Soroban contract address. Obtain this after running `stellar contract deploy`. A mismatch between this value and the actual on-chain deployment will cause all loan lifecycle operations to fail silently or with cryptic RPC errors.
+
+---
+
+## Frontend
+
+These variables are embedded into the Next.js bundle at build time. Any change requires a rebuild (`npm run build`).
+
+### `NEXT_PUBLIC_API_URL`
+
+| | |
+|---|---|
+| Required | Yes |
+| Format | HTTP(S) URL, no trailing slash |
+| Default (local) | `http://localhost:3001` |
+| GitHub Secret | `NEXT_PUBLIC_API_URL` |
+
+Base URL the browser uses to reach the backend REST API. In production this must be the public HTTPS URL of the backend service. An incorrect value causes all API calls from the frontend to fail with network errors.
+
+### `NEXT_PUBLIC_RPC_URL`
+
+| | |
+|---|---|
+| Required | Yes |
+| Format | HTTPS URL |
+| Default (local) | `https://soroban-testnet.stellar.org` |
+| GitHub Secret | `NEXT_PUBLIC_RPC_URL` |
+
+Soroban RPC URL used by the browser-side Stellar SDK (e.g. Freighter wallet integration). Usually the same value as `RPC_URL`. Exposed to the browser, so do not use a private RPC endpoint that carries credentials in the URL.
+
+---
+
+## Backend
+
+These variables are read at runtime by the Express API server (`backend/src/config.ts`). The server validates all required variables on startup using Zod and exits with a descriptive error if any are missing or malformed.
+
+### `PORT`
+
+| | |
+|---|---|
+| Required | No |
+| Format | Integer 1–65535 |
+| Default | `3001` |
+
+TCP port the Express server listens on. Change this if port 3001 is already in use on your machine. The Docker Compose file maps this port to the host automatically.
+
+### `NODE_ENV`
+
+| | |
+|---|---|
+| Required | No |
+| Format | `development` \| `production` \| `test` |
+| Default | `development` |
+
+Controls logging verbosity, error detail in API responses, and certain security defaults. Always set to `production` in deployed environments — this disables stack traces in error responses and enables stricter security headers.
+
+### `FRONTEND_URL`
+
+| | |
+|---|---|
+| Required | In production |
+| Format | HTTP(S) URL, no trailing slash |
+| Default (local) | `http://localhost:3000` |
+| GitHub Secret | `FRONTEND_URL` |
+
+Allowed CORS origin. The backend rejects cross-origin requests from any other origin. In production set this to the exact URL of the deployed frontend (e.g. `https://app.stellarkraal.example.com`).
+
+### `JWT_SECRET`
+
+| | |
+|---|---|
+| Required | In production |
+| Format | Arbitrary string, minimum 32 characters recommended |
+| GitHub Secret | `JWT_SECRET` |
+
+Secret used to sign and verify JWT access tokens. A weak or default value allows anyone to forge valid tokens. Generate a strong value with:
+
+```bash
+openssl rand -hex 32
+```
+
+Rotate this secret by updating the value and redeploying — all existing tokens will be immediately invalidated.
+
+### `WEBHOOK_SECRET`
+
+| | |
+|---|---|
+| Required | No |
+| Format | Hex or arbitrary string, minimum 16 characters |
+| GitHub Secret | `WEBHOOK_SECRET` |
+
+HMAC-SHA256 secret used to verify the signature on incoming webhook payloads. If unset, webhook signature verification is skipped (not recommended in production). Generate with:
+
+```bash
+openssl rand -hex 32
+```
+
+### `ADMIN_API_KEY`
+
+| | |
+|---|---|
+| Required | No |
+| Format | Arbitrary string, minimum 8 characters |
+| GitHub Secret | `ADMIN_API_KEY` |
+
+Bearer token required to access `/api/admin/*` endpoints. If unset, admin routes return 403. Rotate immediately if compromised. Generate with:
+
+```bash
+openssl rand -hex 16
+```
+
+### Rate Limiting
+
+All rate limits are expressed as **requests per minute per IP address**.
+
+| Variable | Default | Description |
+|---|---|---|
+| `RATE_LIMIT_GLOBAL` | `60` | Applied to every route as a baseline ceiling |
+| `RATE_LIMIT_AUTH` | `10` | Applied to `/auth/*` routes to slow brute-force attempts |
+| `RATE_LIMIT_READ` | `100` | Applied to read-only GET routes |
+| `RATE_LIMIT_WRITE` | `10` | Applied to state-changing POST/PUT/DELETE routes |
+
+Increase these values if legitimate traffic is being throttled. Decrease them for tighter abuse protection in production.
+
+### Request Timeouts
+
+| Variable | Default | Description |
+|---|---|---|
+| `TIMEOUT_GLOBAL_MS` | `30000` | Maximum milliseconds for any request before a 408 is returned |
+| `TIMEOUT_WRITE_MS` | `15000` | Maximum milliseconds for write operations (loan origination, collateral updates) |
+
+Values are in milliseconds. Increase `TIMEOUT_WRITE_MS` if Soroban transaction submission is slow on your network.
+
+### RPC Connection Pool
+
+| Variable | Default | Description |
+|---|---|---|
+| `POOL_MIN` | `2` | Minimum persistent RPC connections to keep open |
+| `POOL_MAX` | `10` | Maximum concurrent RPC connections |
+
+`POOL_MIN` must be ≤ `POOL_MAX`. Increase `POOL_MAX` under high write load; decrease it to reduce resource usage on low-traffic deployments.
+
+### `APPRAISAL_CACHE_TTL_MS`
+
+| | |
+|---|---|
+| Required | No |
+| Format | Positive integer (milliseconds) |
+| Default | `300000` (5 minutes) |
+
+How long collateral appraisal results are cached in memory before a fresh RPC call is made. Increase this to reduce RPC traffic; decrease it if you need near-real-time price accuracy for liquidation decisions.
+
+---
+
+## Alerting
+
+These variables configure the backend alert dispatcher. All are optional — the corresponding alert channel is silently disabled if the variable is unset.
+
+### `SLACK_WEBHOOK_URL`
+
+| | |
+|---|---|
+| Required | No |
+| Format | `https://hooks.slack.com/services/T.../B.../...` |
+| GitHub Secret | `SLACK_WEBHOOK_URL` |
+
+Slack incoming webhook URL for deployment notifications and operational alerts. Create one at <https://api.slack.com/messaging/webhooks>. The same webhook is used by the staging deployment workflow.
+
+### `PAGERDUTY_ROUTING_KEY`
+
+| | |
+|---|---|
+| Required | No |
+| Format | 32-character alphanumeric string |
+| GitHub Secret | `PAGERDUTY_ROUTING_KEY` |
+
+PagerDuty Events API v2 routing (integration) key. Only critical-severity alerts (e.g. liquidation failures, RPC outages) are sent to PagerDuty. Find this key in PagerDuty under Services → Integrations → Events API v2.
+
+### `RUNBOOK_BASE_URL`
+
+| | |
+|---|---|
+| Required | No |
+| Format | HTTPS URL, no trailing slash |
+| Default | `https://github.com/teslims2/StellarKraal-/blob/main/docs/runbooks` |
+
+Base URL prepended to runbook paths in alert messages. Override this if you host runbooks elsewhere (e.g. Confluence, Notion).
+
+---
+
+## Quick-reference table
+
+| Variable | Service | Required | Default |
+|---|---|---|---|
+| `NEXT_PUBLIC_NETWORK` | Shared | Yes | `testnet` |
+| `RPC_URL` | Shared | Yes | — |
+| `CONTRACT_ID` | Shared | Yes | — |
+| `NEXT_PUBLIC_API_URL` | Frontend | Yes | `http://localhost:3001` |
+| `NEXT_PUBLIC_RPC_URL` | Frontend | Yes | `https://soroban-testnet.stellar.org` |
+| `PORT` | Backend | No | `3001` |
+| `NODE_ENV` | Backend | No | `development` |
+| `FRONTEND_URL` | Backend | Prod only | `http://localhost:3000` |
+| `JWT_SECRET` | Backend | Prod only | — |
+| `WEBHOOK_SECRET` | Backend | No | — |
+| `ADMIN_API_KEY` | Backend | No | — |
+| `RATE_LIMIT_GLOBAL` | Backend | No | `60` |
+| `RATE_LIMIT_AUTH` | Backend | No | `10` |
+| `RATE_LIMIT_READ` | Backend | No | `100` |
+| `RATE_LIMIT_WRITE` | Backend | No | `10` |
+| `TIMEOUT_GLOBAL_MS` | Backend | No | `30000` |
+| `TIMEOUT_WRITE_MS` | Backend | No | `15000` |
+| `POOL_MIN` | Backend | No | `2` |
+| `POOL_MAX` | Backend | No | `10` |
+| `APPRAISAL_CACHE_TTL_MS` | Backend | No | `300000` |
+| `SLACK_WEBHOOK_URL` | Alerting | No | — |
+| `PAGERDUTY_ROUTING_KEY` | Alerting | No | — |
+| `RUNBOOK_BASE_URL` | Alerting | No | (GitHub URL) |

--- a/env.example
+++ b/env.example
@@ -1,76 +1,174 @@
 # ============================================================
-# StellarKraal Environment Variables
-# Copy this file to .env and fill in values for local dev.
+# StellarKraal — Environment Variables
+# ============================================================
+# Copy this file to .env and fill in values for local dev:
+#   cp .env.example .env
 #
-# Variables marked [GitHub Secret: NAME] must be stored as
-# GitHub Actions repository secrets (Settings → Secrets and
-# variables → Actions) and are injected by CI/CD workflows.
-# Never commit real values to version control.
+# Variables marked [Required] must be set before the service
+# will start. Variables marked [Optional] have safe defaults.
+#
+# Variables marked [GitHub Secret: NAME] must also be stored
+# as GitHub Actions repository secrets (Settings → Secrets
+# and variables → Actions) so CI/CD workflows can inject them.
+# Never commit real secrets to version control.
 # ============================================================
 
-# Stellar network to use (testnet | mainnet)
-# [GitHub Secret: NEXT_PUBLIC_NETWORK]
+
+# ------------------------------------------------------------
+# SHARED — used by both frontend and backend
+# ------------------------------------------------------------
+
+# Stellar network to connect to.
+# Format : "testnet" | "mainnet"
+# Required. [GitHub Secret: NEXT_PUBLIC_NETWORK]
 NEXT_PUBLIC_NETWORK=testnet
 
-# Soroban JSON-RPC endpoint
-# [GitHub Secret: RPC_URL]
+# Soroban JSON-RPC endpoint for the chosen network.
+# Format : HTTPS URL
+# Required. [GitHub Secret: RPC_URL]
 RPC_URL=https://soroban-testnet.stellar.org
 
-# Public RPC URL exposed to the frontend
-# [GitHub Secret: RPC_URL] (same value)
-NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
+# Deployed Soroban contract address (C... or G... format).
+# Obtain this after running `stellar contract deploy`.
+# Format : 56-character Stellar contract/account ID
+# Required. [GitHub Secret: CONTRACT_ID]
+CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
 
-# Deployed Soroban contract ID
-# [GitHub Secret: CONTRACT_ID]
-CONTRACT_ID=your_deployed_contract_id
 
-# Backend service port
-PORT=3001
+# ------------------------------------------------------------
+# FRONTEND — Next.js (NEXT_PUBLIC_* vars are bundled at build)
+# ------------------------------------------------------------
 
-# Frontend API base URL
-# [GitHub Secret: NEXT_PUBLIC_API_URL]
+# Base URL of the backend API, used by the Next.js frontend.
+# Must be reachable from the browser in production.
+# Format : HTTP(S) URL, no trailing slash
+# Required. [GitHub Secret: NEXT_PUBLIC_API_URL]
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
-# Node environment (development | production | test)
+# Public Soroban RPC URL exposed to browser-side SDK calls.
+# Usually the same value as RPC_URL.
+# Format : HTTPS URL
+# Required. [GitHub Secret: NEXT_PUBLIC_RPC_URL]
+NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
+
+
+# ------------------------------------------------------------
+# BACKEND — Node.js / Express API
+# ------------------------------------------------------------
+
+# TCP port the Express server listens on.
+# Format : integer 1–65535
+# Optional. Default: 3001
+PORT=3001
+
+# Node.js runtime environment. Controls logging verbosity,
+# error detail, and certain security defaults.
+# Format : "development" | "production" | "test"
+# Optional. Default: development
 NODE_ENV=development
 
-# Frontend URL for CORS (required in production)
+# Allowed origin for CORS. Set to the frontend URL in
+# production to prevent cross-origin requests from other hosts.
+# Format : HTTP(S) URL, no trailing slash
+# Optional (required in production). [GitHub Secret: FRONTEND_URL]
 FRONTEND_URL=http://localhost:3000
 
-# Rate limiting (requests per minute per IP)
-RATE_LIMIT_GLOBAL=60
-RATE_LIMIT_WRITE=10
-
-# Request timeouts in milliseconds
-TIMEOUT_GLOBAL_MS=30000
-TIMEOUT_WRITE_MS=15000
-
-# Webhook HMAC signing secret — min 32 random bytes
-# [GitHub Secret: WEBHOOK_SECRET]
-# WEBHOOK_SECRET=
-
-# Admin API key for /api/admin/* endpoints
-# [GitHub Secret: ADMIN_API_KEY]
-# ADMIN_API_KEY=
-
-# RPC connection pool size
-POOL_MIN=2
-POOL_MAX=10
-
-# Appraisal cache TTL in milliseconds (default 5 minutes)
-APPRAISAL_CACHE_TTL_MS=300000
-
-# JWT secret for signing access tokens (min 32 chars in production)
-# [GitHub Secret: JWT_SECRET]
+# JWT secret used to sign and verify access tokens.
+# Must be at least 32 characters in production.
+# Generate with: openssl rand -hex 32
+# Format : arbitrary string, min 32 chars recommended
+# Required in production. [GitHub Secret: JWT_SECRET]
 JWT_SECRET=change-me-to-a-strong-jwt-secret-min-32-chars
 
-# Alerting — Slack incoming webhook URL
-# [GitHub Secret: SLACK_WEBHOOK_URL]
+# HMAC secret for verifying incoming webhook payloads.
+# Must be at least 16 random bytes (32+ recommended).
+# Generate with: openssl rand -hex 32
+# Format : hex or arbitrary string, min 16 chars
+# Optional (webhooks disabled if unset). [GitHub Secret: WEBHOOK_SECRET]
+# WEBHOOK_SECRET=
+
+# API key that grants access to /api/admin/* endpoints.
+# Keep this secret; rotate immediately if compromised.
+# Generate with: openssl rand -hex 16
+# Format : arbitrary string, min 8 chars
+# Optional (admin routes disabled if unset). [GitHub Secret: ADMIN_API_KEY]
+# ADMIN_API_KEY=
+
+# --- Rate limiting (requests per minute per IP) ---
+
+# Global rate limit applied to every route.
+# Format : positive integer
+# Optional. Default: 60
+RATE_LIMIT_GLOBAL=60
+
+# Rate limit for authentication routes (/auth/*).
+# Lower than global to slow brute-force attempts.
+# Format : positive integer
+# Optional. Default: 10
+RATE_LIMIT_AUTH=10
+
+# Rate limit for read-only routes (GET requests).
+# Format : positive integer
+# Optional. Default: 100
+RATE_LIMIT_READ=100
+
+# Rate limit for state-changing routes (POST/PUT/DELETE).
+# Format : positive integer
+# Optional. Default: 10
+RATE_LIMIT_WRITE=10
+
+# --- Request timeouts ---
+
+# Maximum time in milliseconds for any request before the
+# server responds with 408 Request Timeout.
+# Format : positive integer (milliseconds)
+# Optional. Default: 30000
+TIMEOUT_GLOBAL_MS=30000
+
+# Maximum time in milliseconds for write operations
+# (loan origination, collateral updates, etc.).
+# Format : positive integer (milliseconds)
+# Optional. Default: 15000
+TIMEOUT_WRITE_MS=15000
+
+# --- RPC connection pool ---
+
+# Minimum number of persistent RPC connections to maintain.
+# Format : positive integer, must be ≤ POOL_MAX
+# Optional. Default: 2
+POOL_MIN=2
+
+# Maximum number of concurrent RPC connections allowed.
+# Format : positive integer, must be ≥ POOL_MIN
+# Optional. Default: 10
+POOL_MAX=10
+
+# --- Caching ---
+
+# Time-to-live for cached collateral appraisal results.
+# Increase to reduce RPC calls; decrease for fresher prices.
+# Format : positive integer (milliseconds)
+# Optional. Default: 300000 (5 minutes)
+APPRAISAL_CACHE_TTL_MS=300000
+
+
+# ------------------------------------------------------------
+# ALERTING — Slack & PagerDuty (backend alert dispatcher)
+# ------------------------------------------------------------
+
+# Slack incoming webhook URL for deployment and alert messages.
+# Create one at https://api.slack.com/messaging/webhooks
+# Format : https://hooks.slack.com/services/T.../B.../...
+# Optional (Slack alerts disabled if unset). [GitHub Secret: SLACK_WEBHOOK_URL]
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
 
-# Alerting — PagerDuty Events API v2 routing key (critical alerts only)
-# [GitHub Secret: PAGERDUTY_ROUTING_KEY]
+# PagerDuty Events API v2 routing key for critical-severity alerts.
+# Find this in PagerDuty under Services → Integrations.
+# Format : 32-character alphanumeric string
+# Optional (PagerDuty alerts disabled if unset). [GitHub Secret: PAGERDUTY_ROUTING_KEY]
 PAGERDUTY_ROUTING_KEY=your-pagerduty-routing-key
 
-# Base URL for runbook links included in alert messages
+# Base URL prepended to runbook paths in alert messages.
+# Format : HTTPS URL, no trailing slash
+# Optional. Default shown below.
 RUNBOOK_BASE_URL=https://github.com/teslims2/StellarKraal-/blob/main/docs/runbooks


### PR DESCRIPTION
- Rewrote .env.example with inline comments for every variable
- Each comment describes purpose, format, required/optional status, and safe example value
- Variables grouped into sections: Shared, Frontend, Backend, Alerting
- Added previously undocumented RATE_LIMIT_AUTH and RATE_LIMIT_READ
- Synced env.example (root duplicate) to match .env.example
- Created docs/guides/environment-variables.md with detailed per-variable reference and a quick-reference table covering all 23 variables

Closes #320
Closes #319
Closes #318 
Closes #304 

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
