### PR TITLE
feat: add GET /api/v1/health/deep endpoint (#594)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -65,6 +65,7 @@ import { scheduleHealthFactorJob } from "./jobs/healthFactorJob";
 import { httpActiveConnections, httpRequestDurationSeconds, httpRequestsTotal } from "./metrics";
 import { fireAlert } from "./utils/alerting";
 import { rules } from "./utils/alertRules";
+import { healthRouter } from "./routes/health";
 
 // ── 5xx spike tracking (rolling 60s window) ───────────────────────────────────
 const fivexxTimestamps: number[] = [];
@@ -121,6 +122,14 @@ app.get("/api/health", async (_req: Request, res: Response) => {
     timestamp: new Date().toISOString(),
   });
 });
+
+/**
+ * GET /api/v1/health/deep
+ * Deep infrastructure health check — verifies DB connectivity, RPC reachability, and disk space.
+ * Excluded from JWT auth and rate-limit middleware intentionally.
+ * @returns 200 { db, rpc, disk } if all components healthy; 503 if any are degraded.
+ */
+app.use("/api/v1/health", healthRouter);
 
 app.use(correlationMiddleware);
 // Request ID middleware

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for GET /api/v1/health/deep
+ */
+import request from "supertest";
+import express, { Express } from "express";
+import { healthRouter } from "./health";
+
+// ── Mock dependencies ─────────────────────────────────────────────────────────
+
+jest.mock("../db/migrationRunner", () => ({
+  checkDbHealth: jest.fn(),
+}));
+
+jest.mock("../utils/rpcClient", () => ({
+  __esModule: true,
+  default: {
+    getHealth: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { checkDbHealth } from "../db/migrationRunner";
+import rpcClient from "../utils/rpcClient";
+
+const mockCheckDbHealth = checkDbHealth as jest.MockedFunction<typeof checkDbHealth>;
+const mockRpcGetHealth = rpcClient.getHealth as jest.MockedFunction<typeof rpcClient.getHealth>;
+
+// ── Test setup ────────────────────────────────────────────────────────────────
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/health", healthRouter);
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/health/deep", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  describe("all components healthy", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+      // disk check will use real fs — in CI the working dir always has > 500 MB free
+    });
+
+    it("returns 200", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.status).toBe(200);
+    });
+
+    it("returns { db: 'ok', rpc: 'ok' } at minimum", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.db).toBe("ok");
+      expect(res.body.rpc).toBe("ok");
+    });
+
+    it("response only contains db, rpc, and disk keys", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(Object.keys(res.body).sort()).toEqual(["db", "disk", "rpc"]);
+    });
+  });
+
+  describe("db degraded", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(false);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+    });
+
+    it("returns 503", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.status).toBe(503);
+    });
+
+    it("returns { db: 'degraded' }", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.db).toBe("degraded");
+    });
+
+    it("still reports rpc status correctly", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.rpc).toBe("ok");
+    });
+  });
+
+  describe("rpc degraded", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockRejectedValue(new Error("connection refused"));
+    });
+
+    it("returns 503", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.status).toBe(503);
+    });
+
+    it("returns { rpc: 'degraded' }", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.rpc).toBe("degraded");
+    });
+
+    it("still reports db status correctly", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.db).toBe("ok");
+    });
+  });
+
+  describe("disk degraded", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+    });
+
+    it("returns 503 when disk check fails", async () => {
+      // Override checkDiskHealth by mocking fs.statfs to simulate low disk
+      const origStatfs = (require("fs") as any).statfs;
+      (require("fs") as any).statfs = (
+        _path: string,
+        cb: (err: null, stats: { bfree: number; bsize: number }) => void
+      ) => cb(null, { bfree: 1, bsize: 1024 }); // 1 KB free — well below threshold
+
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.status).toBe(503);
+      expect(res.body.disk).toBe("degraded");
+
+      // Restore
+      if (origStatfs) (require("fs") as any).statfs = origStatfs;
+    });
+  });
+
+  describe("all components degraded", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(false);
+      mockRpcGetHealth.mockRejectedValue(new Error("rpc down"));
+    });
+
+    it("returns 503", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.status).toBe(503);
+    });
+
+    it("returns all statuses as degraded (except possibly disk)", async () => {
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.body.db).toBe("degraded");
+      expect(res.body.rpc).toBe("degraded");
+    });
+  });
+
+  describe("error envelope", () => {
+    it("responds with JSON content-type", async () => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+
+      const res = await request(app).get("/api/v1/health/deep");
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+  });
+});

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,92 @@
+/**
+ * Deep health check route
+ * GET /api/v1/health/deep
+ *
+ * Verifies DB connectivity, Soroban RPC reachability, and available disk space.
+ * Excluded from JWT auth and rate-limit middleware — registered before those are applied.
+ */
+
+import { Router, Request, Response } from "express";
+import { checkDbHealth } from "../db/migrationRunner";
+import rpcClient from "../utils/rpcClient";
+import logger from "../utils/logger";
+
+/** Minimum free disk bytes before reporting degraded (500 MB) */
+const DISK_MIN_FREE_BYTES = 500 * 1024 * 1024;
+
+type ComponentStatus = "ok" | "degraded";
+
+interface DeepHealthResponse {
+  db: ComponentStatus;
+  rpc: ComponentStatus;
+  disk: ComponentStatus;
+}
+
+/**
+ * Check available disk space on the current working directory partition.
+ * Uses Node's `fs.statfs` (Node 19+) and falls back to a child-process `df` call.
+ * Returns true when free space is above {@link DISK_MIN_FREE_BYTES}.
+ */
+async function checkDiskHealth(): Promise<boolean> {
+  return new Promise((resolve) => {
+    // fs.statfs is available from Node 19+; use a df fallback for older runtimes
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs") as typeof import("fs");
+    if (typeof (fs as any).statfs === "function") {
+      (fs as any).statfs(process.cwd(), (err: NodeJS.ErrnoException | null, stats: any) => {
+        if (err) {
+          logger.warn("disk health check failed (statfs)", { error: err.message });
+          return resolve(false);
+        }
+        const freeBytes: number = stats.bfree * stats.bsize;
+        resolve(freeBytes >= DISK_MIN_FREE_BYTES);
+      });
+    } else {
+      // Fallback: parse `df` output
+      const { exec } = require("child_process") as typeof import("child_process");
+      exec(`df -k "${process.cwd()}"`, (err, stdout) => {
+        if (err) {
+          logger.warn("disk health check failed (df)", { error: err.message });
+          return resolve(false);
+        }
+        // df output: Filesystem 1K-blocks Used Available Use% Mounted
+        const lines = stdout.trim().split("\n");
+        const parts = lines[lines.length - 1].trim().split(/\s+/);
+        const availableKb = parseInt(parts[3], 10);
+        if (isNaN(availableKb)) return resolve(false);
+        resolve(availableKb * 1024 >= DISK_MIN_FREE_BYTES);
+      });
+    }
+  });
+}
+
+const healthRouter = Router();
+
+/**
+ * GET /health/deep
+ *
+ * Returns the health status of each infrastructure component.
+ *
+ * @returns 200 `{ db, rpc, disk }` — all components healthy
+ * @returns 503 `{ db, rpc, disk }` — one or more components degraded
+ */
+healthRouter.get("/deep", async (_req: Request, res: Response) => {
+  const [dbHealthy, rpcHealthy, diskHealthy] = await Promise.allSettled([
+    checkDbHealth(),
+    rpcClient.getHealth().then(() => true).catch(() => false),
+    checkDiskHealth(),
+  ]).then((results) =>
+    results.map((r) => (r.status === "fulfilled" ? r.value : false))
+  );
+
+  const body: DeepHealthResponse = {
+    db: dbHealthy ? "ok" : "degraded",
+    rpc: rpcHealthy ? "ok" : "degraded",
+    disk: diskHealthy ? "ok" : "degraded",
+  };
+
+  const allHealthy = dbHealthy && rpcHealthy && diskHealthy;
+  res.status(allHealthy ? 200 : 503).json(body);
+});
+
+export { healthRouter, checkDiskHealth };

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -33,6 +33,7 @@ import {
 import { fireAlert } from "../utils/alerting";
 import { rules } from "../utils/alertRules";
 import rpcClient from "../utils/rpcClient";
+import { healthRouter } from "./health";
 const CONTRACT_ID = process.env.CONTRACT_ID || "";
 const NETWORK_PASSPHRASE =
   config.NEXT_PUBLIC_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
@@ -106,7 +107,10 @@ v1Router.use((_req: Request, res: Response, next: NextFunction) => {
   next();
 });
 
-// GET /health
+// GET /health/deep — deep infrastructure health check (no auth, no rate limit)
+v1Router.use("/health", healthRouter);
+
+// GET /health — shallow liveness check
 v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const uptime = Math.floor((Date.now() - startTime) / 1000);


### PR DESCRIPTION
## Summary

Added a deep health check endpoint GET /api/v1/health/deep that verifies actual infrastructure connectivity — DB, Soroban RPC, and disk space — beyond the existing shallow liveness check. Returns { db, rpc, disk } with "ok" or "degraded" per component, 200 if all healthy, 503 if any are degraded.

## Related Issue

Fixes #594 

## Changes

- Added backend/src/routes/health.ts with the deep health check handler
- Mounted health router in index.ts before JWT and rate-limit middleware to exclude it from both
- Registered health router in v1.ts for consistency
- Added JSDoc documentation to the new route and handler

## Testing

- 13 Jest integration tests added in health.test.ts
- Tests cover: all components healthy, each component degraded individually, all degraded, and response shape/content-type
- Ran npx jest src/routes/health.test.ts locally — all 13 passing
- No express-validator rules added — this is a GET endpoint with no body or params to validate

## Checklist

- [x] Branch is based on latest `main`
- [x] Commit messages follow Conventional Commits
- [x] Tests were run locally
- [x] Documentation updated if needed

