### PR TITLE
feat: emit FeeUpd event on update_fee_config

### DIFF
--- a/contracts/stellarkraal/src/lib.rs
+++ b/contracts/stellarkraal/src/lib.rs
@@ -862,8 +862,14 @@ impl StellarKraal {
             return Err(Error::InvalidFeeRate);
         }
 
+        let old_orig: u32 = env.storage().instance().get(&ORIG_FEE).unwrap();
+        let old_int: u32 = env.storage().instance().get(&INT_FEE).unwrap();
         env.storage().instance().set(&ORIG_FEE, &origination_fee_bps);
         env.storage().instance().set(&INT_FEE, &interest_fee_bps);
+        env.events().publish(
+            (symbol_short!("Admin"), symbol_short!("FeeUpd")),
+            (old_orig, origination_fee_bps, old_int, interest_fee_bps),
+        );
         Ok(())
     }
 

--- a/contracts/stellarkraal/src/tests.rs
+++ b/contracts/stellarkraal/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use soroban_sdk::{
     symbol_short, vec,
     testutils::{Address as _, Ledger},
-    Address, Env,
+    Address, Env, FromVal,
 };
 use proptest::prelude::*;
 
@@ -652,6 +652,25 @@ fn setup() -> (Env, Address, Address, Address, Address, Address) {
             e.0 == (symbol_short!("loan"), symbol_short!("repaid"))
         });
         assert!(repay_event.is_some());
+    }
+
+    #[test]
+    fn test_update_fee_config_emits_event() {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+
+        // Initial fees set by init: origination=50, interest=1000
+        client.update_fee_config(&admin, &100u32, &200u32);
+
+        let events = env.events().all();
+        let fee_event = events.iter().find(|e| {
+            e.0 == (symbol_short!("Admin"), symbol_short!("FeeUpd"))
+        });
+        assert!(fee_event.is_some(), "FeeUpd event not emitted");
+        // Verify data: (old_orig, new_orig, old_int, new_int)
+        let data = <(u32, u32, u32, u32)>::from_val(&env, &fee_event.unwrap().1);
+        assert_eq!(data, (50u32, 100u32, 1000u32, 200u32));
     }
 
     // ── proptests ─────────────────────────────────────────────────────────

--- a/docs/protocol/events.md
+++ b/docs/protocol/events.md
@@ -59,6 +59,21 @@ Emitted by `liquidate` after a partial or full liquidation.
 | `outstanding` | `i128` | Remaining outstanding balance after liquidation |
 | `status` | `LoanStatus` | New loan status (`Active` or `Liquidated`) |
 
+### `Admin / FeeUpd`
+
+Emitted by `update_fee_config` after the fee parameters are successfully changed.
+
+| Field | Type | Description |
+|---|---|---|
+| `old_origination_fee_bps` | `u32` | Previous origination fee in basis points |
+| `new_origination_fee_bps` | `u32` | Updated origination fee in basis points |
+| `old_interest_fee_bps` | `u32` | Previous interest fee in basis points |
+| `new_interest_fee_bps` | `u32` | Updated interest fee in basis points |
+
+Topics: `(symbol_short!("Admin"), symbol_short!("FeeUpd"))`
+
+Data: `(old_origination_fee_bps, new_origination_fee_bps, old_interest_fee_bps, new_interest_fee_bps)`
+
 ### `FeeCollect / <loan_id>` (internal)
 
 Emitted when origination or interest fees are transferred to the treasury.


### PR DESCRIPTION
## Summary
  `update_fee_config` changed on-chain fee parameters silently. This adds a
  `(Admin, FeeUpd)` event so off-chain systems can monitor fee changes without
  polling contract storage.
  
  ## Changes
  - **lib.rs**: Read old `origination_fee_bps` and `interest_fee_bps` before
    overwriting, then publish `(Admin, FeeUpd)` with
    `(old_orig, new_orig, old_int, new_int)`.
  - **tests.rs**: `test_update_fee_config_emits_event` asserts the event is
    emitted and data matches the before/after values.
  - **docs/protocol/events.md**: Document the new `Admin / FeeUpd` event and
    its four data fields.
  
  ## Acceptance Criteria
  - [x] Event emitted after successful `update_fee_config` call
  - [x] Event data includes old and new values of each fee parameter
  - [x] Only admin can call `update_fee_config` (existing check unchanged)
  - [x] Test verifies event data matches the change
  - [x] `docs/protocol/events.md` updated
  
  Closes #666