### PR TITLE
feat: support ALLOWED_ORIGINS env var for configurable CORS

### DIFF
--- a/ALLOWED_ORIGINS/README.md
+++ b/ALLOWED_ORIGINS/README.md
@@ -1,0 +1,37 @@
+# ALLOWED_ORIGINS
+
+The `ALLOWED_ORIGINS` environment variable controls which origins the backend permits via CORS.
+
+## Format
+
+Comma-separated list of HTTP(S) URLs:
+
+```
+ALLOWED_ORIGINS=https://app.example.com,https://staging.example.com
+```
+
+## Rules
+
+| Environment | Wildcard `*` | HTTP origins | HTTPS origins |
+|-------------|-------------|--------------|---------------|
+| development / test | ✅ allowed | ✅ | ✅ |
+| production | ❌ startup error | ✅ | ✅ |
+
+- Invalid patterns (missing scheme, `ftp://`, etc.) **fail startup validation**.
+- Takes precedence over `FRONTEND_URL` when set.
+- Trailing/leading whitespace around each origin is stripped.
+
+## Examples
+
+```bash
+# Local development — allow any origin
+ALLOWED_ORIGINS=*
+
+# Staging — two specific origins
+ALLOWED_ORIGINS=https://staging.stellarkraal.example.com,https://app.stellarkraal.example.com
+
+# Production — single origin
+ALLOWED_ORIGINS=https://app.stellarkraal.example.com
+```
+
+See also: [`env.example`](../env.example), [`backend/src/middleware/cors.ts`](../backend/src/middleware/cors.ts).

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -28,6 +28,24 @@ const envSchema = z.object({
   NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   // Frontend URL for CORS
   FRONTEND_URL: z.string().url("FRONTEND_URL must be a valid URL").optional(),
+  // Comma-separated list of allowed CORS origins.
+  // Wildcard "*" is rejected in production.
+  ALLOWED_ORIGINS: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        const isProduction = process.env.NODE_ENV === "production";
+        const origins = val.split(",").map((o) => o.trim()).filter(Boolean);
+        if (isProduction && origins.includes("*")) return false;
+        return origins.every((o) => o === "*" || /^https?:\/\/.+/.test(o));
+      },
+      {
+        message:
+          'ALLOWED_ORIGINS must be comma-separated HTTP(S) URLs; wildcard "*" is not allowed in production',
+      },
+    ),
   /**
    * Graceful shutdown drain timeout in milliseconds.
    * The server waits up to this duration for in-flight requests to complete

--- a/backend/src/middleware/cors.test.ts
+++ b/backend/src/middleware/cors.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration tests for CORS middleware — ALLOWED_ORIGINS env var behaviour.
+ */
+import { parseAllowedOrigins } from "./cors";
+
+const PROD_ENV = "production";
+const DEV_ENV = "development";
+
+describe("parseAllowedOrigins", () => {
+  const origEnv = process.env.NODE_ENV;
+  afterEach(() => { process.env.NODE_ENV = origEnv; });
+
+  // ── allowed origins parsing ────────────────────────────────────────────
+  it("returns null when env var is undefined", () => {
+    expect(parseAllowedOrigins(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseAllowedOrigins("")).toBeNull();
+  });
+
+  it("parses a single origin", () => {
+    expect(parseAllowedOrigins("https://app.example.com")).toEqual([
+      "https://app.example.com",
+    ]);
+  });
+
+  it("parses comma-separated origins", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(
+      parseAllowedOrigins(
+        "https://app.example.com,https://staging.example.com",
+      ),
+    ).toEqual(["https://app.example.com", "https://staging.example.com"]);
+  });
+
+  it("trims whitespace around each origin", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(
+      parseAllowedOrigins(" https://a.com , https://b.com "),
+    ).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("allows wildcard in non-production", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(parseAllowedOrigins("*")).toEqual(["*"]);
+  });
+
+  // ── production wildcard rejection ─────────────────────────────────────
+  it("throws when wildcard is used in production", () => {
+    process.env.NODE_ENV = PROD_ENV;
+    expect(() => parseAllowedOrigins("*")).toThrow(/wildcard.*not permitted in production/i);
+  });
+
+  it("throws when wildcard is mixed with origins in production", () => {
+    process.env.NODE_ENV = PROD_ENV;
+    expect(() =>
+      parseAllowedOrigins("https://app.example.com,*"),
+    ).toThrow(/wildcard.*not permitted in production/i);
+  });
+
+  // ── invalid pattern rejection ──────────────────────────────────────────
+  it("throws for an invalid origin pattern (no scheme)", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(() => parseAllowedOrigins("not-a-url")).toThrow(/invalid origin pattern/i);
+  });
+
+  it("throws for ftp:// scheme (only http/https allowed)", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(() => parseAllowedOrigins("ftp://example.com")).toThrow(/invalid origin pattern/i);
+  });
+
+  it("does not throw for valid http:// in non-production", () => {
+    process.env.NODE_ENV = DEV_ENV;
+    expect(() => parseAllowedOrigins("http://localhost:3000")).not.toThrow();
+  });
+
+  it("does not throw for valid https:// in production", () => {
+    process.env.NODE_ENV = PROD_ENV;
+    expect(() =>
+      parseAllowedOrigins("https://app.example.com,https://api.example.com"),
+    ).not.toThrow();
+  });
+
+  // ── multiple origins in production ────────────────────────────────────
+  it("accepts multiple HTTPS origins in production", () => {
+    process.env.NODE_ENV = PROD_ENV;
+    const result = parseAllowedOrigins(
+      "https://app.example.com,https://staging.example.com",
+    );
+    expect(result).toEqual([
+      "https://app.example.com",
+      "https://staging.example.com",
+    ]);
+  });
+});

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -2,41 +2,87 @@ import cors from "cors";
 import { RequestHandler, Request, Response, NextFunction } from "express";
 import logger from "../utils/logger";
 
