### PR TITLE
Document API versioning policy and extract v1 business logic into services

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - "backend/src/routes/**"
+      - "backend/src/services/**"
+      - "backend/src/middleware/deprecation.ts"
       - "backend/src/index.ts"
       - "backend/openapi.json"
+      - "backend/package.json"
   push:
     branches:
       - main
@@ -26,3 +29,14 @@ jobs:
             exit 1
           fi
           echo "openapi.json present"
+
+      - name: Verify info.version matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./backend/package.json').version")
+          SPEC_VERSION=$(node -p "require('./backend/openapi.json').info.version")
+          if [ "$PKG_VERSION" != "$SPEC_VERSION" ]; then
+            echo "ERROR: openapi.json info.version ($SPEC_VERSION) does not match backend/package.json ($PKG_VERSION)."
+            echo "Run: cd backend && npm run openapi:sync"
+            exit 1
+          fi
+          echo "info.version matches package.json ($PKG_VERSION)"

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "docs": "typedoc",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write src",
-    "format:check": "prettier --check src"
+    "format:check": "prettier --check src",
+    "openapi:sync": "node scripts/sync-openapi-version.js"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.0.1",

--- a/backend/scripts/sync-openapi-version.js
+++ b/backend/scripts/sync-openapi-version.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Syncs backend/openapi.json info.version with backend/package.json version.
+ * Updates only the version field to avoid reformatting the entire spec.
+ * Run via: npm run openapi:sync (from backend/)
+ */
+const fs = require("fs");
+const path = require("path");
+
+const backendRoot = path.resolve(__dirname, "..");
+const pkg = JSON.parse(fs.readFileSync(path.join(backendRoot, "package.json"), "utf8"));
+const specPath = path.join(backendRoot, "openapi.json");
+let specText = fs.readFileSync(specPath, "utf8");
+const spec = JSON.parse(specText);
+
+const previous = spec.info.version;
+if (previous === pkg.version) {
+  console.log(`openapi.json info.version already matches package.json (${pkg.version})`);
+  process.exit(0);
+}
+
+spec.info.version = pkg.version;
+const versionPattern = /("info"\s*:\s*\{[\s\S]*?"version"\s*:\s*")[^"]+(")/;
+if (!versionPattern.test(specText)) {
+  console.error("ERROR: Could not locate info.version in openapi.json");
+  process.exit(1);
+}
+
+specText = specText.replace(versionPattern, `$1${pkg.version}$2`);
+fs.writeFileSync(specPath, specText);
+console.log(`Updated openapi.json info.version: ${previous} → ${pkg.version}`);

--- a/backend/src/middleware/deprecation.test.ts
+++ b/backend/src/middleware/deprecation.test.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import {
+  applyDeprecationHeaders,
+  deprecationHeaders,
+  deprecationHeadersWhen,
+} from "./deprecation";
+
+describe("deprecation middleware", () => {
+  const options = {
+    sunset: new Date("2026-12-31T23:59:59Z"),
+    warning: "Use the paginated endpoint instead.",
+    link: '</api/v1/loans?page=1>; rel="successor-version"',
+  };
+
+  function mockRes() {
+    const headers: Record<string, string> = {};
+    return {
+      setHeader: jest.fn((key: string, value: string) => {
+        headers[key] = value;
+      }),
+      headers,
+    } as unknown as Response & { headers: Record<string, string> };
+  }
+
+  it("applyDeprecationHeaders sets Deprecation, Sunset, Warning, and Link", () => {
+    const res = mockRes();
+    applyDeprecationHeaders(res, options);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Deprecation", "true");
+    expect(res.setHeader).toHaveBeenCalledWith("Sunset", options.sunset.toUTCString());
+    expect(res.setHeader).toHaveBeenCalledWith("Warning", `299 - "${options.warning}"`);
+    expect(res.setHeader).toHaveBeenCalledWith("Link", options.link);
+  });
+
+  it("deprecationHeaders middleware always applies headers", () => {
+    const res = mockRes();
+    const next = jest.fn();
+    deprecationHeaders(options)({} as Request, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Deprecation", "true");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("deprecationHeadersWhen applies headers only when predicate is true", () => {
+    const res = mockRes();
+    const next = jest.fn();
+    const middleware = deprecationHeadersWhen((req) => req.query.page === undefined, options);
+
+    middleware({ query: {} } as unknown as Request, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith("Deprecation", "true");
+
+    const res2 = mockRes();
+    middleware({ query: { page: "1" } } as unknown as Request, res2, next);
+    expect(res2.setHeader).not.toHaveBeenCalledWith("Deprecation", "true");
+  });
+});

--- a/backend/src/middleware/deprecation.ts
+++ b/backend/src/middleware/deprecation.ts
@@ -1,0 +1,55 @@
+import { Request, RequestHandler, Response } from "express";
+
+export interface DeprecationOptions {
+  /** RFC 7231 HTTP-date when the endpoint will be removed */
+  sunset: Date;
+  /** Human-readable guidance (RFC 7234 Warning header) */
+  warning: string;
+  /** Optional Link header value, e.g. '</api/v1/loans>; rel="successor-version"' */
+  link?: string;
+}
+
+/**
+ * Writes Deprecation, Sunset, Warning, and optional Link headers on a response.
+ * @param res - Express response object.
+ * @param options - Deprecation metadata.
+ */
+export function applyDeprecationHeaders(res: Response, options: DeprecationOptions): void {
+  res.setHeader("Deprecation", "true");
+  res.setHeader("Sunset", options.sunset.toUTCString());
+  res.setHeader("Warning", `299 - "${options.warning}"`);
+  if (options.link) {
+    res.setHeader("Link", options.link);
+  }
+}
+
+/**
+ * Sets Deprecation, Sunset, and Warning headers on responses from deprecated endpoints.
+ * Use as route-level middleware before the handler.
+ * @param options - Deprecation metadata.
+ * @returns Express middleware that applies deprecation headers.
+ */
+export function deprecationHeaders(options: DeprecationOptions): RequestHandler {
+  return (_req, res, next) => {
+    applyDeprecationHeaders(res, options);
+    next();
+  };
+}
+
+/**
+ * Conditionally applies deprecation headers when predicate returns true.
+ * @param predicate - Returns true when the request should receive deprecation headers.
+ * @param options - Deprecation metadata.
+ * @returns Express middleware that conditionally applies deprecation headers.
+ */
+export function deprecationHeadersWhen(
+  predicate: (req: Request) => boolean,
+  options: DeprecationOptions
+): RequestHandler {
+  return (req, res, next) => {
+    if (predicate(req)) {
+      applyDeprecationHeaders(res, options);
+    }
+    next();
+  };
+}

--- a/backend/src/routes/v1.integration.test.ts
+++ b/backend/src/routes/v1.integration.test.ts
@@ -483,6 +483,7 @@ describe("API v1 Integration Tests", () => {
       const res = await request(app).get("/api/v1/loans");
       expect(res.status).toBe(200);
       expect(res.headers).toHaveProperty("deprecation", "true");
+      expect(res.headers).toHaveProperty("sunset");
       expect(res.headers).toHaveProperty("warning");
       expect(res.headers.warning).toContain("Unpaginated loan listing is deprecated");
     });

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -3,98 +3,61 @@
  * Accessed via /api/v1/...
  */
 import { Router, Request, Response, NextFunction } from "express";
-import {
-  Contract,
-  TransactionBuilder,
-  BASE_FEE,
-  Address,
-  nativeToScVal,
-  xdr,
-  Networks,
-} from "@stellar/stellar-sdk";
 import { z } from "zod";
 import { config } from "../config";
 import { pool } from "../utils/connectionPool";
 import { invalidateAll } from "../utils/appraisalCache";
 import { asyncHandler } from "../utils/asyncHandler";
-import { stellarPublicKeySchema } from "../validators/stellar";
-import { registerWebhook, getWebhooks, getDeliveryLogs, fireWebhooks } from "../webhooks";
+import { registerWebhook, getWebhooks, getDeliveryLogs } from "../webhooks";
 import { timeoutMiddleware } from "../middleware/timeout";
 import { writeLimiter } from "../middleware/rateLimit";
-import {
-  getCollateral,
-  listLoans,
-  getLoan,
-  updateLoan,
-  updateCollateral,
-  insertTransaction,
-  insertLiquidationEvent,
-} from "../db/store";
+import { deprecationHeadersWhen } from "../middleware/deprecation";
 import { fireAlert } from "../utils/alerting";
 import { rules } from "../utils/alertRules";
-import rpcClient from "../utils/rpcClient";
-const CONTRACT_ID = process.env.CONTRACT_ID || "";
-const NETWORK_PASSPHRASE =
-  config.NEXT_PUBLIC_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-
-const SCALE = 10_000;
+import {
+  registerCollateral,
+  registerCollateralSchema,
+  getCollateralById,
+} from "../services/collateralService";
+import {
+  requestLoan,
+  repayLoan,
+  liquidateLoan,
+  getLoanOnChain,
+  getHealthFactor,
+  listLoansPaginated,
+  loanRequestSchema,
+  loanRepaySchema,
+  loanLiquidateSchema,
+  LoanNotFoundError,
+  LoanNotLiquidatableError,
+  InvalidPaginationError,
+} from "../services/loanService";
 
 const APP_VERSION = process.env["npm_package_version"] || "1.0.0";
 const startTime = Date.now();
 
-// ── Validation Schemas ────────────────────────────────────────────────────────
-
-const registerCollateralSchema = z.object({
-  owner: stellarPublicKeySchema,
-  animal_type: z.string().min(1),
-  count: z.number().int().positive(),
-  appraised_value: z.number().int().positive(),
+const settingsSchema = z.object({
+  notifications: z
+    .object({
+      loanApproved: z.boolean(),
+      loanRepaid: z.boolean(),
+      liquidationWarning: z.boolean(),
+    })
+    .optional(),
+  language: z.string().min(2).max(10).optional(),
+  currency: z.string().min(3).max(6).optional(),
 });
 
-const loanRequestSchema = z.object({
-  borrower: stellarPublicKeySchema,
-  collateral_ids: z.array(z.number().int().nonnegative()).min(1),
-  amount: z.number().int().positive(),
-  min_disbursement: z.number().int().positive().optional(),
-});
+type UserSettings = z.infer<typeof settingsSchema> & {
+  walletAddress: string;
+  joinDate: string;
+};
 
-const loanRepaySchema = z.object({
-  borrower: stellarPublicKeySchema,
-  loan_id: z.number().int().nonnegative(),
-  amount: z.number().int().positive(),
-});
-
-const loanLiquidateSchema = z.object({
-  liquidator: stellarPublicKeySchema,
-  loan_id: z.number().int().nonnegative(),
-  repay_amount: z.number().int().positive(),
-});
-
-// ── helpers ───────────────────────────────────────────────────────────────────
-
-async function buildContractTx(
-  sourceAddress: string,
-  method: string,
-  args: xdr.ScVal[]
-): Promise<string> {
-  const account = await rpcClient.getAccount(sourceAddress) as any;
-  const contract = new Contract(CONTRACT_ID);
-  const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(contract.call(method, ...args))
-    .setTimeout(30)
-    .build();
-  const prepared = await rpcClient.prepareTransaction(tx) as any;
-  return prepared.toXDR();
-}
-
-// ── Router ────────────────────────────────────────────────────────────────────
+const settingsStore = new Map<string, UserSettings>();
 
 const v1Router = Router();
 
-// Version envelope middleware — adds api_version to every response
 v1Router.use((_req: Request, res: Response, next: NextFunction) => {
   const originalJson = res.json.bind(res);
   res.json = (body: unknown) => {
@@ -106,7 +69,6 @@ v1Router.use((_req: Request, res: Response, next: NextFunction) => {
   next();
 });
 
-// GET /health
 v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const uptime = Math.floor((Date.now() - startTime) / 1000);
@@ -129,7 +91,6 @@ v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) 
   }
 });
 
-// POST /collateral/register
 v1Router.post(
   "/collateral/register",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -139,18 +100,11 @@ v1Router.post(
     if (!validation.success) {
       return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
     }
-    const { owner, animal_type, count, appraised_value } = validation.data;
-    const xdrTx = await buildContractTx(owner, "register_livestock", [
-      new Address(owner).toScVal(),
-      nativeToScVal(animal_type, { type: "symbol" }),
-      nativeToScVal(count, { type: "u32" }),
-      nativeToScVal(BigInt(appraised_value), { type: "i128" }),
-    ]);
-    res.json({ xdr: xdrTx });
+    const result = await registerCollateral(validation.data);
+    res.json(result);
   })
 );
 
-// POST /loan/request
 v1Router.post(
   "/loan/request",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -160,23 +114,11 @@ v1Router.post(
     if (!validation.success) {
       return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
     }
-    const { borrower, collateral_ids, amount, min_disbursement } = validation.data;
-    const idsScVal = xdr.ScVal.scvVec(collateral_ids.map(id => nativeToScVal(BigInt(id), { type: "u64" })));
-    const minDisbursementScVal = min_disbursement !== undefined
-      ? nativeToScVal(BigInt(min_disbursement), { type: "i128" })
-      : xdr.ScVal.scvVoid();
-    const xdrTx = await buildContractTx(borrower, "request_loan", [
-      new Address(borrower).toScVal(),
-      idsScVal,
-      nativeToScVal(BigInt(amount), { type: "i128" }),
-      minDisbursementScVal,
-    ]);
-    fireWebhooks("loan.approved", { borrower, collateral_ids, amount });
-    res.json({ xdr: xdrTx });
+    const result = await requestLoan(validation.data);
+    res.json(result);
   })
 );
 
-// POST /loan/repay
 v1Router.post(
   "/loan/repay",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -186,18 +128,11 @@ v1Router.post(
     if (!validation.success) {
       return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
     }
-    const { borrower, loan_id, amount } = validation.data;
-    const xdrTx = await buildContractTx(borrower, "repay_loan", [
-      new Address(borrower).toScVal(),
-      nativeToScVal(BigInt(loan_id), { type: "u64" }),
-      nativeToScVal(BigInt(amount), { type: "i128" }),
-    ]);
-    fireWebhooks("loan.repaid", { borrower, loan_id, amount });
-    res.json({ xdr: xdrTx });
+    const result = await repayLoan(validation.data);
+    res.json(result);
   })
 );
 
-// POST /loan/liquidate
 v1Router.post(
   "/loan/liquidate",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -207,149 +142,79 @@ v1Router.post(
     if (!validation.success) {
       return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
     }
-    const { liquidator, loan_id, repay_amount } = validation.data;
-
-    // Fetch loan and verify it exists
-    const loan = getLoan(String(loan_id));
-    if (!loan) {
-      return res.status(404).json({ error: `Loan ${loan_id} not found` });
+    try {
+      const result = await liquidateLoan(validation.data);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof LoanNotFoundError) {
+        return res.status(404).json({ error: err.message });
+      }
+      if (err instanceof LoanNotLiquidatableError) {
+        return res
+          .status(400)
+          .json({ error: err.message, health_factor: err.healthFactor });
+      }
+      throw err;
     }
-
-    // Check health factor — reject if loan is safe (HF >= SCALE)
-    const collateral = getCollateral(loan.collateral_id);
-    const collateralValue = collateral?.appraised_value ?? 0;
-    const hf = loan.amount > 0 && collateralValue > 0
-      ? (collateralValue * 8_000) / (loan.amount * SCALE) * SCALE
-      : null;
-
-    if (hf === null || hf >= SCALE) {
-      return res.status(400).json({ error: "Loan health factor is above liquidation threshold", health_factor: hf });
-    }
-
-    // Invoke Soroban liquidation function
-    const xdrTx = await buildContractTx(liquidator, "liquidate", [
-      new Address(liquidator).toScVal(),
-      nativeToScVal(BigInt(loan_id), { type: "u64" }),
-      nativeToScVal(BigInt(repay_amount), { type: "i128" }),
-    ]);
-
-    // Update loan and collateral status to liquidated
-    const updatedLoan = updateLoan(loan.id, { status: "liquidated" });
-    if (collateral) {
-      updateCollateral(collateral.id, { status: "liquidated" });
-    }
-
-    // Record liquidation event
-    insertLiquidationEvent({ loan_id: loan.id, liquidator, repay_amount });
-    insertTransaction({ borrower: loan.borrower, type: "liquidation", status: "completed", amount: repay_amount, loanId: loan.id, collateralId: loan.collateral_id });
-
-    fireWebhooks("loan.liquidated", { liquidator, loan_id, repay_amount });
-    res.json({ xdr: xdrTx, loan: updatedLoan });
   })
 );
 
-// GET /loan/:id
-v1Router.get("/loan/:id", async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const contract = new Contract(CONTRACT_ID);
-    const account = await rpcClient.getAccount(
-      "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6"
-    ) as any;
-    const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: NETWORK_PASSPHRASE,
-    })
-      .addOperation(contract.call("get_loan", nativeToScVal(BigInt(req.params.id as string), { type: "u64" })))
-      .setTimeout(30)
-      .build();
-    const result = await rpcClient.simulateTransaction(tx);
-    res.json({ result: (result as any).result?.retval });
-  } catch (err) {
-    next(err);
-  }
-});
+v1Router.get(
+  "/loan/:id",
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = await getLoanOnChain(req.params.id as string);
+    res.json(result);
+  })
+);
 
