### PR TITLE
feat: health probes, CORS max-age, Soroban error mapping, DELETE webhook

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -78,6 +78,7 @@ import {
   type UpdateCollateralInput,
 } from "./validators/collateral";
 import rpcClient from "./utils/rpcClient";
+import { mapSorobanError } from "./utils/sorobanErrors";
 import { registerWebhook, getWebhooks, getDeliveryLogs, fireWebhooks } from "./webhooks";
 import { scheduleHealthFactorJob } from "./jobs/healthFactorJob";
 import { httpActiveConnections, httpRequestDurationSeconds, httpRequestsTotal } from "./metrics";
@@ -365,8 +366,12 @@ async function buildContractTx(
     .setTimeout(30)
     .build();
 
-  const prepared = await rpcClient.prepareTransaction(tx);
-  return prepared.toXDR();
+  try {
+    const prepared = await rpcClient.prepareTransaction(tx);
+    return prepared.toXDR();
+  } catch (err) {
+    throw mapSorobanError(err);
+  }
 }
 
 // ── Timeout constants ──────────────────────────────────────────────────────────

--- a/backend/src/middleware/cors.test.ts
+++ b/backend/src/middleware/cors.test.ts
@@ -1,7 +1,9 @@
 /**
  * Integration tests for CORS middleware — ALLOWED_ORIGINS env var behaviour.
  */
-import { parseAllowedOrigins } from "./cors";
+import request from "supertest";
+import express from "express";
+import { parseAllowedOrigins, corsMiddleware } from "./cors";
 
 const PROD_ENV = "production";
 const DEV_ENV = "development";
@@ -92,5 +94,20 @@ describe("parseAllowedOrigins", () => {
       "https://app.example.com",
       "https://staging.example.com",
     ]);
