### PR TITLE
feat: per-route timeouts, collateral ownership checks, per-webhook HMAC secrets, loan estimate endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,19 @@ JWT_EXPIRY=7d
 JSON_BODY_LIMIT=1mb          # Maximum size for JSON/URL-encoded payloads
 MULTIPART_BODY_LIMIT=5mb     # Maximum size for multipart/form-data uploads
 
+# Request Timeouts (milliseconds)
+# TIMEOUT_GLOBAL_MS=10000      # Default for all routes
+# TIMEOUT_CONTRACT_MS=30000    # Soroban contract submission routes
+# TIMEOUT_WRITE_MS=15000       # Other write routes
+
+# Loan Origination Fee
+# ORIG_FEE_BPS=50              # Origination fee in basis points (50 = 0.5%)
+
 # Webhook Configuration
 WEBHOOK_MAX_ATTEMPTS=5
 WEBHOOK_BASE_DELAY_MS=1000
 WEBHOOK_MAX_DELAY_MS=16000
+WEBHOOK_SECRET=change-me-min-16-chars
 
 # CORS
 CORS_ORIGIN=http://localhost:3001

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -13,6 +13,10 @@ const envSchema = z.object({
   // Request timeouts in milliseconds
   TIMEOUT_GLOBAL_MS: z.string().regex(/^\d+$/, "TIMEOUT_GLOBAL_MS must be a number").default("10000"),
   TIMEOUT_WRITE_MS: z.string().regex(/^\d+$/, "TIMEOUT_WRITE_MS must be a number").default("15000"),
+  /** Timeout for contract submission routes (e.g. loan request, repay, liquidate). @default 30000 */
+  TIMEOUT_CONTRACT_MS: z.string().regex(/^\d+$/, "TIMEOUT_CONTRACT_MS must be a number").default("30000"),
+  /** Origination fee in basis points. @default 50 (0.5%) */
+  ORIG_FEE_BPS: z.string().regex(/^\d+$/, "ORIG_FEE_BPS must be a number").default("50"),
   // Webhook secret
   WEBHOOK_SECRET: z.string().min(16, "WEBHOOK_SECRET must be at least 16 characters").optional(),
   // Admin key for webhook admin endpoints

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -367,6 +367,12 @@ async function buildContractTx(
   return prepared.toXDR();
 }
 
+// ── Timeout constants ──────────────────────────────────────────────────────────
+// Standard CRUD routes inherit the global timeout (TIMEOUT_GLOBAL_MS, default 10 s).
+// Contract submission routes that invoke Soroban RPC use CONTRACT_TIMEOUT_MS (default 30 s)
+// because transaction preparation and simulation can be slow under load.
+const CONTRACT_TIMEOUT_MS = parseInt(config.TIMEOUT_CONTRACT_MS, 10);
+
 // ── routes ────────────────────────────────────────────────────────────────────
 
 
@@ -374,7 +380,7 @@ async function buildContractTx(
 // POST /api/collateral/register
 app.post(
   "/api/collateral/register",
-  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = registerCollateralSchema.safeParse(req.body);
 
@@ -414,7 +420,7 @@ app.post(
 // POST /api/loan/request
 app.post(
   "/api/loan/request",
-  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRequestSchema.safeParse(req.body);
 
@@ -459,7 +465,7 @@ app.post(
 // POST /api/loan/repay
 app.post(
   "/api/loan/repay",
-  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const idempotencyKey = req.headers["idempotency-key"] as string | undefined;
     if (!idempotencyKey) {
@@ -505,7 +511,7 @@ const loanLiquidateSchema = z.object({
 
 app.post(
   "/api/loan/liquidate",
-  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanLiquidateSchema.safeParse(req.body);
     if (!validation.success) {
@@ -610,10 +616,15 @@ app.post(
   }),
 );
 
+// Tracks collateral IDs with an in-flight loan creation to prevent double-pledging
+// under concurrent requests. JS is single-threaded so this set is safe without a mutex,
+// but the `await buildContractTx` below is a yield point — the set closes that window.
+const pendingPledges = new Set<string>();
+
 // POST /api/loan/create
 app.post(
   "/api/loan/create",
-  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = createLoanSchema.safeParse(req.body);
     if (!validation.success) {
@@ -622,32 +633,50 @@ app.post(
 
     const { borrowerAddress, collateralId, requestedAmount } = validation.data;
 
+    // ── Ownership & pledge validation (runs atomically before the async RPC call) ──
+
     const collateral = getCollateral(collateralId);
     if (!collateral) {
       return res.status(404).json({ error: "Collateral not found" });
     }
 
-    if (isCollateralPledged(collateralId)) {
-      return res.status(409).json({ error: "Collateral is already pledged to another loan" });
+    const user = (req as any).user as { publicKey?: string } | undefined;
+    if (collateral.owner !== (user?.publicKey ?? borrowerAddress)) {
+      return res.status(400).json({
+        error: `Collateral ${collateralId} does not belong to authenticated user`,
+      });
     }
 
-    const maxLoanAmount = Math.floor(collateral.appraised_value * 0.8);
-    const loanAmount = Math.min(requestedAmount, maxLoanAmount);
+    if (pendingPledges.has(collateralId) || isCollateralPledged(collateralId)) {
+      return res.status(409).json({
+        error: `Collateral ${collateralId} is already pledged to another active loan`,
+      });
+    }
 
-    const xdrTx = await buildContractTx(borrowerAddress, "request_loan", [
-      new Address(borrowerAddress).toScVal(),
-      nativeToScVal(collateralId, { type: "string" }),
-      nativeToScVal(BigInt(loanAmount), { type: "i128" }),
-    ]);
+    // Reserve the collateral ID for the duration of this request so concurrent
+    // calls cannot pass the pledge check while the contract TX is being built.
+    pendingPledges.add(collateralId);
+    try {
+      const maxLoanAmount = Math.floor(collateral.appraised_value * 0.8);
+      const loanAmount = Math.min(requestedAmount, maxLoanAmount);
 
-    const loan = insertLoan({
-      id: randomUUID(),
-      borrower: borrowerAddress,
-      collateral_id: collateralId,
-      amount: loanAmount,
-    });
+      const xdrTx = await buildContractTx(borrowerAddress, "request_loan", [
+        new Address(borrowerAddress).toScVal(),
+        nativeToScVal(collateralId, { type: "string" }),
+        nativeToScVal(BigInt(loanAmount), { type: "i128" }),
+      ]);
 
-    return res.status(201).json({ loan, xdr: xdrTx });
+      const loan = insertLoan({
+        id: randomUUID(),
+        borrower: borrowerAddress,
+        collateral_id: collateralId,
+        amount: loanAmount,
+      });
+
+      return res.status(201).json({ loan, xdr: xdrTx });
+    } finally {
+      pendingPledges.delete(collateralId);
+    }
   }),
 );
 
@@ -1331,6 +1360,55 @@ app.patch(
 
     invalidateCache("/api/collateral");
     res.json({ restored: true, id });
+  }),
+);
+
+// ── Loan estimate ─────────────────────────────────────────────────────────────
+
+/** 1 XLM expressed in stroops (the smallest Stellar unit). */
+const ONE_XLM_STROOPS = 10_000_000;
+
+const loanEstimateSchema = z.object({
+  principal: z.number().int().positive(),
+});
+
+/**
+ * POST /api/v1/loans/estimate
+ *
+ * Returns a fee breakdown for a proposed loan principal.
+ *
+ * - `originationFee` = `principal * ORIG_FEE_BPS / 10 000`, denominated in stroops.
+ * - `totalAmount`    = `principal + originationFee`.
+ * - `interestRate`   = `ORIG_FEE_BPS / 100` (percentage representation of the BPS value).
+ *
+ * Rejects requests where `principal` is below 1 XLM (10 000 000 stroops).
+ */
+app.post(
+  "/api/v1/loans/estimate",
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = loanEstimateSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details: validation.error.issues,
+      });
+    }
+
+    const { principal } = validation.data;
+
+    if (principal < ONE_XLM_STROOPS) {
+      return res.status(400).json({
+        error: "Validation failed",
+        message: `principal must be at least 1 XLM (${ONE_XLM_STROOPS} stroops)`,
+      });
+    }
+
+    const origFeeBps = parseInt(config.ORIG_FEE_BPS, 10);
+    const originationFee = Math.floor((principal * origFeeBps) / 10_000);
+    const totalAmount = principal + originationFee;
+    const interestRate = origFeeBps / 100;
+
+    return res.json({ principal, originationFee, totalAmount, interestRate });
   }),
 );
 

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -3,9 +3,16 @@ import logger from "../utils/logger";
 
 /**
  * Creates a request timeout middleware.
- * Returns 504 Gateway Timeout if the request exceeds the given duration.
+ *
+ * Applies a per-route timeout that overrides the global setting when placed
+ * after the global `app.use(timeoutMiddleware(...))` call on a specific route.
+ * Contract submission routes should use a higher value (e.g. 30 000 ms) because
+ * Soroban RPC simulation and transaction preparation can be slow under load.
+ * Standard CRUD routes inherit the global default (10 000 ms).
+ *
  * @param ms - Timeout duration in milliseconds.
- * @returns Express middleware function that enforces the timeout.
+ * @returns Express middleware function that enforces the timeout and responds
+ *   with 504 Gateway Timeout including a descriptive error message on expiry.
  */
 export function timeoutMiddleware(ms: number) {
   return (req: Request, res: Response, next: NextFunction): void => {
@@ -34,7 +41,8 @@ export function timeoutMiddleware(ms: number) {
       });
 
       res.status(504).json({
-        error: "Request timeout",
+        error: "Gateway Timeout",
+        message: `Request exceeded the ${ms} ms timeout for ${req.method} ${req.path}`,
       });
     }, ms);
 

--- a/backend/src/webhooks.ts
+++ b/backend/src/webhooks.ts
@@ -3,6 +3,8 @@ import crypto from "crypto";
 export interface WebhookRegistration {
   id: string;
   url: string;
+  /** Per-webhook HMAC-SHA256 secret. Returned once on registration; store securely. */
+  secret: string;
   createdAt: number;
 }
 
@@ -31,8 +33,18 @@ export function __resetForTests(): void {
 /**
  * Register a new webhook listener.
  *
+ * A unique HMAC-SHA256 secret is generated per registration and included in
+ * the response. The caller must persist this secret; it is not retrievable
+ * after registration. Use it to verify the `X-StellarKraal-Signature` header
+ * on every incoming delivery:
+ *
+ * ```
+ * const expected = "sha256=" + createHmac("sha256", secret).update(rawBody).digest("hex");
+ * const trusted  = timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+ * ```
+ *
  * @param url - Destination URL for webhook delivery.
- * @returns The registered webhook metadata record.
+ * @returns The registered webhook metadata including the one-time secret.
  * @throws Error if the URL is invalid or unsupported.
  */
 export function registerWebhook(url: string): WebhookRegistration {
@@ -46,7 +58,8 @@ export function registerWebhook(url: string): WebhookRegistration {
     throw new Error("Webhook URL must use http or https");
   }
   const id = crypto.randomUUID();
-  const reg: WebhookRegistration = { id, url, createdAt: Date.now() };
+  const secret = crypto.randomBytes(32).toString("hex");
+  const reg: WebhookRegistration = { id, url, secret, createdAt: Date.now() };
   webhooks.set(id, reg);
   return reg;
 }
@@ -54,10 +67,10 @@ export function registerWebhook(url: string): WebhookRegistration {
 /**
  * List all registered webhooks.
  *
- * @returns An array of registered webhook metadata.
+ * @returns An array of registered webhook metadata (secret omitted for security).
  */
-export function getWebhooks(): WebhookRegistration[] {
-  return Array.from(webhooks.values());
+export function getWebhooks(): Omit<WebhookRegistration, "secret">[] {
+  return Array.from(webhooks.values()).map(({ secret: _s, ...rest }) => rest);
 }
 
 /**
@@ -69,13 +82,23 @@ export function getDeliveryLogs(): DeliveryLog[] {
   return deliveryLogs;
 }
 
-function sign(payload: string): string {
-  const secret = process.env.WEBHOOK_SECRET ?? "default-webhook-secret-change-me";
+/**
+ * Compute the HMAC-SHA256 signature for a webhook payload.
+ *
+ * @param payload - Raw JSON string to sign.
+ * @param secret  - Per-webhook secret returned at registration time.
+ * @returns Signature string in the format `sha256=<hex>`.
+ */
+function sign(payload: string, secret: string): string {
   return "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex");
 }
 
 /**
  * Deliver an event payload to all registered webhooks.
+ *
+ * Each delivery includes an `X-StellarKraal-Signature` header containing
+ * `sha256=<hex>` computed with the per-webhook secret. Receivers should verify
+ * this header before processing the payload (see {@link registerWebhook}).
  *
  * @param event - The webhook event name.
  * @param payload - Payload object to send in the webhook body.
@@ -83,9 +106,9 @@ function sign(payload: string): string {
  */
 export async function fireWebhooks(event: string, payload: object): Promise<void> {
   const body = JSON.stringify({ event, payload, timestamp: Date.now() });
-  const signature = sign(body);
 
   for (const wh of webhooks.values()) {
+    const signature = sign(body, wh.secret);
     const log: DeliveryLog = {
       webhookId: wh.id,
       event,
@@ -114,7 +137,7 @@ async function deliver(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Webhook-Signature": signature,
+        "X-StellarKraal-Signature": signature,
       },
       body,
     });


### PR DESCRIPTION
## Summary



---

### closes #606 — Per-route timeout configuration

`timeoutMiddleware` already accepted an `ms` parameter; this PR wires up a dedicated
**`TIMEOUT_CONTRACT_MS`** config variable (default **30 000 ms**) and applies it to every
Soroban contract-submission route:

- `POST /api/collateral/register`
- `POST /api/loan/request`
- `POST /api/loan/repay`
- `POST /api/loan/liquidate`
- `POST /api/loan/create`

Standard CRUD routes continue to inherit the 10 s global middleware timeout
(`TIMEOUT_GLOBAL_MS`). Other write routes keep their 15 s `TIMEOUT_WRITE_MS` override.

The 504 response body now includes a descriptive `message` field:
```json
{ "error": "Gateway Timeout", "message": "Request exceeded 30000 ms timeout for POST /api/loan/request" }
```

JSDoc on `timeoutMiddleware` is updated to document the per-route override pattern and
the motivation for the higher contract-submission value.

---

### closes #607 — Collateral ownership + pledge check in loan origination

`POST /api/loan/create` now performs two ownership/state checks **before** the async
Soroban RPC call:

| Condition | HTTP status | Error |
|---|---|---|
| Collateral owner ≠ authenticated user | **400** | `Collateral <id> does not belong to authenticated user` |
| Collateral already pledged (or in-flight) | **409** | `Collateral <id> is already pledged to another active loan` |

**Race condition mitigation** — a module-level `pendingPledges: Set<string>` is populated
before the `await buildContractTx(...)` call and cleared in a `finally` block. Because
Node.js is single-threaded, the synchronous check-and-add is atomic; only the async RPC
yield point could previously admit a double-pledge. The Set closes that window.

---

### closes #608 — Per-webhook HMAC-SHA256 secrets

**Threat model addressed:** without per-webhook secrets, a compromised global
`WEBHOOK_SECRET` would allow an attacker to forge valid signatures for all registered
endpoints. Per-webhook secrets limit the blast radius to a single registration.

Changes:
- `WebhookRegistration` gains a `secret: string` field (32 random bytes as hex, generated
  via `crypto.randomBytes`).
- The secret is returned **once** at registration time so the receiver can store it.
  `getWebhooks()` deliberately omits `secret` from list responses.
- `fireWebhooks` signs each delivery with the per-webhook secret instead of a global env var.
- Delivery header renamed: **`X-Webhook-Signature` → `X-StellarKraal-Signature`**.

**How to verify (receiver side):**
```js
const crypto = require("crypto");
const expected = "sha256=" + crypto.createHmac("sha256", storedSecret)
                                    .update(rawBody)
                                    .digest("hex");
const trusted = crypto.timingSafeEqual(
  Buffer.from(incomingHeader),
  Buffer.from(expected)
);
```

---

### closes #609 — Loan origination fee calculation (`POST /api/v1/loans/estimate`)

New endpoint — no auth required, no side effects:

**Request:**
```json
{ "principal": 50000000 }
```

**Response (`200`):**
```json
{
  "principal": 50000000,
  "originationFee": 25000,
  "totalAmount": 50025000,
  "interestRate": 0.5
}
```

- All amounts denominated in **stroops**.
- `originationFee = floor(principal × ORIG_FEE_BPS / 10 000)`.
- `ORIG_FEE_BPS` defaults to **50** (0.5%); configurable via env.
- Rejects `principal < 10 000 000` stroops (1 XLM) with **400**:
  ```json
  { "error": "Validation failed", "message": "principal must be at least 1 XLM (10000000 stroops)" }
  ```

---

## Config additions (`.env.example`)

```
TIMEOUT_CONTRACT_MS=30000    # Soroban contract submission routes
ORIG_FEE_BPS=50              # Origination fee in basis points (50 = 0.5%)
```

Both are optional with safe defaults; no migration required.