-// GET /health/:loanId
-v1Router.get("/health/:loanId", async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const contract = new Contract(CONTRACT_ID);
-    const account = await rpcClient.getAccount(
-      "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6"
-    ) as any;
-    const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: NETWORK_PASSPHRASE,
-    })
-      .addOperation(
-        contract.call("health_factor", nativeToScVal(BigInt(req.params.loanId as string), { type: "u64" }))
-      )
-      .setTimeout(30)
-      .build();
-    const result = await rpcClient.simulateTransaction(tx);
-    res.json({ health_factor: (result as any).result?.retval });
-  } catch (err) {
-    next(err);
-  }
-});
+v1Router.get(
+  "/health/:loanId",
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = await getHealthFactor(req.params.loanId as string);
+    res.json(result);
+  })
+);
 
-// GET /collateral/:id
 v1Router.get("/collateral/:id", (req: Request, res: Response) => {
-  const record = getCollateral(req.params.id as string);
+  const record = getCollateralById(req.params.id as string);
   if (!record) {
     return res.status(404).json({ error: "Collateral not found" });
   }
   res.json(record);
 });
-// GET /loans - List loans with filtering and pagination
-v1Router.get("/loans", asyncHandler(async (req: Request, res: Response) => {
-  const pageRaw = req.query.page !== undefined ? Number(req.query.page) : 1;
-  let limitRaw = 20;
-  let isPageSize = false;
-  if (req.query.pageSize !== undefined) {
-    limitRaw = Number(req.query.pageSize);
-    isPageSize = true;
-  } else if (req.query.limit !== undefined) {
-    limitRaw = Number(req.query.limit);
-  }
 
-  if (!Number.isInteger(pageRaw) || pageRaw < 1 || !Number.isInteger(limitRaw) || limitRaw < 1) {
-    return res.status(400).json({ error: "Invalid pagination parameters" });
-  }
+v1Router.get(
+  "/loans",
+  deprecationHeadersWhen(
+    (req) =>
+      req.query.page === undefined &&
+      req.query.pageSize === undefined &&
+      req.query.limit === undefined,
+    {
+      sunset: new Date("2026-12-31T23:59:59Z"),
+      warning: "Unpaginated loan listing is deprecated; use ?page=1&pageSize=20",
+      link: '</api/v1/loans?page=1&pageSize=20>; rel="successor-version"',
+    }
+  ),
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const result = listLoansPaginated(req.query as Record<string, string | undefined>);
+      res.json({
+        data: result.data,
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        pageSize: result.pageSize,
+      });
+    } catch (err) {
+      if (err instanceof InvalidPaginationError) {
+        return res.status(400).json({ error: err.message });
+      }
+      throw err;
+    }
+  })
+);
 
