### PR TITLE
feat: color system, typography scale, auth login, and response caching

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -48,6 +48,7 @@ import {
   invalidateAll,
   configureCacheTTL,
 } from "./utils/appraisalCache";
+import { responseCacheMiddleware, invalidateCache } from "./utils/responseCache";
 import { randomUUID } from "crypto";
 import path from "path";
 import { mkdirSync } from "fs";
@@ -439,6 +440,7 @@ app.post(
       nativeToScVal(BigInt(amount), { type: "i128" }),
     ]);
     fireWebhooks("loan.approved", { borrower, collateral_id, amount });
+    invalidateCache("/api/loans");
     res.json({ xdr: xdrTx, ...(cached?.stale ? { stale: true } : {}) });
   }),
 );
@@ -483,11 +485,12 @@ app.post(
   }),
 );
 
-// GET /api/loans — paginated loan listing
+// GET /api/loans — paginated loan listing (cached 30 s)
 // Deprecated: unpaginated usage will be removed in a future version.
 app.get(
   "/api/loans",
   readLimiter,
+  responseCacheMiddleware,
   asyncHandler(async (req: Request, res: Response) => {
     const pageRaw = req.query.page !== undefined ? Number(req.query.page) : 1;
     const pageSizeVal = req.query.pageSize !== undefined ? req.query.pageSize : req.query.limit;
@@ -529,6 +532,7 @@ const collateralQuerySchema = z.object({
 
 app.get(
   "/api/collateral",
+  responseCacheMiddleware,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = collateralQuerySchema.safeParse(req.query);
     if (!validation.success) {
@@ -919,6 +923,7 @@ app.post(
       image_url: imageUrl,
     });
 
+    invalidateCache("/api/collateral");
     res.status(201).json(record);
   }),
 );
@@ -940,6 +945,7 @@ app.post("/api/v1/collateral", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_M
   }
   const { owner, animal_type, count, appraised_value } = validation.data;
   const record = insertCollateral({ id: randomUUID(), owner, animal_type, count, appraised_value });
+  invalidateCache("/api/collateral");
   res.status(201).json(record);
 }));
 
