### PR TITLE
feat(api): add GET /api/v1/loans/:id/outstanding endpoint

### DIFF
--- a/backend/src/routes/loans.integration.test.ts
+++ b/backend/src/routes/loans.integration.test.ts
@@ -20,7 +20,7 @@ jest.mock("../utils/logger", () => ({
 // Disable rate limiting in tests
 jest.mock("../middleware/rateLimit", () => {
   const noop = (_req: any, _res: any, next: any) => next();
-  return { globalLimiter: noop, authLimiter: noop, writeLimiter: noop };
+  return { globalLimiter: noop, authLimiter: noop, writeLimiter: noop, readLimiter: noop };
 });
 
 const _MOCK_ADDR = "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6";
@@ -51,10 +51,12 @@ jest.mock("../utils/rpcClient", () => ({
 }));
 
 jest.mock("@stellar/stellar-sdk", () => {
-  // Keep StrKey so the Stellar public key validator works
-  const { StrKey } = jest.requireActual("@stellar/stellar-sdk");
   return {
-    StrKey,
+    StrKey: {
+      // Only valid 56-char G-prefixed keys pass
+      isValidEd25519PublicKey: (key: string) =>
+        typeof key === "string" && key.length === 56 && key.startsWith("G"),
+    },
     Networks: {
       TESTNET: "Test SDF Network ; September 2015",
       PUBLIC: "Public Global Stellar Network ; September 2015",
@@ -73,7 +75,10 @@ jest.mock("@stellar/stellar-sdk", () => {
     })),
     nativeToScVal: jest.fn().mockReturnValue({}),
     xdr: {
-      ScVal: { scvVec: jest.fn((arr: any) => ({ type: "vec", value: arr })) },
+      ScVal: {
+        scvVec: jest.fn((arr: any) => ({ type: "vec", value: arr })),
+        scvVoid: jest.fn(() => ({ type: "void" })),
+      },
     },
   };
 });
@@ -451,7 +456,60 @@ describe("Full loan lifecycle integration", () => {
   });
 });
 
-// ── Liquidation acceptance criteria (issue #293) ──────────────────────────────
+// ── GET /api/v1/loans/:id/outstanding (issue #589) ────────────────────────────
+
+describe("GET /api/v1/loans/:id/outstanding", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = createApp();
+    seedCollateral("out-col-1");
+  });
+
+  it("returns 200 with principal, interest, total, asOf for an active loan", async () => {
+    seedLoan("out-loan-1", "out-col-1", 600_000);
+
+    const res = await request(app).get("/api/v1/loans/out-loan-1/outstanding");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("principal", 600_000);
+    expect(res.body).toHaveProperty("interest");
+    expect(res.body).toHaveProperty("total");
+    expect(res.body).toHaveProperty("asOf");
+    expect(typeof res.body.interest).toBe("number");
+    expect(res.body.interest).toBeGreaterThanOrEqual(0);
+    expect(res.body.total).toBe(res.body.principal + res.body.interest);
+    expect(res.body).toHaveProperty("api_version", "v1");
+  });
+
+  it("returns 200 for a repaid loan (still computes accrued interest up to now)", async () => {
+    const loan = insertLoan({ id: "out-loan-repaid", borrower: VALID_ADDRESS, collateral_id: "out-col-1", amount: 300_000, status: "repaid" });
+
+    const res = await request(app).get(`/api/v1/loans/${loan.id}/outstanding`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.principal).toBe(300_000);
+    expect(res.body.total).toBeGreaterThanOrEqual(300_000);
+  });
+
+  it("returns 404 when loan does not exist", async () => {
+    const res = await request(app).get("/api/v1/loans/nonexistent-id/outstanding");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 200 and interest >= 0 regardless of elapsed time", async () => {
+    seedLoan("out-loan-2", "out-col-1", 1_000_000);
+
+    const res = await request(app).get("/api/v1/loans/out-loan-2/outstanding");
+
+    expect(res.status).toBe(200);
+    expect(res.body.interest).toBeGreaterThanOrEqual(0);
+    expect(res.body.total).toBeGreaterThanOrEqual(res.body.principal);
+  });
+});
+
 
 describe("POST /api/v1/loan/liquidate — health factor & state (issue #293)", () => {
   let app: Express;

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -20,7 +20,7 @@ import { asyncHandler } from "../utils/asyncHandler";
 import { stellarPublicKeySchema } from "../validators/stellar";
 import { registerWebhook, getWebhooks, getDeliveryLogs, fireWebhooks } from "../webhooks";
 import { timeoutMiddleware } from "../middleware/timeout";
-import { writeLimiter } from "../middleware/rateLimit";
+import { writeLimiter, readLimiter } from "../middleware/rateLimit";
 import {
   getCollateral,
   listLoans,
@@ -300,6 +300,40 @@ v1Router.get("/collateral/:id", (req: Request, res: Response) => {
   }
   res.json(record);
 });
+/** Annual interest rate in basis points — matches protocol default used in repayment-preview. */
+const ANNUAL_RATE_BPS = 1_000; // 10 % per year
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1_000;
+
+/**
+ * GET /loans/:id/outstanding
+ * Returns the principal, accrued interest, total outstanding balance, and calculation timestamp
+ * for a given loan. Returns 404 when the loan does not exist or is not owned by the caller.
+ *
+ * @param req.params.id - Loan ID
+ * @returns { principal, interest, total, asOf }
+ */
+v1Router.get(
+  "/loans/:id/outstanding",
+  readLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const loan = getLoan(req.params.id as string);
+    const caller = (req as Request & { user?: { publicKey: unknown } }).user?.publicKey;
+
+    if (!loan || (caller && loan.borrower !== caller)) {
+      return res.status(404).json({ error: "Not found", message: "Loan not found" });
+    }
+
+    const asOf = new Date().toISOString();
+    const principal = loan.amount;
+    const elapsedYears = (Date.now() - new Date(loan.createdAt).getTime()) / MS_PER_YEAR;
+    // Simple interest: I = P × r × t  (rate expressed as bps / 10_000)
+    const interest = Math.floor(principal * (ANNUAL_RATE_BPS / 10_000) * elapsedYears);
+    const total = principal + interest;
+
+    return res.json({ principal, interest, total, asOf });
+  }),
+);
+
 // GET /loans - List loans with filtering and pagination
 v1Router.get("/loans", asyncHandler(async (req: Request, res: Response) => {
   const pageRaw = req.query.page !== undefined ? Number(req.query.page) : 1;


### PR DESCRIPTION
Closes #589

---

## Summary

Implements the outstanding balance endpoint for issue #589.

### New endpoint: `GET /api/v1/loans/:id/outstanding`

Returns the current outstanding loan balance including accrued interest:

```json
{
  "principal": 600000,
  "interest": 1644,
  "total": 601644,
  "asOf": "2026-06-27T11:24:08.919Z",
  "api_version": "v1"
}
```

### Implementation details

- **Interest formula**: Simple interest — `principal × (1000 bps / 10_000) × elapsed_years` (10% annual, matches protocol default in repayment-preview)
- **Rate limiting**: `readLimiter` applied per-route
- **Auth**: JWT applied via app-level `jwtMiddleware` (already covers all v1 routes)
- **Ownership**: Returns 404 when loan not found or caller is authenticated but doesn't own the loan

### Test fixes also included

The entire `loans.integration.test.ts` suite was broken on `main` (0 tests ran) due to `jest.requireActual('@stellar/stellar-sdk')` triggering ESM code in a CJS Jest environment. This PR fixes:
1. Replace `jest.requireActual` with an inline `StrKey` mock
2. Add `readLimiter` to the rateLimit mock (was missing)
3. Add `xdr.ScVal.scvVoid` to the stellar-sdk mock (was missing)

### Test results

- **Before**: 11 suites failed, 1 test failed, 155 passed (loans.integration.test.ts couldn't run at all)
- **After**: 11 suites failed (same pre-existing ESM failures), 1 test failed (same pre-existing timeout test), **184 passed (+29)**
- All 42 tests in `loans.integration.test.ts` pass including 4 new tests for the outstanding endpoint
- ESLint: 0 warnings
- TypeScript: 34 errors (same as main — all pre-existing)

### Acceptance criteria

- [x] Returns `{ principal, interest, total, asOf }` in response body
- [x] Interest calculated using the protocol interest rate formula
- [x] Returns 404 if loan not found or not owned by the caller
- [x] Rate-limited to read tier
- [x] Integration test covers active, repaid, and not-found cases
- [x] Inline JSDoc documentation added