-  if (!isPageSize && limitRaw > 100) {
-    return res.status(400).json({ error: "Invalid pagination parameters" });
-  }
-  const maxLimit = Math.min(limitRaw, 100);
-
-  const { status, borrowerAddress, from, to } = req.query as Record<string, string | undefined>;
-
-  const validStatuses = ["active", "repaid", "liquidated"];
-  if (status && !validStatuses.includes(status)) {
-    return res.status(400).json({ error: `status must be one of: ${validStatuses.join(", ")}` });
-  }
-  if (from && isNaN(new Date(from).getTime())) {
-    return res.status(400).json({ error: "from must be a valid ISO date" });
-  }
-  if (to && isNaN(new Date(to).getTime())) {
-    return res.status(400).json({ error: "to must be a valid ISO date" });
-  }
-
-  if (req.query.page === undefined && req.query.pageSize === undefined && req.query.limit === undefined) {
-    res.setHeader("Deprecation", "true");
-    res.setHeader("Warning", '299 - "Unpaginated loan listing is deprecated; use ?page=1&pageSize=20"');
-  }
-
-  const result = listLoans({ status, borrowerAddress, from, to, page: pageRaw, limit: maxLimit });
-  res.json({
-    data: result.data,
-    total: result.total,
-    page: result.page,
-    limit: result.limit,
-    pageSize: result.limit,
-  });
-}));
-
-// POST /oracle/price-update
 v1Router.post(
   "/oracle/price-update",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -359,7 +224,6 @@ v1Router.post(
   }
 );
 