@@ -1075,6 +1081,7 @@ app.put(
 
     const newBalance = loan.outstanding_balance - amount;
     const updated = updateLoan(req.params.id, { outstanding_balance: newBalance });
+    invalidateCache("/api/loans");
 
     insertTransaction({
       borrower: loan.borrower,

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,12 +2,12 @@
  * JWT authentication middleware and auth routes.
  *
  * Flow:
- *   1. GET  /api/auth/challenge  — returns a one-time challenge string
- *   2. POST /api/auth/login      — client submits { publicKey, signature, challenge }
- *                                  backend verifies Stellar signature, issues JWT + refresh token
+ *   1. GET  /api/auth/challenge  — returns a one-time challenge nonce
+ *   2. POST /api/auth/login      — client submits { walletAddress, signedChallenge: { nonce, signature } }
+ *                                  backend verifies Stellar ed25519 signature, issues JWT + refresh token
  *   3. POST /api/auth/refresh    — exchanges a valid refresh token for a new JWT
  *
- * JWT expires in 15 minutes; refresh tokens expire in 7 days.
+ * JWT expires in 24 hours by default; refresh tokens expire in 7 days.
  * All POST/PUT/DELETE routes (except auth endpoints) require a valid JWT.
  */
 import { Request, Response, NextFunction, Router } from 'express';
@@ -19,7 +19,7 @@ import { Keypair } from '@stellar/stellar-sdk';
 const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production-min-32-chars!!';
 const ACCESS_TTL_MS = process.env.JWT_EXPIRES_IN_MS
   ? parseInt(process.env.JWT_EXPIRES_IN_MS, 10)
-  : 15 * 60 * 1000; // default 15 minutes
+  : 24 * 60 * 60 * 1000; // default 24 hours
 const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -76,35 +76,44 @@ authRouter.get('/challenge', (_req: Request, res: Response) => {
   res.json({ challenge });
 });
 
-// POST /api/auth/login — verify Stellar signature, issue JWT
+// POST /api/auth/login — verify Stellar wallet signature, issue JWT
+// Accepts { walletAddress, signedChallenge: { nonce, signature } }
 authRouter.post('/login', (req: Request, res: Response) => {
-  const { publicKey, signature, challenge } = req.body as {
-    publicKey?: string;
-    signature?: string;
-    challenge?: string;
+  const { walletAddress, signedChallenge } = req.body as {
+    walletAddress?: string;
+    signedChallenge?: { nonce?: string; signature?: string };
   };
 
-  if (!publicKey || !signature || !challenge) {
-    return res.status(400).json({ error: 'publicKey, signature, and challenge are required' });
+  if (!walletAddress || !signedChallenge?.nonce || !signedChallenge?.signature) {
+    return res.status(400).json({
+      error: 'walletAddress and signedChallenge (with nonce and signature) are required',
+    });
   }
 
-  // Validate challenge exists and hasn't expired
-  const expiry = challenges.get(challenge);
+  const { nonce, signature } = signedChallenge;
+
+  // Validate nonce was issued by this server and hasn't expired
+  const expiry = challenges.get(nonce);
   if (!expiry || Date.now() > expiry) {
     return res.status(401).json({ error: 'Invalid or expired challenge' });
   }
-  challenges.delete(challenge); // one-time use
+  challenges.delete(nonce); // one-time use
 
   // Verify Stellar ed25519 signature
   try {
-    const kp = Keypair.fromPublicKey(publicKey);
-    const valid = kp.verify(Buffer.from(challenge, 'hex'), Buffer.from(signature, 'hex'));
+    const kp = Keypair.fromPublicKey(walletAddress);
+    const valid = kp.verify(Buffer.from(nonce, 'hex'), Buffer.from(signature, 'hex'));
     if (!valid) return res.status(401).json({ error: 'Signature verification failed' });
   } catch {
-    return res.status(401).json({ error: 'Invalid public key or signature' });
+    return res.status(401).json({ error: 'Invalid wallet address or signature' });
   }
 
-  res.json(issueTokens(publicKey));
+  const now = Date.now();
+  const exp = now + ACCESS_TTL_MS;
+  const accessToken = signJwt({ sub: walletAddress, iat: Math.floor(now / 1000), exp: Math.floor(exp / 1000) });
+  const refreshToken = randomBytes(32).toString('hex');
+  refreshTokens.set(refreshToken, { publicKey: walletAddress, exp: now + REFRESH_TTL_MS });
+  res.json({ accessToken, refreshToken, expiresIn: ACCESS_TTL_MS / 1000 });
 });
 
 // POST /api/auth/refresh — rotate refresh token

--- a/backend/src/utils/responseCache.ts
+++ b/backend/src/utils/responseCache.ts
@@ -1,0 +1,65 @@
+import { Request, Response, NextFunction } from "express";
+import logger from "./logger";
+
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+interface CacheEntry {
+  body: unknown;
+  cachedAt: number;
+}
+
+const store = new Map<string, CacheEntry>();
+
+function cacheKey(req: Request): string {
+  return `${req.path}?${new URLSearchParams(req.query as Record<string, string>).toString()}`;
+}
+
+function isExpired(entry: CacheEntry): boolean {
+  return Date.now() - entry.cachedAt > CACHE_TTL_MS;
+}
+
+/** Middleware that caches GET responses for 30 s and respects Cache-Control: no-cache. */
+export function responseCacheMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const noCache =
+    req.headers["cache-control"] === "no-cache" ||
+    req.headers["pragma"] === "no-cache";
+
+  const key = cacheKey(req);
+
+  if (!noCache) {
+    const entry = store.get(key);
+    if (entry && !isExpired(entry)) {
+      logger.debug("response_cache_hit", { path: req.path, key });
+      res.setHeader("X-Cache", "HIT");
+      res.json(entry.body);
+      return;
+    }
+    logger.debug("response_cache_miss", { path: req.path, key });
+  }
+
+  // Intercept res.json to capture the response body for caching
+  const originalJson = res.json.bind(res);
+  res.json = (body: unknown) => {
+    if (res.statusCode === 200 && !noCache) {
+      store.set(key, { body, cachedAt: Date.now() });
+    }
+    res.setHeader("X-Cache", "MISS");
+    return originalJson(body);
+  };
+
+  next();
+}
+
+/** Invalidate all cache entries whose path matches the given prefix. */
+export function invalidateCache(pathPrefix: string): void {
+  let count = 0;
+  for (const key of store.keys()) {
+    if (key.startsWith(pathPrefix)) {
+      store.delete(key);
+      count++;
+    }
+  }
+  if (count > 0) {
+    logger.debug("response_cache_invalidated", { pathPrefix, count });
+  }
+}

--- a/frontend/src/app/docs/colors/page.tsx
+++ b/frontend/src/app/docs/colors/page.tsx
@@ -1,0 +1,124 @@
+export const metadata = { title: "Color Palette — StellarKraal Design Tokens" };
+
+const semanticTokens = [
+  {
+    group: "Primary",
+    tokens: [
+      { name: "color-primary",       cssVar: "--token-primary",       description: "Main brand / interactive" },
+      { name: "color-primary-hover", cssVar: "--token-primary-hover", description: "Primary hover state" },
+      { name: "color-on-primary",    cssVar: "--token-on-primary",    description: "Text on primary surface" },
+    ],
+  },
+  {
+    group: "Secondary",
+    tokens: [
+      { name: "color-secondary",       cssVar: "--token-secondary",       description: "Secondary brand / CTA" },
+      { name: "color-secondary-hover", cssVar: "--token-secondary-hover", description: "Secondary hover state" },
+      { name: "color-on-secondary",    cssVar: "--token-on-secondary",    description: "Text on secondary surface" },
+    ],
+  },
+  {
+    group: "Accent",
+    tokens: [
+      { name: "color-accent", cssVar: "--token-accent", description: "Highlight / focus ring" },
+    ],
+  },
+  {
+    group: "Danger",
+    tokens: [
+      { name: "color-danger",        cssVar: "--token-danger",        description: "Error / destructive action" },
+      { name: "color-danger-subtle", cssVar: "--token-danger-subtle", description: "Error background / badge" },
+      { name: "color-on-danger",     cssVar: "--token-on-danger",     description: "Text on danger surface" },
+    ],
+  },
+  {
+    group: "Success",
+    tokens: [
+      { name: "color-success",        cssVar: "--token-success",        description: "Positive outcome" },
+      { name: "color-success-subtle", cssVar: "--token-success-subtle", description: "Success background / badge" },
+      { name: "color-on-success",     cssVar: "--token-on-success",     description: "Text on success surface" },
+    ],
+  },
+  {
+    group: "Warning",
+    tokens: [
+      { name: "color-warning",        cssVar: "--token-warning",        description: "Caution / degraded state" },
+      { name: "color-warning-subtle", cssVar: "--token-warning-subtle", description: "Warning background / badge" },
+      { name: "color-on-warning",     cssVar: "--token-on-warning",     description: "Text on warning surface" },
+    ],
+  },
+  {
+    group: "Surface",
+    tokens: [
+      { name: "color-surface",       cssVar: "--token-surface",       description: "Page background" },
+      { name: "color-surface-raised", cssVar: "--token-surface-raised", description: "Card / panel background" },
+    ],
+  },
+  {
+    group: "Text",
+    tokens: [
+      { name: "color-text",         cssVar: "--token-text",         description: "Primary text" },
+      { name: "color-text-subtle",  cssVar: "--token-text-subtle",  description: "Secondary text" },
+      { name: "color-text-muted",   cssVar: "--token-text-muted",   description: "Placeholder / disabled text" },
+      { name: "color-text-inverse", cssVar: "--token-text-inverse", description: "Text on dark surfaces" },
+    ],
+  },
+  {
+    group: "Border",
+    tokens: [
+      { name: "color-border",       cssVar: "--token-border",       description: "Default divider / outline" },
+      { name: "color-border-strong", cssVar: "--token-border-strong", description: "Emphasis border" },
+    ],
+  },
+];
+
+function Swatch({ cssVar }: { cssVar: string }) {
+  return (
+    <span
+      className="inline-block w-8 h-8 rounded border border-black/10 shrink-0"
+      style={{ backgroundColor: `var(${cssVar})` }}
+      aria-hidden
+    />
+  );
+}
+
+export default function ColorPalettePage() {
+  return (
+    <main className="max-w-4xl mx-auto px-6 py-12 space-y-12">
+      <div>
+        <h1 className="text-h1 mb-2">Color Palette</h1>
+        <p className="text-body" style={{ color: "var(--token-text-subtle)" }}>
+          Semantic design tokens defined in{" "}
+          <code className="font-mono text-sm bg-black/5 px-1 rounded">tailwind.config.js</code>.
+          Use token names (e.g. <code className="font-mono text-sm bg-black/5 px-1 rounded">bg-color-primary</code>)
+          instead of raw Tailwind color classes. Dark mode variants are applied automatically via CSS custom properties.
+        </p>
+      </div>
+
+      {semanticTokens.map(({ group, tokens }) => (
+        <section key={group}>
+          <h2 className="text-h3 mb-4 border-b pb-2" style={{ borderColor: "var(--token-border)" }}>
+            {group}
+          </h2>
+          <div className="space-y-3">
+            {tokens.map(({ name, cssVar, description }) => (
+              <div key={name} className="flex items-center gap-4">
+                <Swatch cssVar={cssVar} />
+                <div className="flex-1 min-w-0">
+                  <p className="text-label font-mono">{name}</p>
+                  <p className="text-caption">{description}</p>
+                </div>
+                <code
+                  className="text-caption font-mono shrink-0"
+                  style={{ color: "var(--token-text-muted)" }}
+                >
+                  {cssVar}
+                </code>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -18,6 +18,32 @@
   --color-nav-border: rgba(61, 40, 16, 0.1);
   --color-skeleton-base: #e8ddd0;
   --color-skeleton-shine: #f5ede0;
+
+  /* ── Semantic design tokens — light (#297) ── */
+  --token-primary:          #5D3C15;
+  --token-primary-hover:    #3D2810;
+  --token-on-primary:       #FFFFFF;
+  --token-secondary:        #B45309;
+  --token-secondary-hover:  #92400E;
+  --token-on-secondary:     #FFFFFF;
+  --token-accent:           #D97706;
+  --token-danger:           #DC2626;
+  --token-danger-subtle:    #FEE2E2;
+  --token-on-danger:        #FFFFFF;
+  --token-success:          #16A34A;
+  --token-success-subtle:   #D4F4DD;
+  --token-on-success:       #FFFFFF;
+  --token-warning:          #D97706;
+  --token-warning-subtle:   #FEF3C7;
+  --token-on-warning:       #FFFFFF;
+  --token-surface:          #FDF6EC;
+  --token-surface-raised:   #FFFFFF;
+  --token-text:             #3D2810;
+  --token-text-subtle:      #5D3C15;
+  --token-text-muted:       #8B5A1F;
+  --token-text-inverse:     #FFFFFF;
+  --token-border:           #F0D9B8;
+  --token-border-strong:    #D4A05A;
 }
 
 /* ── Dark mode CSS variables ── */
@@ -36,6 +62,32 @@
   --color-nav-border: rgba(240, 217, 184, 0.1);
   --color-skeleton-base: #3D2810;
   --color-skeleton-shine: #5D3C15;
+
+  /* ── Semantic design tokens — dark (#297) ── */
+  --token-primary:          #F0D9B8;
+  --token-primary-hover:    #FDF6EC;
+  --token-on-primary:       #1A1007;
+  --token-secondary:        #FBDC7D;
+  --token-secondary-hover:  #FDEAB3;
+  --token-on-secondary:     #1A1007;
+  --token-accent:           #F8CA47;
+  --token-danger:           #F87171;
+  --token-danger-subtle:    #450A0A;
+  --token-on-danger:        #FFFFFF;
+  --token-success:          #4ADE80;
+  --token-success-subtle:   #052E16;
+  --token-on-success:       #FFFFFF;
+  --token-warning:          #FBD049;
+  --token-warning-subtle:   #451A03;
+  --token-on-warning:       #1A1007;
+  --token-surface:          #2A1B0B;
+  --token-surface-raised:   #2A1B0B;
+  --token-text:             #FDF6EC;
+  --token-text-subtle:      #F0D9B8;
+  --token-text-muted:       #D4A05A;
+  --token-text-inverse:     #1A1007;
+  --token-border:           #3D2810;
+  --token-border-strong:    #5D3C15;
 }
 
 /* ── Base styles using variables ── */
@@ -107,6 +159,58 @@ body {
   );
   background-size: 200% 100%;
   animation: shimmer 1.4s ease-in-out infinite;
+}
+
+/* ── Typography component classes (#298) ── */
+@layer components {
+  .text-h1 {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+    font-weight: 700;
+    color: var(--token-text);
+  }
+  .text-h2 {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+    font-weight: 700;
+    color: var(--token-text);
+  }
+  .text-h3 {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    font-weight: 600;
+    color: var(--token-text);
+  }
+  .text-h4 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    font-weight: 600;
+    color: var(--token-text);
+  }
+  .text-body {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    font-weight: 400;
+    color: var(--token-text);
+  }
+  .text-body-sm {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-weight: 400;
+    color: var(--token-text-subtle);
+  }
+  .text-caption {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 400;
+    color: var(--token-text-muted);
+  }
+  .text-label {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-weight: 500;
+    color: var(--token-text-subtle);
+  }
 }
 
 /* ── Toast animations ── */

--- a/frontend/src/components/Heading.tsx
+++ b/frontend/src/components/Heading.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface HeadingProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function H1({ children, className = "" }: HeadingProps) {
+  return <h1 className={`text-h1 ${className}`}>{children}</h1>;
+}
+
+export function H2({ children, className = "" }: HeadingProps) {
+  return <h2 className={`text-h2 ${className}`}>{children}</h2>;
+}
+
+export function H3({ children, className = "" }: HeadingProps) {
+  return <h3 className={`text-h3 ${className}`}>{children}</h3>;
+}
+
+export function H4({ children, className = "" }: HeadingProps) {
+  return <h4 className={`text-h4 ${className}`}>{children}</h4>;
+}

--- a/frontend/src/lib/design-tokens.ts
+++ b/frontend/src/lib/design-tokens.ts
@@ -72,6 +72,23 @@ export const colors = {
   }
 } as const;
 
+// ── Typography tokens (#298) ─────────────────────────────────────────────────
+
+export const typography = {
+  heading: {
+    h1: "text-h1",
+    h2: "text-h2",
+    h3: "text-h3",
+    h4: "text-h4",
+  },
+  body: {
+    default: "text-body",
+    sm: "text-body-sm",
+  },
+  caption: "text-caption",
+  label: "text-label",
+} as const;
+
 // Utility function to get contrast-compliant color combinations
 export function getContrastPair(background: 'light' | 'dark' = 'light') {
   return background === 'light' 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,8 +4,47 @@ module.exports = {
   darkMode: "class",
   theme: {
     extend: {
+      // ── Typography scale (#298) ──────────────────────────────────────────────
+      fontSize: {
+        "heading-1": ["2.25rem", { lineHeight: "2.5rem", fontWeight: "700" }],
+        "heading-2": ["1.875rem", { lineHeight: "2.25rem", fontWeight: "700" }],
+        "heading-3": ["1.5rem", { lineHeight: "2rem", fontWeight: "600" }],
+        "heading-4": ["1.25rem", { lineHeight: "1.75rem", fontWeight: "600" }],
+        "body-lg": ["1.125rem", { lineHeight: "1.75rem", fontWeight: "400" }],
+        body: ["1rem", { lineHeight: "1.5rem", fontWeight: "400" }],
+        "body-sm": ["0.875rem", { lineHeight: "1.25rem", fontWeight: "400" }],
+        caption: ["0.75rem", { lineHeight: "1rem", fontWeight: "400" }],
+        label: ["0.875rem", { lineHeight: "1.25rem", fontWeight: "500" }],
+      },
       colors: {
-        // WCAG AA compliant color palette
+        // ── Semantic design tokens (#297) ────────────────────────────────────
+        // Referenced via CSS custom properties so dark mode flips automatically.
+        "color-primary":          "var(--token-primary)",
+        "color-primary-hover":    "var(--token-primary-hover)",
+        "color-on-primary":       "var(--token-on-primary)",
+        "color-secondary":        "var(--token-secondary)",
+        "color-secondary-hover":  "var(--token-secondary-hover)",
+        "color-on-secondary":     "var(--token-on-secondary)",
+        "color-accent":           "var(--token-accent)",
+        "color-danger":           "var(--token-danger)",
+        "color-danger-subtle":    "var(--token-danger-subtle)",
+        "color-on-danger":        "var(--token-on-danger)",
+        "color-success":          "var(--token-success)",
+        "color-success-subtle":   "var(--token-success-subtle)",
+        "color-on-success":       "var(--token-on-success)",
+        "color-warning":          "var(--token-warning)",
+        "color-warning-subtle":   "var(--token-warning-subtle)",
+        "color-on-warning":       "var(--token-on-warning)",
+        "color-surface":          "var(--token-surface)",
+        "color-surface-raised":   "var(--token-surface-raised)",
+        "color-text":             "var(--token-text)",
+        "color-text-subtle":      "var(--token-text-subtle)",
+        "color-text-muted":       "var(--token-text-muted)",
+        "color-text-inverse":     "var(--token-text-inverse)",
+        "color-border":           "var(--token-border)",
+        "color-border-strong":    "var(--token-border-strong)",
+
+        // WCAG AA compliant descriptive palette (kept for backward compat)
         brown: {
           50: "#FDF8F3",
           100: "#F9EFE1", 


### PR DESCRIPTION
## Summary

- **#297** — Semantic color design tokens (`color-primary`, `color-secondary`, `color-accent`, `color-danger`, `color-success`, `color-warning`, surface/text/border tokens) added to `tailwind.config.js` as CSS custom properties. Full light + dark mode variants in `globals.css`. Color palette reference page at `/docs/colors`.
- **#298** — Typography scale (`heading-1` through `heading-4`, `body`, `body-sm`, `caption`, `label`) added to `tailwind.config.js`. `@layer components` classes (`text-h1`–`text-h4`, `text-body`, `text-caption`, `text-label`) in `globals.css`. `H1`–`H4` React heading components. Typography tokens exported from `design-tokens.ts`.
- **#277** — `POST /api/auth/login` updated to accept `{ walletAddress, signedChallenge: { nonce, signature } }`. Verifies Stellar ed25519 signature, returns JWT with `sub`, `iat`, `exp` claims. Default JWT expiry changed from 15 min → **24 hours**.
- **#278** — 30-second in-memory response cache for `GET /api/collateral` and `GET /api/loans`. Invalidated on collateral/loan create and loan update. `response_cache_hit/miss/invalidated` logged at debug level. `Cache-Control: no-cache` bypasses cache. `X-Cache` header on all responses.

## Test plan

- [ ] Visit `/docs/colors` — all semantic token swatches render correctly in light and dark mode
- [ ] Toggle dark mode — `color-danger`, `color-success`, etc. flip to dark variants automatically
- [ ] Use `H1`–`H4` components and `.text-h1`/`.text-body` utility classes — size and weight enforced
- [ ] `GET /api/auth/challenge` → `POST /api/auth/login` with a valid Stellar keypair — expect JWT with 24 h expiry and `sub`/`iat`/`exp` claims
- [ ] `POST /api/auth/login` with invalid signature → expect `401`
- [ ] `GET /api/collateral` twice — second response returns `X-Cache: HIT`
- [ ] `POST /api/collateral` (new record) → `GET /api/collateral` — expect `X-Cache: MISS` (cache invalidated)
- [ ] `GET /api/loans` with `Cache-Control: no-cache` → expect `X-Cache: MISS`

closes #297
closes #298
closes #277
closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)