### PR TITLE
feat: add error states with retry to all data-fetching components

### DIFF
--- a/frontend/src/app/collateral/page.tsx
+++ b/frontend/src/app/collateral/page.tsx
@@ -1,13 +1,13 @@
 'use client';
-import { Suspense, useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useState, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import SearchFilterBar from '@/components/SearchFilterBar';
 import PageTransition from '@/components/PageTransition';
 import Card from '@/components/Card';
 import SkeletonCollateralCard from '@/components/SkeletonCollateralCard';
 import EmptyState from '@/components/EmptyState';
+import ErrorState from '@/components/ErrorState';
 import Pagination from '@/components/Pagination';
-import { usePagination } from '@/hooks/usePagination';
 
 interface Collateral {
   id: string;
@@ -34,12 +34,7 @@ function CollateralListContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [items, setItems] = useState<Collateral[]>([]);
-  const [meta, setMeta] = useState<PaginationMeta>({
-    total: 0,
-    page: 1,
-    limit: 10,
-    pages: 1,
-  });
+  const [meta, setMeta] = useState<PaginationMeta>({ total: 0, page: 1, limit: 10, pages: 1 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -61,13 +56,13 @@ function CollateralListContent() {
       types.forEach((t) => params.append('type', t));
 
       const res = await fetch(`${API}/api/collateral?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch collateral');
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
 
       const data = await res.json();
       setItems(Array.isArray(data.data) ? data.data : []);
       if (data.meta) setMeta(data.meta);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : 'Failed to load collateral');
       setItems([]);
     } finally {
       setLoading(false);
@@ -84,9 +79,6 @@ function CollateralListContent() {
     router.push(`?${params.toString()}`);
   };
 
-  const { page, limit, totalPages, setPage, setLimit, slice } = usePagination(filtered.length);
-  const paginated = slice(filtered);
-
   return (
     <div className="space-y-4">
       <SearchFilterBar
@@ -94,12 +86,6 @@ function CollateralListContent() {
         typeOptions={TYPE_OPTIONS}
         searchPlaceholder="Search by ID, owner, or animal type…"
       />
-
-      {error && (
-        <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700">
-          {error}
-        </div>
-      )}
 
       {loading ? (
         <ul className="space-y-2">
@@ -109,7 +95,9 @@ function CollateralListContent() {
             </li>
           ))}
         </ul>
-      ) : filtered.length === 0 ? (
+      ) : error ? (
+        <ErrorState message={error} onRetry={fetchCollateral} />
+      ) : items.length === 0 ? (
         <EmptyState
           icon="🐄"
           heading={q || types.length > 0 ? 'No Collateral Found' : 'No Collateral Registered'}
@@ -122,7 +110,7 @@ function CollateralListContent() {
       ) : (
         <>
           <ul className="space-y-2">
-            {paginated.map((col) => (
+            {items.map((col) => (
               <li key={col.id}>
                 <Card>
                   <div className="flex justify-between items-center">
@@ -145,10 +133,15 @@ function CollateralListContent() {
           </ul>
           <Pagination
             page={page}
-            totalPages={totalPages}
+            totalPages={meta.pages}
             limit={limit}
-            onPageChange={setPage}
-            onLimitChange={setLimit}
+            onPageChange={handlePageChange}
+            onLimitChange={(newLimit) => {
+              const params = new URLSearchParams(searchParams);
+              params.set('limit', newLimit.toString());
+              params.set('page', '1');
+              router.push(`?${params.toString()}`);
+            }}
           />
         </>
       )}

--- a/frontend/src/app/dashboard/collateral/[id]/page.tsx
+++ b/frontend/src/app/dashboard/collateral/[id]/page.tsx
@@ -1,11 +1,12 @@
-"use client";
-import { useState, useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
-import WalletConnect from "@/components/WalletConnect";
-import Card from "@/components/Card";
-import Skeleton from "@/components/Skeleton";
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import WalletConnect from '@/components/WalletConnect';
+import Card from '@/components/Card';
+import Skeleton from '@/components/Skeleton';
+import ErrorState from '@/components/ErrorState';
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 interface Collateral {
   id: string;
@@ -25,9 +26,9 @@ interface Loan {
 }
 
 const ANIMAL_ICONS: Record<string, string> = {
-  cattle: "🐄",
-  goat: "🐐",
-  sheep: "🐑",
+  cattle: '🐄',
+  goat: '🐐',
+  sheep: '🐑',
 };
 
 function DetailSkeleton() {
@@ -62,27 +63,26 @@ export default function CollateralDetailPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (wallet && collateralId) {
-      fetchDetails();
-    }
-  }, [wallet, collateralId]);
-
-  async function fetchDetails() {
+  const fetchDetails = useCallback(async () => {
+    if (!wallet || !collateralId) return;
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`${API}/api/collateral/${collateralId}?owner=${wallet}`);
-      if (!res.ok) throw new Error("Failed to fetch collateral details");
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       const data = await res.json();
       setCollateral(data.collateral);
       setLoans(data.loans || []);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load collateral details');
     } finally {
       setLoading(false);
     }
-  }
+  }, [wallet, collateralId]);
+
+  useEffect(() => {
+    fetchDetails();
+  }, [fetchDetails]);
 
   if (!wallet) {
     return (
@@ -104,19 +104,20 @@ export default function CollateralDetailPage() {
   if (error || !collateral) {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
-        <button onClick={() => router.back()} className="text-brown-600 hover:text-brown-700 mb-6 font-semibold">
+        <button
+          onClick={() => router.back()}
+          className="text-brown-600 hover:text-brown-700 mb-6 font-semibold"
+        >
           ← Back
         </button>
-        <Card variant="warning">
-          <p className="text-error-dark">{error || "Collateral not found"}</p>
-        </Card>
+        <ErrorState message={error || 'Collateral not found'} onRetry={fetchDetails} />
       </main>
     );
   }
 
   const xlmValue = (collateral.appraised_value / 1e7).toFixed(2);
   const usdValue = (parseFloat(xlmValue) * 0.12).toFixed(2);
-  const icon = ANIMAL_ICONS[collateral.animal_type] || "🐾";
+  const icon = ANIMAL_ICONS[collateral.animal_type] || '🐾';
 
   // Derive outstanding balance and a simple health factor from loans
   const totalOutstanding = loans.reduce((sum, l) => sum + l.amount, 0);
@@ -130,7 +131,10 @@ export default function CollateralDetailPage() {
 
   return (
     <main className="max-w-2xl mx-auto px-4 py-10">
-      <button onClick={() => router.back()} className="text-brown-600 hover:text-brown-700 mb-6 font-semibold">
+      <button
+        onClick={() => router.back()}
+        className="text-brown-600 hover:text-brown-700 mb-6 font-semibold"
+      >
         ← Back to Collateral
       </button>
 
@@ -138,7 +142,9 @@ export default function CollateralDetailPage() {
       {isAtRisk && (
         <Card variant="warning" className="mb-4">
           <div className="flex items-center gap-3">
-            <span className="text-2xl" aria-hidden="true">⚠️</span>
+            <span className="text-2xl" aria-hidden="true">
+              ⚠️
+            </span>
             <div>
               <p className="font-bold text-warning-dark">Liquidation Risk</p>
               <p className="text-sm text-warning-dark/80">
@@ -151,7 +157,7 @@ export default function CollateralDetailPage() {
 
       {/* Primary metrics — large, prominent */}
       <div className="grid grid-cols-2 gap-4 mb-4">
-        <Card variant={isAtRisk ? "warning" : "highlighted"}>
+        <Card variant={isAtRisk ? 'warning' : 'highlighted'}>
           <p className="text-xs font-medium text-brown-500 uppercase tracking-wide mb-1">
             Health Factor
           </p>
@@ -161,7 +167,11 @@ export default function CollateralDetailPage() {
                 {(healthFactorBps / 10000).toFixed(2)}
               </p>
               <p className="text-xs text-brown-500 mt-1">
-                {healthFactorBps >= 15000 ? "Healthy" : healthFactorBps >= 12000 ? "Moderate" : "At Risk"}
+                {healthFactorBps >= 15000
+                  ? 'Healthy'
+                  : healthFactorBps >= 12000
+                    ? 'Moderate'
+                    : 'At Risk'}
               </p>
             </>
           ) : (
@@ -173,9 +183,7 @@ export default function CollateralDetailPage() {
           <p className="text-xs font-medium text-brown-500 uppercase tracking-wide mb-1">
             Outstanding Balance
           </p>
-          <p className="text-4xl font-bold text-brown-700 dark:text-cream-50">
-            {outstandingXlm}
-          </p>
+          <p className="text-4xl font-bold text-brown-700 dark:text-cream-50">{outstandingXlm}</p>
           <p className="text-xs text-brown-500 mt-1">XLM</p>
         </Card>
       </div>
@@ -188,7 +196,9 @@ export default function CollateralDetailPage() {
             <span className="text-4xl">{icon}</span>
             <h1 className="text-2xl font-bold text-brown-700 dark:text-cream-50 capitalize">
               {collateral.animal_type}
-              <span className="ml-2 text-base font-normal text-brown-500">× {collateral.count}</span>
+              <span className="ml-2 text-base font-normal text-brown-500">
+                × {collateral.count}
+              </span>
             </h1>
           </div>
         }
@@ -226,7 +236,13 @@ export default function CollateralDetailPage() {
 
       {/* Associated loans */}
       {loans.length > 0 ? (
-        <Card header={<h2 className="text-lg font-semibold text-brown-700 dark:text-cream-50">Associated Loans</h2>}>
+        <Card
+          header={
+            <h2 className="text-lg font-semibold text-brown-700 dark:text-cream-50">
+              Associated Loans
+            </h2>
+          }
+        >
           <div className="space-y-3">
             {loans.map((loan) => {
               const loanXlm = (loan.amount / 1e7).toFixed(2);
@@ -245,7 +261,7 @@ export default function CollateralDetailPage() {
                     </span>
                   </div>
                   <p className="text-lg font-bold text-brown-700 dark:text-cream-50 mt-1">
-                    {loanXlm} XLM{" "}
+                    {loanXlm} XLM{' '}
                     <span className="text-sm font-normal text-brown-500">(${loanUsd})</span>
                   </p>
                 </div>
@@ -257,7 +273,7 @@ export default function CollateralDetailPage() {
         <Card className="text-center">
           <p className="text-brown-500 mb-4">No loans associated with this collateral</p>
           <button
-            onClick={() => router.push("/borrow")}
+            onClick={() => router.push('/borrow')}
             className="bg-brown-600 text-cream-50 px-6 py-2 rounded-lg font-semibold hover:bg-brown-700 transition"
           >
             Request a Loan

--- a/frontend/src/app/dashboard/collateral/page.tsx
+++ b/frontend/src/app/dashboard/collateral/page.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import WalletConnect from '@/components/WalletConnect';
 import CollateralSummary from '@/components/CollateralSummary';
 import CollateralGrid from '@/components/CollateralGrid';
+import ErrorState from '@/components/ErrorState';
 import Pagination from '@/components/Pagination';
 import { usePagination } from '@/hooks/usePagination';
 import { Button } from '@/components/ui';
@@ -26,26 +27,25 @@ export default function CollateralPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (wallet) {
-      fetchCollaterals();
-    }
-  }, [wallet]);
-
-  async function fetchCollaterals() {
+  const fetchCollaterals = useCallback(async () => {
+    if (!wallet) return;
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`${API}/api/collateral/list?owner=${wallet}`);
-      if (!res.ok) throw new Error('Failed to fetch collaterals');
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       const data = await res.json();
       setCollaterals(data.collaterals || []);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
+      setError(e instanceof Error ? e.message : 'Failed to load collateral');
     } finally {
       setLoading(false);
     }
-  }
+  }, [wallet]);
+
+  useEffect(() => {
+    fetchCollaterals();
+  }, [fetchCollaterals]);
 
   function handleCardClick(collateralId: string) {
     router.push(`/dashboard/collateral/${collateralId}`);
@@ -61,12 +61,16 @@ export default function CollateralPage() {
 
       {wallet && (
         <>
-          {collaterals.length > 0 ? (
+          {error ? (
+            <ErrorState message={error} onRetry={fetchCollaterals} />
+          ) : loading ? (
+            <CollateralGrid collaterals={[]} loading={true} onCardClick={handleCardClick} />
+          ) : collaterals.length > 0 ? (
             <>
               <CollateralSummary collaterals={collaterals} />
               <CollateralGrid
                 collaterals={paginated}
-                loading={loading}
+                loading={false}
                 onCardClick={handleCardClick}
               />
               <Pagination
@@ -86,15 +90,6 @@ export default function CollateralPage() {
                 Register livestock as collateral to start borrowing
               </p>
               <Button onClick={() => router.push('/borrow')}>Register Collateral</Button>
-            </div>
-          )}
-
-          {error && (
-            <div
-              role="alert"
-              className="mt-4 bg-error-light border border-error rounded-xl p-4 text-error-dark text-sm"
-            >
-              {error}
             </div>
           )}
         </>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,36 +1,43 @@
-"use client";
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { GlossaryTerm } from "@/components/GlossaryTerm";
-import WalletConnect from "@/components/WalletConnect";
-import CollateralCard from "@/components/CollateralCard";
-import RepayPanel from "@/components/RepayPanel";
-import HealthGauge from "@/components/HealthGauge";
-import LoanRepaymentCalculator from "@/components/LoanRepaymentCalculator";
-import TransactionHistory from "@/components/TransactionHistory";
-import SkeletonHealthDashboard from "@/components/SkeletonHealthDashboard";
-import HelpMenu from "@/components/HelpMenu";
-import OnboardingModal from "@/components/OnboardingModal";
-import Card from "@/components/Card";
-import { useHealthFactor } from "@/hooks/useHealthFactor";
-import { useOnboarding } from "@/hooks/useOnboarding";
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { GlossaryTerm } from '@/components/GlossaryTerm';
+import WalletConnect from '@/components/WalletConnect';
+import CollateralCard from '@/components/CollateralCard';
+import RepayPanel from '@/components/RepayPanel';
+import HealthGauge from '@/components/HealthGauge';
+import LoanRepaymentCalculator from '@/components/LoanRepaymentCalculator';
+import TransactionHistory from '@/components/TransactionHistory';
+import SkeletonHealthDashboard from '@/components/SkeletonHealthDashboard';
+import ErrorState from '@/components/ErrorState';
+import HelpMenu from '@/components/HelpMenu';
+import OnboardingModal from '@/components/OnboardingModal';
+import Card from '@/components/Card';
+import { useHealthFactor } from '@/hooks/useHealthFactor';
+import { useOnboarding } from '@/hooks/useOnboarding';
 
 export default function Dashboard() {
   const router = useRouter();
   const [wallet, setWallet] = useState<string | null>(null);
-  const [loanId, setLoanId] = useState("");
-  const [activeLoanId, setActiveLoanId] = useState("");
-  
+  const [loanId, setLoanId] = useState('');
+  const [activeLoanId, setActiveLoanId] = useState('');
+
   useEffect(() => {
-    if (typeof window !== "undefined" && window.location.search.includes("mockWallet=true")) {
-      setWallet("GBXXXXXXMOCKWALLETADDRESSXXXXXX");
+    if (typeof window !== 'undefined' && window.location.search.includes('mockWallet=true')) {
+      setWallet('GBXXXXXXMOCKWALLETADDRESSXXXXXX');
     }
   }, []);
-  
-  const { showOnboarding, openOnboarding, closeOnboarding } = useOnboarding();
-  const { healthFactor } = useHealthFactor(activeLoanId);
 
-  function handleProceedToRepay(nextLoanId: string, _nextAmount: string) {
+  const { showOnboarding, openOnboarding, closeOnboarding } = useOnboarding();
+  const {
+    healthFactor,
+    loading: isHealthLoading,
+    error: healthError,
+    refresh: refreshHealth,
+  } = useHealthFactor(activeLoanId);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function handleProceedToRepay(nextLoanId: string, _amount: string) {
     setLoanId(nextLoanId);
   }
 
@@ -51,7 +58,7 @@ export default function Dashboard() {
             <CollateralCard walletAddress={wallet} />
             <LoanRepaymentCalculator
               onProceed={handleProceedToRepay}
-              onApplyForLoan={() => router.push("/borrow")}
+              onApplyForLoan={() => router.push('/borrow')}
             />
           </div>
 
@@ -82,13 +89,21 @@ export default function Dashboard() {
                   onChange={(e) => setLoanId(e.target.value)}
                 />
                 <button
-                  onClick={refreshHealth}
+                  onClick={() => {
+                    setActiveLoanId(loanId);
+                    refreshHealth();
+                  }}
                   className="rounded-lg bg-gold-500 px-4 py-2 font-semibold text-cream-50 transition hover:bg-gold-600 flex items-center gap-2"
                 >
                   Check
                 </button>
               </div>
-              {healthFactor !== null && <HealthGauge value={healthFactor} />}
+              {healthError && (
+                <div className="mt-4">
+                  <ErrorState message={healthError} onRetry={refreshHealth} />
+                </div>
+              )}
+              {healthFactor !== null && !healthError && <HealthGauge value={healthFactor} />}
             </Card>
           )}
         </>

--- a/frontend/src/app/loans/page.tsx
+++ b/frontend/src/app/loans/page.tsx
@@ -8,6 +8,7 @@ import Card from '@/components/Card';
 import SkeletonLoanCard from '@/components/SkeletonLoanCard';
 import Pagination from '@/components/Pagination';
 import EmptyState from '@/components/EmptyState';
+import ErrorState from '@/components/ErrorState';
 import { usePagination } from '@/hooks/usePagination';
 import { usePolling } from '@/hooks/usePolling';
 import { badgeVariants } from '@/lib/animations';
@@ -31,16 +32,21 @@ function LoanListContent() {
   const reduced = useReducedMotion();
   const [loans, setLoans] = useState<Loan[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const fetchLoans = useCallback(() => {
+    setError(null);
     fetch(`${API}/api/loans`)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`Server error: ${r.status}`);
+        return r.json();
+      })
       .then((data) => {
-        setLoans(Array.isArray(data) ? data : (Array.isArray(data?.data) ? data.data : []));
+        setLoans(Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []);
         setLastUpdated(new Date());
       })
-      .catch(() => {})
+      .catch((e) => setError(e.message || 'Failed to load loans'))
       .finally(() => setLoading(false));
   }, []);
 
@@ -87,6 +93,8 @@ function LoanListContent() {
             </li>
           ))}
         </ul>
+      ) : error ? (
+        <ErrorState message={error} onRetry={fetchLoans} />
       ) : filtered.length === 0 ? (
         <EmptyState
           icon="📋"

--- a/frontend/src/components/CollateralCard.tsx
+++ b/frontend/src/components/CollateralCard.tsx
@@ -1,25 +1,30 @@
-"use client";
-import { useState } from "react";
-import { colors } from "@/lib/design-tokens";
-import Card from "@/components/Card";
-import Spinner from "@/components/Spinner";
+'use client';
+import { useState } from 'react';
+import { colors } from '@/lib/design-tokens';
+import Card from '@/components/Card';
+import Spinner from '@/components/Spinner';
+import ErrorState from '@/components/ErrorState';
 
-interface Props {
-  walletAddress: string;
-}
+const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
-
-export default function CollateralCard({ walletAddress }: Props) {
-  const [collateralId, setCollateralId] = useState("");
-  const [data, setData] = useState<any>(null);
+// walletAddress is accepted for API consistency but lookup uses a user-entered loan ID
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function CollateralCard(_props: { walletAddress: string }) {
+  const [collateralId, setCollateralId] = useState('');
+  const [data, setData] = useState<unknown>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function lookup() {
     setLoading(true);
+    setError(null);
+    setData(null);
     try {
       const res = await fetch(`${API}/api/loan/${collateralId}`);
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setData(await res.json());
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch loan data');
     } finally {
       setLoading(false);
     }
@@ -31,8 +36,11 @@ export default function CollateralCard({ walletAddress }: Props) {
       header={<h2 className={`text-xl font-semibold ${colors.text.primary}`}>Loan Lookup</h2>}
     >
       <div className="flex gap-2">
-        <label htmlFor="lookup-loan-id" className="sr-only">Loan ID</label>
+        <label htmlFor="lookup-loan-id" className="sr-only">
+          Loan ID
+        </label>
         <input
+          id="lookup-loan-id"
           className={`${colors.form.input} rounded-lg px-3 py-2 flex-1 min-w-0 ${colors.text.primary} ${colors.form.placeholder}`}
           placeholder="Loan ID"
           value={collateralId}
@@ -48,12 +56,17 @@ export default function CollateralCard({ walletAddress }: Props) {
               <Spinner />
               <span>Fetching…</span>
             </>
-          ) : "Fetch"}
+          ) : (
+            'Fetch'
+          )}
         </button>
       </div>
+      {error && <ErrorState message={error} onRetry={lookup} />}
       {data && (
-        <pre className={`mt-4 ${colors.background.secondary} rounded-lg p-3 text-xs overflow-auto ${colors.text.primary}`}>
-          {JSON.stringify(data, null, 2)}
+        <pre
+          className={`mt-4 ${colors.background.secondary} rounded-lg p-3 text-xs overflow-auto ${colors.text.primary}`}
+        >
+          {JSON.stringify(data as Record<string, unknown>, null, 2)}
         </pre>
       )}
     </Card>

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -1,0 +1,27 @@
+interface ErrorStateProps {
+  message?: string;
+  onRetry: () => void;
+}
+
+export default function ErrorState({
+  message = 'Something went wrong. Please try again.',
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center py-10 px-4 text-center rounded-xl border border-red-200 bg-red-50 dark:bg-red-950/20 dark:border-red-800"
+    >
+      <span className="text-4xl mb-3" aria-hidden="true">
+        ⚠️
+      </span>
+      <p className="text-sm text-red-700 dark:text-red-400 mb-4 max-w-sm">{message}</p>
+      <button
+        onClick={onRetry}
+        className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-semibold hover:bg-red-700 transition focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import EmptyState from './EmptyState';
+import ErrorState from './ErrorState';
 import { EmptyTransactionsIllustration } from './illustrations';
 import Card from '@/components/Card';
 import Pagination from '@/components/Pagination';
@@ -20,21 +21,42 @@ export default function TransactionHistory({ walletAddress }: { walletAddress: s
   const router = useRouter();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchTransactions = useCallback(() => {
+    setLoaded(false);
+    setError(null);
     fetch(`${API}/api/transactions?borrower=${walletAddress}`)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`Server error: ${r.status}`);
+        return r.json();
+      })
       .then((body) => {
         setTransactions(Array.isArray(body?.data) ? body.data : []);
       })
-      .catch(() => setTransactions([]))
+      .catch((e) => {
+        setError(e.message || 'Failed to load transactions');
+        setTransactions([]);
+      })
       .finally(() => setLoaded(true));
   }, [walletAddress]);
 
-  const { page, limit, totalPages, setPage, setLimit, slice } = usePagination(transactions.length);
-  const paginated = slice(transactions);
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
 
   if (!loaded) return null;
+
+  if (error) {
+    return (
+      <Card
+        className="mb-4"
+        header={<h2 className="text-xl font-semibold text-brown-700">Transactions</h2>}
+      >
+        <ErrorState message={error} onRetry={fetchTransactions} />
+      </Card>
+    );
+  }
 
   if (transactions.length === 0) {
     return (
@@ -51,6 +73,9 @@ export default function TransactionHistory({ walletAddress }: { walletAddress: s
       </Card>
     );
   }
+
+  const { page, limit, totalPages, setPage, setLimit, slice } = usePagination(transactions.length);
+  const paginated = slice(transactions);
 
   return (
     <Card

--- a/frontend/src/hooks/useHealthFactor.ts
+++ b/frontend/src/hooks/useHealthFactor.ts
@@ -1,27 +1,28 @@
-"use client";
-import { useEffect, useRef, useState, useCallback } from "react";
+'use client';
+import { useEffect, useRef, useState, useCallback } from 'react';
 
 const POLL_INTERVAL = 30_000;
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export function useHealthFactor(loanId: string) {
   const [healthFactor, setHealthFactor] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetch_ = useCallback(async () => {
     if (!loanId) return;
     setLoading(true);
+    setError(null);
     try {
-      const res = await fetch(
-        `${API}/api/health/${loanId}`
-      );
+      const res = await fetch(`${API}/api/health/${loanId}`);
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       const data = await res.json();
       setHealthFactor(Number(data.health_factor ?? 0));
       setLastUpdated(new Date());
-    } catch {
-      // keep stale value on error
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch health factor');
     } finally {
       setLoading(false);
     }
@@ -30,7 +31,7 @@ export function useHealthFactor(loanId: string) {
   const startPolling = useCallback(() => {
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = setInterval(() => {
-      if (document.visibilityState === "visible") fetch_();
+      if (document.visibilityState === 'visible') fetch_();
     }, POLL_INTERVAL);
   }, [fetch_]);
 
@@ -40,15 +41,15 @@ export function useHealthFactor(loanId: string) {
     startPolling();
 
     const onVisibility = () => {
-      if (document.visibilityState === "visible") fetch_();
+      if (document.visibilityState === 'visible') fetch_();
     };
-    document.addEventListener("visibilitychange", onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
-      document.removeEventListener("visibilitychange", onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [loanId, fetch_, startPolling]);
 
-  return { healthFactor, loading, lastUpdated, refresh: fetch_ };
+  return { healthFactor, loading, error, lastUpdated, refresh: fetch_ };
 }


### PR DESCRIPTION
- Add ErrorState component (message + retry button, red border/bg)
- CollateralCard, TransactionHistory, useHealthFactor: error + retry
- collateral/page, loans/page, dashboard/page: error + retry
- dashboard/collateral/[id]/page: error + retry
- Fix dashboard/collateral/page: show ErrorState before empty-state check so fetch errors are never hidden behind the empty UI

Closes #251

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please