-// Warn at startup if FRONTEND_URL is missing in production
-if (process.env.NODE_ENV === "production" && !process.env.FRONTEND_URL) {
+const isProduction = process.env.NODE_ENV === "production";
+
+/**
+ * Parse ALLOWED_ORIGINS env var into a set of allowed origins.
+ * Throws at startup if a wildcard is present in production or a pattern is invalid.
+ */
+export function parseAllowedOrigins(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  const origins = raw
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  const prod = process.env.NODE_ENV === "production";
+
+  for (const o of origins) {
+    if (o === "*") {
+      if (prod) {
+        throw new Error(
+          'ALLOWED_ORIGINS: wildcard "*" is not permitted in production (NODE_ENV=production)',
+        );
+      }
+      continue;
+    }
+    if (!/^https?:\/\/.+/.test(o)) {
+      throw new Error(`ALLOWED_ORIGINS: invalid origin pattern "${o}" — must be an HTTP(S) URL or "*"`);
+    }
+  }
+
+  return origins;
+}
+
+// Parse and validate at module load time (startup validation).
+const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+
+if (!allowedOrigins && isProduction && !process.env.FRONTEND_URL) {
   logger.warn(
-    "CORS misconfiguration: FRONTEND_URL is not set in production. Requests from the frontend will be blocked.",
+    "CORS misconfiguration: neither ALLOWED_ORIGINS nor FRONTEND_URL is set in production. " +
+      "Requests from the frontend will be blocked.",
   );
 }
 
-// Authenticated routes require credentials; wildcard origin is incompatible with credentials.
 function isAuthRoute(path: string): boolean {
   return path.startsWith("/api") && path !== "/api/health";
 }
 
+function resolveOrigin(
+  req: Request,
+): cors.CorsOptions["origin"] {
+  const authRoute = isAuthRoute(req.path);
+
+  // ALLOWED_ORIGINS takes precedence over FRONTEND_URL
+  if (allowedOrigins) {
+    if (allowedOrigins.includes("*")) {
+      return authRoute ? true : "*";
+    }
+    return (origin, cb) => {
+      if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
+      cb(null, false);
+    };
+  }
+
+  const frontendUrl = process.env.FRONTEND_URL;
+  return isProduction
+    ? frontendUrl || false
+    : frontendUrl || (authRoute ? true : "*");
+}
+
 /**
- * Express middleware that applies CORS policy for frontend and authenticated API routes.
- * In production, only the configured `FRONTEND_URL` is allowed.
- *
- * @param req - Incoming Express request.
- * @param res - Express response object.
- * @param next - Next middleware callback.
+ * Express middleware that applies CORS policy.
+ * Reads allowed origins from ALLOWED_ORIGINS (comma-separated) or falls back to FRONTEND_URL.
+ * Wildcard "*" is rejected in production.
  */
 export const corsMiddleware: RequestHandler = (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  const isProduction = process.env.NODE_ENV === "production";
-  const frontendUrl = process.env.FRONTEND_URL;
   const authRoute = isAuthRoute(req.path);
-
-  const origin: cors.CorsOptions["origin"] = isProduction
-    ? frontendUrl || false
-    : frontendUrl || (authRoute ? true : "*");
-
   cors({
-    origin,
+    origin: resolveOrigin(req),
     credentials: authRoute,
     maxAge: 86400,
   })(req, res, next);

--- a/env.example
+++ b/env.example
@@ -73,6 +73,13 @@ NODE_ENV=development
 # Optional (required in production). [GitHub Secret: FRONTEND_URL]
 FRONTEND_URL=http://localhost:3000
 
+# Comma-separated list of allowed CORS origins.
+# Takes precedence over FRONTEND_URL when set.
+# Wildcard "*" is only permitted in non-production environments.
+# Format : comma-separated HTTP(S) URLs, e.g. https://app.example.com,https://staging.example.com
+# Optional. [GitHub Secret: ALLOWED_ORIGINS]
+# ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+
 # JWT secret used to sign and verify access tokens.
 # Must be at least 32 characters in production.
 # Generate with: openssl rand -hex 32


### PR DESCRIPTION
- Parse comma-separated ALLOWED_ORIGINS in cors.ts; takes precedence over FRONTEND_URL
- Wildcard '*' rejected at startup when NODE_ENV=production
- Invalid origin patterns (missing scheme, ftp://, etc.) throw on load
- Add ALLOWED_ORIGINS validation in config.ts env schema
- Update env.example with ALLOWED_ORIGINS documentation
- Add ALLOWED_ORIGINS/README.md with usage examples
- Add cors.test.ts with 13 tests covering allowed origins, wildcard rejection in production, and invalid pattern errors

Closes #635

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please