+  });
+});
+
+describe("corsMiddleware preflight caching", () => {
+  it("sets Access-Control-Max-Age to 600 on OPTIONS preflight", async () => {
+    const app = express();
+    app.use(corsMiddleware);
+    app.get("/api/test", (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://example.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-max-age"]).toBe("600");
   });
 });

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -84,6 +84,6 @@ export const corsMiddleware: RequestHandler = (
   cors({
     origin: resolveOrigin(req),
     credentials: authRoute,
-    maxAge: 86400,
+    maxAge: 600,
   })(req, res, next);
 };

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -45,6 +45,91 @@ function buildApp(): Express {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+describe("GET /api/v1/health/live", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  it("returns 200", async () => {
+    const res = await request(app).get("/api/v1/health/live");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns { status: 'alive' }", async () => {
+    const res = await request(app).get("/api/v1/health/live");
+    expect(res.body.status).toBe("alive");
+  });
+
+  it("responds with JSON content-type", async () => {
+    const res = await request(app).get("/api/v1/health/live");
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+});
+
+describe("GET /api/v1/health/ready", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  describe("all dependencies reachable", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+    });
+
+    it("returns 200", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.status).toBe(200);
+    });
+
+    it("returns { status: 'ready', db: 'ok', rpc: 'ok' }", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.body).toMatchObject({ status: "ready", db: "ok", rpc: "ok" });
+    });
+  });
+
+  describe("db unreachable", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(false);
+      mockRpcGetHealth.mockResolvedValue({ status: "healthy" } as any);
+    });
+
+    it("returns 503", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.status).toBe(503);
+    });
+
+    it("returns { status: 'not_ready', db: 'degraded' }", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.body.status).toBe("not_ready");
+      expect(res.body.db).toBe("degraded");
+    });
+  });
+
+  describe("rpc unreachable", () => {
+    beforeEach(() => {
+      mockCheckDbHealth.mockResolvedValue(true);
+      mockRpcGetHealth.mockRejectedValue(new Error("connection refused"));
+    });
+
+    it("returns 503", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.status).toBe(503);
+    });
+
+    it("returns { status: 'not_ready', rpc: 'degraded' }", async () => {
+      const res = await request(app).get("/api/v1/health/ready");
+      expect(res.body.status).toBe("not_ready");
+      expect(res.body.rpc).toBe("degraded");
+    });
+  });
+});
+
 describe("GET /api/v1/health/deep", () => {
   let app: Express;
 

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -63,6 +63,43 @@ async function checkDiskHealth(): Promise<boolean> {
 const healthRouter = Router();
 
 /**
+ * GET /health/live
+ *
+ * Liveness probe — confirms the process is running and can accept requests.
+ * No dependency checks; Kubernetes restarts the pod only when this fails.
+ *
+ * @returns 200 `{ status: "alive" }`
+ */
+healthRouter.get("/live", (_req: Request, res: Response) => {
+  res.status(200).json({ status: "alive" });
+});
+
+/**
+ * GET /health/ready
+ *
+ * Readiness probe — confirms external dependencies (DB, Soroban RPC) are
+ * reachable. Kubernetes stops routing traffic when this returns 503.
+ *
+ * @returns 200 `{ status: "ready", db, rpc }` — all dependencies reachable
+ * @returns 503 `{ status: "not_ready", db, rpc }` — one or more unreachable
+ */
+healthRouter.get("/ready", async (_req: Request, res: Response) => {
+  const [dbHealthy, rpcHealthy] = await Promise.allSettled([
+    checkDbHealth(),
+    rpcClient.getHealth().then(() => true).catch(() => false),
+  ]).then((results) =>
+    results.map((r) => (r.status === "fulfilled" ? r.value : false))
+  );
+
+  const ready = dbHealthy && rpcHealthy;
+  res.status(ready ? 200 : 503).json({
+    status: ready ? "ready" : "not_ready",
+    db: dbHealthy ? "ok" : "degraded",
+    rpc: rpcHealthy ? "ok" : "degraded",
+  });
+});
+
+/**
  * GET /health/deep
  *
  * Returns the health status of each infrastructure component.

--- a/backend/src/routes/v1.integration.test.ts
+++ b/backend/src/routes/v1.integration.test.ts
@@ -7,6 +7,7 @@ import request from "supertest";
 import express, { Express } from "express";
 import { v1Router } from "./v1";
 import { insertCollateral, insertLoan } from "../db/store";
+import { __resetForTests } from "../webhooks";
 
 const VALID_ADDRESS = "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6";
 const INVALID_ADDRESS = "INVALID_KEY";
@@ -598,6 +599,34 @@ describe("API v1 Integration Tests", () => {
       const loanRecordRes = await request(app).get("/api/v1/loan/1");
       expect(loanRecordRes.status).toBe(200);
       expect(loanRecordRes.body.result).toBeDefined();
+    });
+  });
+
+  // ── DELETE /api/v1/webhooks/:id ───────────────────────────────────────────
+
+  describe("DELETE /api/v1/webhooks/:id", () => {
+    beforeEach(() => {
+      __resetForTests();
+    });
+
+    it("returns 204 and removes an existing webhook", async () => {
+      const createRes = await request(app)
+        .post("/api/v1/webhooks")
+        .send({ url: "https://example.com/hook" });
+      expect(createRes.status).toBe(201);
+      const { id } = createRes.body;
+
+      const deleteRes = await request(app).delete(`/api/v1/webhooks/${id}`);
+      expect(deleteRes.status).toBe(204);
+
+      const listRes = await request(app).get("/api/v1/admin/webhooks");
+      expect(listRes.body.some((w: { id: string }) => w.id === id)).toBe(false);
+    });
+
+    it("returns 404 when the webhook does not exist", async () => {
+      const res = await request(app).delete("/api/v1/webhooks/non-existent-id");
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Webhook not found");
     });
   });
 

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -8,7 +8,7 @@ import { config } from "../config";
 import { pool } from "../utils/connectionPool";
 import { invalidateAll } from "../utils/appraisalCache";
 import { asyncHandler } from "../utils/asyncHandler";
-import { registerWebhook, getWebhooks, getDeliveryLogs } from "../webhooks";
+import { registerWebhook, getWebhooks, getDeliveryLogs, deleteWebhook } from "../webhooks";
 import { timeoutMiddleware } from "../middleware/timeout";
 import { writeLimiter } from "../middleware/rateLimit";
 import { deprecationHeadersWhen } from "../middleware/deprecation";
@@ -239,6 +239,15 @@ v1Router.get("/admin/webhooks", (_req: Request, res: Response) => {
 
 v1Router.get("/admin/webhooks/logs", (_req: Request, res: Response) => {
   res.json(getDeliveryLogs());
+});
+
+v1Router.delete("/webhooks/:id", (req: Request, res: Response) => {
+  const { id } = req.params;
+  const deleted = deleteWebhook(id as string);
+  if (!deleted) {
+    return res.status(404).json({ error: "Webhook not found", message: `No webhook with id '${id}'` });
+  }
+  res.status(204).send();
 });
 
 v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {

--- a/backend/src/utils/sorobanErrors.test.ts
+++ b/backend/src/utils/sorobanErrors.test.ts
@@ -1,0 +1,60 @@
+import { mapSorobanError } from "./sorobanErrors";
+
+describe("mapSorobanError", () => {
+  it("maps known contract error codes to human-readable messages", () => {
+    const err = new Error("HostError: Error(Contract, #4)");
+    const result = mapSorobanError(err);
+    expect(result.message).toBe(
+      "Insufficient collateral: loan amount exceeds the maximum allowed by the LTV ratio"
+    );
+  });
+
+  it("maps error code 1 (NotInitialized)", () => {
+    const err = new Error("simulation failed: Error(Contract, #1)");
+    expect(mapSorobanError(err).message).toBe("Contract is not initialized");
+  });
+
+  it("maps error code 3 (Unauthorized)", () => {
+    const err = new Error("Error(Contract, #3)");
+    expect(mapSorobanError(err).message).toBe(
+      "Unauthorized: caller does not have the required permissions"
+    );
+  });
+
+  it("maps error code 5 (LoanNotFound)", () => {
+    const err = new Error("Error(Contract, #5)");
+    expect(mapSorobanError(err).message).toBe("Loan not found");
+  });
+
+  it("maps error code 13 (ContractPaused)", () => {
+    const err = new Error("Error(Contract, #13)");
+    expect(mapSorobanError(err).message).toBe(
+      "Contract is paused — new operations are temporarily disabled"
+    );
+  });
+
+  it("returns 'Contract error code N' for unknown codes", () => {
+    const err = new Error("Error(Contract, #99)");
+    expect(mapSorobanError(err).message).toBe("Contract error code 99");
+  });
+
+  it("passes through non-contract errors unchanged", () => {
+    const err = new Error("network timeout");
+    const result = mapSorobanError(err);
+    expect(result).toBe(err);
+    expect(result.message).toBe("network timeout");
+  });
+
+  it("wraps string errors in an Error", () => {
+    const result = mapSorobanError("something went wrong");
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("something went wrong");
+  });
+
+  it("handles error code with extra whitespace after hash", () => {
+    const err = new Error("Error(Contract, #  7)");
+    // Whitespace between # and digits won't match — returned unchanged
+    const result = mapSorobanError(err);
+    expect(result.message).toBe("Error(Contract, #  7)");
+  });
+});

--- a/backend/src/utils/sorobanErrors.ts
+++ b/backend/src/utils/sorobanErrors.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps Soroban contract error codes to human-readable messages.
+ * Codes correspond to the `Error` enum in contracts/stellarkraal/src/lib.rs.
+ */
+
+const SOROBAN_ERROR_MESSAGES: Record<number, string> = {
+  1:  "Contract is not initialized",
+  2:  "Contract is already initialized",
+  3:  "Unauthorized: caller does not have the required permissions",
+  4:  "Insufficient collateral: loan amount exceeds the maximum allowed by the LTV ratio",
+  5:  "Loan not found",
+  6:  "Collateral not found",
+  7:  "Health factor is safe: loan is not eligible for liquidation",
+  8:  "Invalid amount: value must be positive and must not cause overflow",
+  9:  "Loan is already closed",
+  10: "Invalid fee rate: rate exceeds the protocol maximum of 5%",
+  11: "Exceeds close factor: repay amount is above the close-factor cap",
+  12: "Invalid close factor: value must be between 1 and 10 000 bps",
+  13: "Contract is paused — new operations are temporarily disabled",
+  14: "Oracle is already registered",
+  15: "Oracle limit reached: maximum number of oracles has been registered",
+  16: "Oracle not found",
+  17: "Insufficient oracle quorum: not enough valid price submissions",
+  18: "Invalid price: price value is out of bounds or otherwise invalid",
+  19: "Contract is not paused",
+};
+
+// Matches Soroban host-error strings like: Error(Contract, #4)
+const CONTRACT_ERROR_RE = /Error\(Contract,\s*#(\d+)\)/;
+
+/**
+ * Convert a raw Soroban RPC error into a human-readable Error.
+ *
+ * If the error message contains a contract error code, it is replaced with
+ * the corresponding description from {@link SOROBAN_ERROR_MESSAGES}.
+ * Unknown codes produce "Contract error code N" so callers always get a
+ * meaningful string rather than a raw numeric code.
+ *
+ * Non-contract errors are returned unchanged.
+ */
+export function mapSorobanError(err: unknown): Error {
+  const message = err instanceof Error ? err.message : String(err);
+  const match = CONTRACT_ERROR_RE.exec(message);
+  if (match) {
+    const code = parseInt(match[1], 10);
+    const description = SOROBAN_ERROR_MESSAGES[code] ?? `Contract error code ${code}`;
+    return new Error(description);
+  }
+  return err instanceof Error ? err : new Error(message);
+}

--- a/backend/src/webhooks.test.ts
+++ b/backend/src/webhooks.test.ts
@@ -3,6 +3,7 @@ import {
   registerWebhook,
   getWebhooks,
   getDeliveryLogs,
+  deleteWebhook,
   fireWebhooks,
   __resetForTests,
 } from "./webhooks";
@@ -47,6 +48,27 @@ describe("registerWebhook", () => {
     expect(() => registerWebhook("ftp://example.com/hook")).toThrow(
       "Webhook URL must use http or https"
     );
+  });
+});
+
+// ── deleteWebhook ─────────────────────────────────────────────────────────────
+
+describe("deleteWebhook", () => {
+  it("returns true and removes the webhook when it exists", () => {
+    const reg = registerWebhook(WEBHOOK_URL);
+    expect(deleteWebhook(reg.id)).toBe(true);
+    expect(getWebhooks().some((w) => w.id === reg.id)).toBe(false);
+  });
+
+  it("returns false when the webhook does not exist", () => {
+    expect(deleteWebhook("non-existent-id")).toBe(false);
+  });
+
+  it("does not affect other registered webhooks", () => {
+    const reg1 = registerWebhook("https://a.example.com/hook");
+    const reg2 = registerWebhook("https://b.example.com/hook");
+    deleteWebhook(reg1.id);
+    expect(getWebhooks().some((w) => w.id === reg2.id)).toBe(true);
   });
 });
 

--- a/backend/src/webhooks.ts
+++ b/backend/src/webhooks.ts
@@ -74,6 +74,16 @@ export function getWebhooks(): Omit<WebhookRegistration, "secret">[] {
 }
 
 /**
+ * Deregister a webhook by ID.
+ *
+ * @param id - The unique webhook ID returned at registration time.
+ * @returns `true` if the webhook was found and removed, `false` if not found.
+ */
+export function deleteWebhook(id: string): boolean {
+  return webhooks.delete(id);
+}
+
+/**
  * Retrieve the current webhook delivery log entries.
  *
  * @returns An array of delivery log entries for recent webhook attempts.


### PR DESCRIPTION
## Summary

- **#622** — Split `/health` into `/health/live` (liveness: always 200 if process is up) and `/health/ready` (readiness: 200/503 based on DB + RPC reachability). Both added to `healthRouter` so they are accessible at `/api/v1/health/live` and `/api/v1/health/ready`.
- **#621** — Changed `Access-Control-Max-Age` from `86400` to `600` seconds in the CORS middleware. Browsers will now cache preflight results for 10 minutes instead of 24 hours, matching the issue spec.
- **#619** — Created `backend/src/utils/sorobanErrors.ts` mapping Soroban contract error codes 1–19 to human-readable descriptions (e.g. code 4 → "Insufficient collateral: loan amount exceeds the maximum allowed by the LTV ratio"). `buildContractTx` now wraps `prepareTransaction` errors through `mapSorobanError` before propagating to the client.
- **#614** — Added `deleteWebhook(id)` to `webhooks.ts` and `DELETE /webhooks/:id` to the v1 router. Returns `204 No Content` on success, `404` with `{ error, message }` envelope if the ID is not found.

## Security note (DELETE webhook — #614)

The DELETE endpoint is reachable by any authenticated JWT holder. Since webhook IDs are UUIDs (128-bit random), enumeration is not feasible. The action is non-reversible (webhook must be re-registered to receive events again), so the endpoint is protected by the existing `jwtMiddleware` which guards all `DELETE` verbs. No additional ownership check is added at this stage because the current webhook store has no user-ownership model; a future task should add per-user webhook scoping.

## Test plan

- [ ] `GET /api/v1/health/live` returns `200 { status: "alive" }` with no dependency checks
- [ ] `GET /api/v1/health/ready` returns `200` when DB + RPC healthy, `503` when either is down
- [ ] `OPTIONS` request to any API route includes `Access-Control-Max-Age: 600`
- [ ] Contract invocation failure with `Error(Contract, #4)` surfaces as "Insufficient collateral: …" in the response body
- [ ] `DELETE /api/v1/webhooks/:id` with a valid ID returns `204`; with an unknown ID returns `404 { error: "Webhook not found" }`
- [ ] All unit tests in `health.test.ts`, `cors.test.ts`, `sorobanErrors.test.ts`, and `webhooks.test.ts` pass

Closes #622
Closes #621
Closes #619
Closes #614