-// POST /webhooks
 v1Router.post(
   "/webhooks",
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
@@ -370,30 +234,24 @@ v1Router.post(
     }
     try {
       return res.status(201).json(registerWebhook(url));
-    } catch (err: any) {
-      return res.status(400).json({ error: err.message });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to register webhook";
+      return res.status(400).json({ error: message });
     }
   }
 );
 
-// GET /admin/webhooks
 v1Router.get("/admin/webhooks", (_req: Request, res: Response) => {
   res.json(getWebhooks());
 });
 
-// GET /admin/webhooks/logs
 v1Router.get("/admin/webhooks/logs", (_req: Request, res: Response) => {
   res.json(getDeliveryLogs());
 });
 
-/**
- * POST /alerts/webhook
- * Receiver for AWS SNS notifications (specifically for BACKUP_JOB_FAILED)
- */
 v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {
   const body = req.body;
 
-  // Handle SNS subscription confirmation
   if (req.header("x-amz-sns-message-type") === "SubscriptionConfirmation") {
     const subscribeUrl = body.SubscribeURL;
     if (subscribeUrl) {
@@ -402,12 +260,13 @@ v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {
     }
   }
 
-  // Handle actual notification
   if (req.header("x-amz-sns-message-type") === "Notification") {
     try {
       const message = JSON.parse(body.Message);
-      // Check if it's a backup failure event
-      if (message["detail-type"] === "Backup Job State Change" && message.detail.state === "FAILED") {
+      if (
+        message["detail-type"] === "Backup Job State Change" &&
+        message.detail.state === "FAILED"
+      ) {
         await fireAlert(rules.backupFailure, "AWS Backup job failed", {
           backupJobId: message.detail.backupJobId,
           resourceArn: message.detail.resourceArn,
@@ -421,33 +280,10 @@ v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {
   res.status(200).send("OK");
 });
 
-export { v1Router, startTime, APP_VERSION };
-
-// ── User Settings ─────────────────────────────────────────────────────────────
-
-const settingsSchema = z.object({
-  notifications: z.object({
-    loanApproved: z.boolean(),
-    loanRepaid: z.boolean(),
-    liquidationWarning: z.boolean(),
-  }).optional(),
-  language: z.string().min(2).max(10).optional(),
-  currency: z.string().min(3).max(6).optional(),
-});
-
-type UserSettings = z.infer<typeof settingsSchema> & {
-  walletAddress: string;
-  joinDate: string;
-};
-
-// In-memory store (replace with DB persistence in production)
-const settingsStore = new Map<string, UserSettings>();
-
 v1Router.get("/settings/:wallet", (req: Request, res: Response) => {
   const wallet = req.params.wallet as string;
   const existing = settingsStore.get(wallet);
   if (!existing) {
-    // Return defaults for new users
     return res.json({
       walletAddress: wallet,
       joinDate: new Date().toISOString(),
@@ -476,3 +312,5 @@ v1Router.put("/settings/:wallet", (req: Request, res: Response) => {
   settingsStore.set(wallet, updated);
   res.json(updated);
 });
+
+export { v1Router, startTime, APP_VERSION };

--- a/backend/src/services/collateralService.ts
+++ b/backend/src/services/collateralService.ts
@@ -1,0 +1,42 @@
+/**
+ * Collateral business logic — decoupled from HTTP layer for v1/v2 reuse.
+ */
+import { Address, nativeToScVal } from "@stellar/stellar-sdk";
+import { z } from "zod";
+import { stellarPublicKeySchema } from "../validators/stellar";
+import { getCollateral } from "../db/store";
+import { buildContractTx } from "./contractTx";
+
+export const registerCollateralSchema = z.object({
+  owner: stellarPublicKeySchema,
+  animal_type: z.string().min(1),
+  count: z.number().int().positive(),
+  appraised_value: z.number().int().positive(),
+});
+
+export type RegisterCollateralInput = z.infer<typeof registerCollateralSchema>;
+
+/**
+ * Builds a register_livestock contract transaction.
+ * @param input - Validated collateral registration payload.
+ * @returns Unsigned XDR transaction for client signing.
+ */
+export async function registerCollateral(input: RegisterCollateralInput): Promise<{ xdr: string }> {
+  const { owner, animal_type, count, appraised_value } = input;
+  const xdrTx = await buildContractTx(owner, "register_livestock", [
+    new Address(owner).toScVal(),
+    nativeToScVal(animal_type, { type: "symbol" }),
+    nativeToScVal(count, { type: "u32" }),
+    nativeToScVal(BigInt(appraised_value), { type: "i128" }),
+  ]);
+  return { xdr: xdrTx };
+}
+
+/**
+ * Fetches a collateral record by ID.
+ * @param id - Collateral record identifier.
+ * @returns Collateral record or undefined when not found.
+ */
+export function getCollateralById(id: string) {
+  return getCollateral(id);
+}

--- a/backend/src/services/contractTx.ts
+++ b/backend/src/services/contractTx.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared Soroban transaction builder used by loan and collateral services.
+ */
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { config } from "../config";
+import rpcClient from "../utils/rpcClient";
+
+const CONTRACT_ID = process.env.CONTRACT_ID || "";
+const NETWORK_PASSPHRASE =
+  config.NEXT_PUBLIC_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+/**
+ * Builds an unsigned Soroban contract transaction XDR for client signing.
+ * @param sourceAddress - Stellar account that will sign the transaction.
+ * @param method - Soroban contract method name.
+ * @param args - Encoded contract arguments.
+ * @returns Base64-encoded unsigned transaction XDR.
+ */
+export async function buildContractTx(
+  sourceAddress: string,
+  method: string,
+  args: xdr.ScVal[]
+): Promise<string> {
+  const account = (await rpcClient.getAccount(sourceAddress)) as any;
+  const contract = new Contract(CONTRACT_ID);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+  const prepared = (await rpcClient.prepareTransaction(tx)) as any;
+  return prepared.toXDR();
+}
+
+export { CONTRACT_ID, NETWORK_PASSPHRASE };

--- a/backend/src/services/loanService.ts
+++ b/backend/src/services/loanService.ts
@@ -1,0 +1,276 @@
+/**
+ * Loan business logic — decoupled from HTTP layer for v1/v2 reuse.
+ */
+import {
+  Address,
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  nativeToScVal,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { z } from "zod";
+import { stellarPublicKeySchema } from "../validators/stellar";
+import {
+  getCollateral,
+  listLoans,
+  getLoan,
+  updateLoan,
+  updateCollateral,
+  insertTransaction,
+  insertLiquidationEvent,
+} from "../db/store";
+import { fireWebhooks } from "../webhooks";
+import { buildContractTx, CONTRACT_ID, NETWORK_PASSPHRASE } from "./contractTx";
+import rpcClient from "../utils/rpcClient";
+
+const SCALE = 10_000;
+const SIMULATION_ACCOUNT = "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6";
+
+export const loanRequestSchema = z.object({
+  borrower: stellarPublicKeySchema,
+  collateral_ids: z.array(z.number().int().nonnegative()).min(1),
+  amount: z.number().int().positive(),
+  min_disbursement: z.number().int().positive().optional(),
+});
+
+export const loanRepaySchema = z.object({
+  borrower: stellarPublicKeySchema,
+  loan_id: z.number().int().nonnegative(),
+  amount: z.number().int().positive(),
+});
+
+export const loanLiquidateSchema = z.object({
+  liquidator: stellarPublicKeySchema,
+  loan_id: z.number().int().nonnegative(),
+  repay_amount: z.number().int().positive(),
+});
+
+export type LoanRequestInput = z.infer<typeof loanRequestSchema>;
+export type LoanRepayInput = z.infer<typeof loanRepaySchema>;
+export type LoanLiquidateInput = z.infer<typeof loanLiquidateSchema>;
+
+export interface ListLoansQuery {
+  page?: string;
+  pageSize?: string;
+  limit?: string;
+  status?: string;
+  borrowerAddress?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface ListLoansResult {
+  data: ReturnType<typeof listLoans>["data"];
+  total: number;
+  page: number;
+  limit: number;
+  pageSize: number;
+}
+
+export class LoanNotFoundError extends Error {
+  constructor(loanId: number | string) {
+    super(`Loan ${loanId} not found`);
+    this.name = "LoanNotFoundError";
+  }
+}
+
+export class LoanNotLiquidatableError extends Error {
+  healthFactor: number | null;
+
+  constructor(healthFactor: number | null) {
+    super("Loan health factor is above liquidation threshold");
+    this.name = "LoanNotLiquidatableError";
+    this.healthFactor = healthFactor;
+  }
+}
+
+export class InvalidPaginationError extends Error {
+  constructor(message = "Invalid pagination parameters") {
+    super(message);
+    this.name = "InvalidPaginationError";
+  }
+}
+
+/**
+ * Builds a request_loan contract transaction and fires approval webhooks.
+ * @param input - Validated loan request payload.
+ * @returns Unsigned XDR transaction for client signing.
+ */
+export async function requestLoan(input: LoanRequestInput): Promise<{ xdr: string }> {
+  const { borrower, collateral_ids, amount, min_disbursement } = input;
+  const idsScVal = xdr.ScVal.scvVec(
+    collateral_ids.map((id) => nativeToScVal(BigInt(id), { type: "u64" }))
+  );
+  const minDisbursementScVal =
+    min_disbursement !== undefined
+      ? nativeToScVal(BigInt(min_disbursement), { type: "i128" })
+      : xdr.ScVal.scvVoid();
+  const xdrTx = await buildContractTx(borrower, "request_loan", [
+    new Address(borrower).toScVal(),
+    idsScVal,
+    nativeToScVal(BigInt(amount), { type: "i128" }),
+    minDisbursementScVal,
+  ]);
+  fireWebhooks("loan.approved", { borrower, collateral_ids, amount });
+  return { xdr: xdrTx };
+}
+
+/**
+ * Builds a repay_loan contract transaction and fires repayment webhooks.
+ * @param input - Validated loan repayment payload.
+ * @returns Unsigned XDR transaction for client signing.
+ */
+export async function repayLoan(input: LoanRepayInput): Promise<{ xdr: string }> {
+  const { borrower, loan_id, amount } = input;
+  const xdrTx = await buildContractTx(borrower, "repay_loan", [
+    new Address(borrower).toScVal(),
+    nativeToScVal(BigInt(loan_id), { type: "u64" }),
+    nativeToScVal(BigInt(amount), { type: "i128" }),
+  ]);
+  fireWebhooks("loan.repaid", { borrower, loan_id, amount });
+  return { xdr: xdrTx };
+}
+
+/**
+ * Validates liquidation eligibility, builds contract tx, and updates local state.
+ * @param input - Validated liquidation payload.
+ * @returns Unsigned XDR and updated loan record.
+ * @throws LoanNotFoundError when the loan does not exist.
+ * @throws LoanNotLiquidatableError when health factor is above threshold.
+ */
+export async function liquidateLoan(input: LoanLiquidateInput) {
+  const { liquidator, loan_id, repay_amount } = input;
+
+  const loan = getLoan(String(loan_id));
+  if (!loan) {
+    throw new LoanNotFoundError(loan_id);
+  }
+
+  const collateral = getCollateral(loan.collateral_id);
+  const collateralValue = collateral?.appraised_value ?? 0;
+  const hf =
+    loan.amount > 0 && collateralValue > 0
+      ? ((collateralValue * 8_000) / (loan.amount * SCALE)) * SCALE
+      : null;
+
+  if (hf === null || hf >= SCALE) {
+    throw new LoanNotLiquidatableError(hf);
+  }
+
+  const xdrTx = await buildContractTx(liquidator, "liquidate", [
+    new Address(liquidator).toScVal(),
+    nativeToScVal(BigInt(loan_id), { type: "u64" }),
+    nativeToScVal(BigInt(repay_amount), { type: "i128" }),
+  ]);
+
+  const updatedLoan = updateLoan(loan.id, { status: "liquidated" });
+  if (collateral) {
+    updateCollateral(collateral.id, { status: "liquidated" });
+  }
+
+  insertLiquidationEvent({ loan_id: loan.id, liquidator, repay_amount });
+  insertTransaction({
+    borrower: loan.borrower,
+    type: "liquidation",
+    status: "completed",
+    amount: repay_amount,
+    loanId: loan.id,
+    collateralId: loan.collateral_id,
+  });
+
+  fireWebhooks("loan.liquidated", { liquidator, loan_id, repay_amount });
+  return { xdr: xdrTx, loan: updatedLoan };
+}
+
+/**
+ * Simulates get_loan on the Soroban contract.
+ * @param loanId - On-chain loan identifier.
+ * @returns Simulated contract return value.
+ */
+export async function getLoanOnChain(loanId: string) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = (await rpcClient.getAccount(SIMULATION_ACCOUNT)) as any;
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call("get_loan", nativeToScVal(BigInt(loanId), { type: "u64" }))
+    )
+    .setTimeout(30)
+    .build();
+  const result = await rpcClient.simulateTransaction(tx);
+  return { result: (result as { result?: { retval: unknown } }).result?.retval };
+}
+
+/**
+ * Simulates health_factor on the Soroban contract.
+ * @param loanId - On-chain loan identifier.
+ * @returns Simulated health factor value.
+ */
+export async function getHealthFactor(loanId: string) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = (await rpcClient.getAccount(SIMULATION_ACCOUNT)) as any;
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call("health_factor", nativeToScVal(BigInt(loanId), { type: "u64" }))
+    )
+    .setTimeout(30)
+    .build();
+  const result = await rpcClient.simulateTransaction(tx);
+  return { health_factor: (result as { result?: { retval: unknown } }).result?.retval };
+}
+
+/**
+ * Lists loans with pagination and optional filters.
+ * @param query - Query string parameters from the HTTP request.
+ * @returns Paginated loan list.
+ * @throws InvalidPaginationError when pagination or filter params are invalid.
+ */
+export function listLoansPaginated(query: ListLoansQuery): ListLoansResult {
+  const pageRaw = query.page !== undefined ? Number(query.page) : 1;
+  let limitRaw = 20;
+  let isPageSize = false;
+
+  if (query.pageSize !== undefined) {
+    limitRaw = Number(query.pageSize);
+    isPageSize = true;
+  } else if (query.limit !== undefined) {
+    limitRaw = Number(query.limit);
+  }
+
+  if (!Number.isInteger(pageRaw) || pageRaw < 1 || !Number.isInteger(limitRaw) || limitRaw < 1) {
+    throw new InvalidPaginationError();
+  }
+
+  if (!isPageSize && limitRaw > 100) {
+    throw new InvalidPaginationError();
+  }
+
+  const maxLimit = Math.min(limitRaw, 100);
+  const { status, borrowerAddress, from, to } = query;
+
+  const validStatuses = ["active", "repaid", "liquidated"];
+  if (status && !validStatuses.includes(status)) {
+    throw new InvalidPaginationError(`status must be one of: ${validStatuses.join(", ")}`);
+  }
+  if (from && isNaN(new Date(from).getTime())) {
+    throw new InvalidPaginationError("from must be a valid ISO date");
+  }
+  if (to && isNaN(new Date(to).getTime())) {
+    throw new InvalidPaginationError("to must be a valid ISO date");
+  }
+
+  const result = listLoans({ status, borrowerAddress, from, to, page: pageRaw, limit: maxLimit });
+  return {
+    data: result.data,
+    total: result.total,
+    page: result.page,
+    limit: result.limit,
+    pageSize: result.limit,
+  };
+}

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,136 @@
+# API Versioning Policy
+
+StellarKraal exposes versioned REST endpoints under `/api/v1/`. This document defines when a new version is introduced, how breaking changes are handled, and how clients should migrate.
+
+## Version scheme
+
+| Layer | Format | Example | Source of truth |
+|-------|--------|---------|-----------------|
+| URL path | `v{N}` | `/api/v1/loan/request` | Route mount in `backend/src/routes/v1.ts` |
+| OpenAPI `info.version` | SemVer (`MAJOR.MINOR.PATCH`) | `1.0.0` | `backend/package.json` (synced via `npm run openapi:sync`) |
+| Response envelope | `api_version` field | `"v1"` | Version router middleware |
+
+The URL version (`v1`) is the **compatibility boundary**. The OpenAPI `info.version` tracks the **release** of the spec and backend package; a patch bump does not require a new URL version.
+
+## Breaking vs non-breaking changes
+
+### Non-breaking (safe within the same URL version)
+
+- Adding optional request fields
+- Adding new response fields
+- Adding new endpoints
+- Adding new query parameters (optional)
+- Bug fixes that restore documented behaviour
+- Performance improvements with identical contracts
+
+### Breaking (requires a new URL version, e.g. `/api/v2/`)
+
+- Removing or renaming fields in request or response bodies
+- Changing field types (e.g. `string` → `number`)
+- Changing required fields (making optional fields required, or removing required fields)
+- Changing HTTP methods or URL paths
+- Changing authentication requirements
+- Changing error response shapes clients depend on
+- Changing pagination defaults in a way that breaks existing clients
+
+When a breaking change is unavoidable, ship it in a new router (`v2.ts`) backed by shared service modules. The v1 router remains available until the deprecation window closes.
+
+## Deprecation timeline
+
+1. **Announce** — Add `Deprecation: true` and `Sunset: <HTTP-date>` headers to affected endpoints. Document the change in the migration guide (see below).
+2. **Dual-run** — Maintain both old and new behaviour (or redirect unversioned paths to v1) for at least **6 months**.
+3. **Sunset** — After the `Sunset` date, remove the deprecated endpoint or return `410 Gone`.
+
+### Standard headers
+
+| Header | Value | Meaning |
+|--------|-------|---------|
+| `Deprecation` | `true` | Endpoint is deprecated; migrate to the replacement |
+| `Sunset` | HTTP-date (RFC 7231) | Last day the endpoint is guaranteed to work |
+| `Warning` | `299 - "message"` | Human-readable guidance for developers |
+| `Link` | `<url>; rel="successor-version"` | Optional pointer to the replacement endpoint |
+
+Example middleware usage:
+
+```typescript
+import { deprecationHeaders, deprecationHeadersWhen } from "../middleware/deprecation";
+
+// Always deprecated
+router.get(
+  "/legacy-endpoint",
+  deprecationHeaders({
+    sunset: new Date("2026-12-31T23:59:59Z"),
+    warning: "Use GET /api/v1/loans?page=1&pageSize=20 instead.",
+    link: "</api/v1/loans>; rel=\"successor-version\"",
+  }),
+  handler
+);
+
+// Conditionally deprecated (e.g. unpaginated listing)
+router.get(
+  "/loans",
+  deprecationHeadersWhen(
+    (req) => !req.query.page && !req.query.pageSize && !req.query.limit,
+    {
+      sunset: new Date("2026-12-31T23:59:59Z"),
+      warning: "Unpaginated loan listing is deprecated; use ?page=1&pageSize=20",
+    }
+  ),
+  handler
+);
+```
+
+## Migration guide format
+
+When introducing `/api/v2/` (or deprecating v1 endpoints), publish a migration guide at `docs/migrations/v1-to-v2.md` with this structure:
+
+```markdown
+# Migrating from API v1 to v2
+
+## Overview
+- Release date: YYYY-MM-DD
+- v1 sunset date: YYYY-MM-DD
+- Breaking changes summary (1–3 sentences)
+
+## Endpoint mapping
+
+| v1 | v2 | Notes |
+|----|----|-------|
+| POST /api/v1/loan/request | POST /api/v2/loans | `collateral_id` → `collateral_ids[]` |
+
+## Request/response diffs
+(per changed endpoint: before/after JSON examples)
+
+## Client checklist
+- [ ] Update base URL to `/api/v2`
+- [ ] Update field names per mapping table
+- [ ] Handle new error codes
+- [ ] Remove reliance on deprecated headers/endpoints
+```
+
+## Architecture for multi-version support
+
+Route handlers in `backend/src/routes/v1.ts` (and future `v2.ts`) should be thin HTTP adapters. Business logic lives in service modules:
+
+```
+backend/src/
+  routes/
+    v1.ts          ← HTTP: validation, status codes, headers
+    v2.ts          ← future versioned router
+  services/
+    loanService.ts
+    collateralService.ts
+```
+
+A v2 router reuses the same services and only changes request/response mapping, making version upgrades incremental rather than a full rewrite.
+
+## Client guidance
+
+1. **Always call versioned URLs** — Use `/api/v1/...` instead of unversioned `/api/...`. Unversioned routes redirect with `Deprecation` headers.
+2. **Ignore unknown response fields** — Forward-compatible clients must tolerate new JSON keys.
+3. **Watch response headers** — Log `Deprecation`, `Sunset`, and `Warning` in development; alert on them in production integrations.
+4. **Pin integration tests** to the URL version, not only the OpenAPI package version.
+
+## Changelog
+
+API-level changes are recorded in the repository CHANGELOG (when present) and reflected in OpenAPI `info.version` bumps. Patch releases document non-breaking fixes; minor releases document additive changes; major URL version bumps document breaking migrations.


### PR DESCRIPTION
Closes #506

## Summary
- Adds `docs/api-versioning.md` with versioning policy, deprecation timeline, and migration guide format
- Extracts loan/collateral business logic from `v1.ts` into `services/` for straightforward v2 adoption
- Introduces Deprecation/Sunset header middleware with a live example on unpaginated `GET /api/v1/loans`
- Enforces OpenAPI `info.version` sync with `backend/package.json` via script and CI


## Test plan
- [ ] Review `docs/api-versioning.md`
- [ ] Verify unpaginated `GET /api/v1/loans` returns Deprecation + Sunset headers
- [ ] Verify paginated `GET /api/v1/loans?page=1&pageSize=20` has no deprecation headers
- [ ] Confirm loan/collateral endpoints still return unsigned XDR
- [ ] Run `cd backend && npm run openapi:sync` and confirm CI version check passes