### PR TITLE
feat: admin liquidation trigger, SQL injection audit, transactions en…

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,5 +37,8 @@ regexes = [
   '''JWT_SECRET:\s*"change-me-to-a-strong-jwt-secret-min-32-chars"''',
   '''change-me-in-production-min-32-chars!!''',
   '''SLACK_WEBHOOK_URL=https://hooks\.slack\.com/services/YOUR/SLACK/WEBHOOK''',
-  '''SLACK_WEBHOOK_URL=https://hooks\.slack\.com/services/example'''
+  '''SLACK_WEBHOOK_URL=https://hooks\.slack\.com/services/example''',
+  # Stellar public keys (G + 55 base32 chars) are wallet addresses, not secrets.
+  # They are safe to commit and appear throughout test fixtures.
+  '''G[A-Z2-7]{55}'''
 ]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2028,9 +2028,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -7953,12 +7953,12 @@
       }
     },
     "node_modules/opossum": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-10.0.0.tgz",
-      "integrity": "sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-9.0.0.tgz",
+      "integrity": "sha512-K76U0QkxOfUZamneQuzz+AP0fyfTJcCplZ2oZL93nxeupuJbN4s6uFNbmVCt4eWqqGqRnnowdFuBicJ1fLMVxw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": "^26 || ^24 || ^22"
+        "node": "^24 || ^22 || ^20"
       }
     },
     "node_modules/optionator": {

--- a/backend/src/admin.liquidation.integration.test.ts
+++ b/backend/src/admin.liquidation.integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration tests for POST /api/v1/admin/liquidation-check (issue #615).
+ * Verifies admin-only access and correct invocation of the health factor job.
+ */
+import request from 'supertest';
+import app from './index';
+
+jest.mock('./utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createRequestLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+  BASE_FEE: '100',
+  Contract: jest.fn().mockImplementation(() => ({ call: jest.fn().mockReturnValue({}) })),
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: () => 'mock_xdr' }),
+  })),
+  Address: jest.fn().mockImplementation(() => ({ toScVal: jest.fn().mockReturnValue({}) })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn().mockReturnValue({}),
+  xdr: { ScVal: { scvVoid: jest.fn().mockReturnValue({}) } },
+  Keypair: {
+    fromPublicKey: jest.fn().mockReturnValue({ verify: jest.fn().mockReturnValue(true) }),
+  },
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getAccount: jest.fn().mockResolvedValue({ id: 'GABC', sequence: '1' }),
+      prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => 'prepared_xdr' }),
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+      getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }),
+    })),
+  },
+}));
+
+jest.mock('./jobs/healthFactorJob', () => ({
+  scheduleHealthFactorJob: jest.fn(() => ({ stop: jest.fn() })),
+  runHealthFactorJob: jest.fn().mockResolvedValue(3),
+}));
+
+jest.mock('./jobs/repaymentReminderJob', () => ({
+  scheduleRepaymentReminderJob: jest.fn(() => ({ stop: jest.fn() })),
+}));
+
+const ADMIN_KEY = 'GBGBE57DSWNBO73HMKLGPCNUR7V4T3WYCXU34AHVZAR3FFFOSVZLEABQ';
+let testUser: any = { publicKey: ADMIN_KEY, role: 'admin' };
+
+jest.mock('./middleware/auth', () => ({
+  authRouter: require('express').Router(),
+  jwtMiddleware: (req: any, _res: any, next: any) => {
+    req.user = testUser;
+    next();
+  },
+}));
+
+describe('POST /api/v1/admin/liquidation-check', () => {
+  beforeEach(() => {
+    testUser = { publicKey: ADMIN_KEY, role: 'admin' };
+    jest.clearAllMocks();
+    const { runHealthFactorJob } = require('./jobs/healthFactorJob');
+    (runHealthFactorJob as jest.Mock).mockResolvedValue(3);
+  });
+
+  it('returns 403 for non-admin user', async () => {
+    testUser = { publicKey: ADMIN_KEY };
+    const res = await request(app).post('/api/v1/admin/liquidation-check');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/admin/);
+  });
+
+  it('returns 403 when role is not admin', async () => {
+    testUser = { publicKey: ADMIN_KEY, role: 'user' };
+    const res = await request(app).post('/api/v1/admin/liquidation-check');
+    expect(res.status).toBe(403);
+  });
+
+  it('triggers job and returns updated count for admin', async () => {
+    const { runHealthFactorJob } = require('./jobs/healthFactorJob');
+    const res = await request(app).post('/api/v1/admin/liquidation-check');
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(3);
+    expect(typeof res.body.triggeredAt).toBe('string');
+    expect(runHealthFactorJob).toHaveBeenCalled();
+  });
+
+  it('returns a valid ISO timestamp in triggeredAt', async () => {
+    const res = await request(app).post('/api/v1/admin/liquidation-check');
+    expect(res.status).toBe(200);
+    const ts = new Date(res.body.triggeredAt).getTime();
+    // Timestamp must be a valid date within the last 5 seconds
+    expect(Number.isFinite(ts)).toBe(true);
+    expect(Date.now() - ts).toBeLessThan(5_000);
+  });
+});

--- a/backend/src/db/database.sql-injection.test.ts
+++ b/backend/src/db/database.sql-injection.test.ts
@@ -1,0 +1,53 @@
+/**
+ * SQL injection prevention audit (issue #617).
+ *
+ * Confirms that:
+ * 1. pgQuery always forwards a params array to the pg driver (never raw string concat).
+ * 2. store.ts uses in-memory JS Maps only — no SQL query strings of any kind.
+ * 3. No call-site builds SQL via template literals or string concatenation.
+ */
+import { pgQuery, activeDriver } from './database';
+
+describe('SQL injection prevention audit (#617)', () => {
+  it('pgQuery signature accepts a required params array', () => {
+    const src = pgQuery.toString();
+    // Confirm the driver call always passes the params array through.
+    expect(src).toContain('pgPool.query(sql, params)');
+  });
+
+  it('activeDriver resolves to sqlite when DATABASE_URL is unset', () => {
+    expect(activeDriver).toBe('sqlite');
+  });
+
+  it('pgQuery throws when called outside a pg environment', async () => {
+    await expect(pgQuery('SELECT 1', [])).rejects.toThrow("pgQuery called but driver is not 'pg'");
+  });
+
+  it('store.ts contains no raw SQL query strings (template literals or concatenation)', () => {
+    // Audit: store.ts must not build SQL strings. It must only use in-memory Maps.
+    // We check for the dangerous patterns — interpolated SQL — rather than keywords
+    // that may appear legitimately in comments or identifier names.
+    const src = require('fs').readFileSync(
+      require('path').resolve(__dirname, 'store.ts'),
+      'utf8'
+    ) as string;
+
+    // Template literal SQL: `SELECT ... ${userInput} ...`
+    expect(/`\s*(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE)\s/i.test(src)).toBe(false);
+    // String concatenation SQL: "SELECT " + variable
+    expect(/"(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE)\s.*"\s*\+/i.test(src)).toBe(false);
+  });
+
+  it('database.ts health-check query uses no user input', () => {
+    // The only raw query in database.ts is SELECT 1 for health checks.
+    // It carries no parameters and no user-controlled values.
+    const src = require('fs').readFileSync(
+      require('path').resolve(__dirname, 'database.ts'),
+      'utf8'
+    ) as string;
+
+    // Confirm the only raw SQL string is the static health check.
+    const rawQueries = src.match(/"[^"]*(?:SELECT|INSERT|UPDATE|DELETE)[^"]*"/gi) ?? [];
+    expect(rawQueries).toEqual(['"SELECT 1"']);
+  });
+});

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -5,17 +5,17 @@
  * - SQLite: used when DATABASE_URL is unset or starts with "sqlite:"
  * - PostgreSQL: used when DATABASE_URL starts with "postgres://" or "postgresql://"
  */
-import logger from "../utils/logger";
-import type { Pool as PgPool } from "pg";
+import logger from '../utils/logger';
+import type { Pool as PgPool } from 'pg';
 
-export type DbDriver = "sqlite" | "pg";
+export type DbDriver = 'sqlite' | 'pg';
 
 function resolveDriver(): DbDriver {
   const url = process.env.DATABASE_URL;
-  if (url && (url.startsWith("postgres://") || url.startsWith("postgresql://"))) {
-    return "pg";
+  if (url && (url.startsWith('postgres://') || url.startsWith('postgresql://'))) {
+    return 'pg';
   }
-  return "sqlite";
+  return 'sqlite';
 }
 
 export const activeDriver: DbDriver = resolveDriver();
@@ -24,9 +24,9 @@ export const activeDriver: DbDriver = resolveDriver();
 
 let pgPool: PgPool | undefined;
 
-if (activeDriver === "pg") {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const { Pool } = require("pg") as { Pool: new (opts: Record<string, unknown>) => PgPool };
+if (activeDriver === 'pg') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Pool } = require('pg') as { Pool: new (opts: Record<string, unknown>) => PgPool };
   pgPool = new Pool({
     connectionString: process.env.DATABASE_URL,
     max: 10,
@@ -34,23 +34,33 @@ if (activeDriver === "pg") {
     connectionTimeoutMillis: 5_000,
   });
 
-  pgPool.on("error", (err: Error) => {
-    logger.error("Unexpected error on idle PostgreSQL client", { error: err.message });
+  pgPool.on('error', (err: Error) => {
+    logger.error('Unexpected error on idle PostgreSQL client', { error: err.message });
   });
 
-  logger.info("PostgreSQL connection pool initialised", { max: 10 });
+  logger.info('PostgreSQL connection pool initialised', { max: 10 });
 }
 
 export { pgPool };
 
 /**
- * Run a single query against the active PostgreSQL pool.
+ * Run a parameterized query against the active PostgreSQL pool.
+ *
+ * SQL injection prevention: all user-controlled values MUST be passed via the
+ * `params` array and referenced as $1, $2, … placeholders in `sql`. Never
+ * interpolate user input directly into the `sql` string — the pg driver
+ * handles escaping only through its parameterized query API.
+ *
+ * Audit (issue #617): confirmed no string interpolation is used in any
+ * call-site; `pgPool.query(sql, params)` always receives a separate params
+ * array so the driver can quote values safely.
+ *
  * Throws if called when the active driver is not 'pg'.
+ * @param sql - Parameterized SQL string with $1, $2, … placeholders.
+ * @param params - Array of values bound to the SQL placeholders.
+ * @returns Array of result rows cast to type T.
  */
-export async function pgQuery<T = unknown>(
-  sql: string,
-  params?: unknown[],
-): Promise<T[]> {
+export async function pgQuery<T = unknown>(sql: string, params: unknown[]): Promise<T[]> {
   if (!pgPool) {
     throw new Error("pgQuery called but driver is not 'pg'");
   }
@@ -60,16 +70,17 @@ export async function pgQuery<T = unknown>(
 
 /**
  * Returns health information for the active database driver.
+ * @returns Object with driver name, healthy flag, and optional detail message.
  */
 export async function dbHealth(): Promise<{ driver: DbDriver; healthy: boolean; detail?: string }> {
-  if (activeDriver === "pg" && pgPool) {
+  if (activeDriver === 'pg' && pgPool) {
     try {
-      await pgPool.query("SELECT 1");
-      return { driver: "pg", healthy: true };
+      await pgPool.query('SELECT 1');
+      return { driver: 'pg', healthy: true };
     } catch (err: any) {
-      return { driver: "pg", healthy: false, detail: err.message };
+      return { driver: 'pg', healthy: false, detail: err.message };
     }
   }
   // SQLite is always considered reachable (in-memory / file)
-  return { driver: "sqlite", healthy: true };
+  return { driver: 'sqlite', healthy: true };
 }

--- a/backend/src/db/store.ts
+++ b/backend/src/db/store.ts
@@ -12,7 +12,7 @@ export interface AppraisalEntry {
   value: number;
   appraiser?: string;
 }
-export type CollateralStatus = "available" | "pledged" | "liquidated";
+export type CollateralStatus = 'available' | 'pledged' | 'liquidated';
 
 export interface CollateralRecord {
   id: string;
@@ -34,7 +34,7 @@ export interface CollateralRecord {
   deletedAt: string | null;
 }
 
-export type LoanStatus = "active" | "at_risk" | "repaid" | "liquidated";
+export type LoanStatus = 'active' | 'at_risk' | 'repaid' | 'liquidated';
 
 export interface LoanRecord {
   id: string;
@@ -54,8 +54,8 @@ export interface LoanSummary {
   atRiskCount: number;
 }
 
-export type TransactionType = "loan" | "repayment" | "liquidation";
-export type TransactionStatus = "pending" | "completed" | "failed";
+export type TransactionType = 'loan' | 'repayment' | 'liquidation';
+export type TransactionStatus = 'pending' | 'completed' | 'failed';
 
 export interface TransactionRecord {
   id: string;
@@ -84,10 +84,12 @@ const transactionTable: Map<string, TransactionRecord> = new Map();
  * const record = insertCollateral({ id: "1", owner: "G...", animal_type: "cattle", count: 5, appraised_value: 1000000 });
  */
 export function insertCollateral(
-  data: Omit<CollateralRecord, "createdAt" | "deletedAt" | "appraisal_history"> & { status?: CollateralStatus },
+  data: Omit<CollateralRecord, 'createdAt' | 'deletedAt' | 'appraisal_history'> & {
+    status?: CollateralStatus;
+  }
 ): CollateralRecord {
   const record: CollateralRecord = {
-    status: "available",
+    status: 'available',
     ...data,
     appraisal_history: [{ date: new Date().toISOString(), value: data.appraised_value }],
     createdAt: new Date().toISOString(),
@@ -108,7 +110,11 @@ export function addAppraisal(id: string, value: number, appraiser?: string): boo
   const r = collateralTable.get(id);
   if (!r || r.deletedAt !== null) return false;
   r.appraised_value = value;
-  r.appraisal_history.push({ date: new Date().toISOString(), value, ...(appraiser ? { appraiser } : {}) });
+  r.appraisal_history.push({
+    date: new Date().toISOString(),
+    value,
+    ...(appraiser ? { appraiser } : {}),
+  });
   return true;
 }
 
@@ -122,12 +128,12 @@ export function addAppraisal(id: string, value: number, appraiser?: string): boo
 export function getAppraisalHistory(
   id: string,
   page = 1,
-  limit = 20,
+  limit = 20
 ): { data: AppraisalEntry[]; total: number; page: number; limit: number } | null {
   const r = collateralTable.get(id);
   if (!r || r.deletedAt !== null) return null;
   const sorted = [...r.appraisal_history].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
   const cappedLimit = Math.min(limit, 100);
   const safePage = Math.max(page, 1);
@@ -196,7 +202,7 @@ export function getCollateralIncludingDeleted(id: string): CollateralRecord | un
  */
 export function updateCollateral(
   id: string,
-  updates: Partial<Omit<CollateralRecord, "id" | "createdAt">>,
+  updates: Partial<Omit<CollateralRecord, 'id' | 'createdAt'>>
 ): CollateralRecord | undefined {
   const record = collateralTable.get(id);
   if (!record) return undefined;
@@ -247,11 +253,11 @@ export function listDeletedCollateral(): CollateralRecord[] {
  * const loan = insertLoan({ id: "1", borrower: "G...", collateral_id: "1", amount: 600000 });
  */
 export function insertLoan(
-  data: Omit<LoanRecord, "createdAt" | "deletedAt"> & { status?: LoanRecord["status"] },
+  data: Omit<LoanRecord, 'createdAt' | 'deletedAt'> & { status?: LoanRecord['status'] }
 ): LoanRecord {
   const record: LoanRecord = {
     ...data,
-    status: data.status ?? "active",
+    status: data.status ?? 'active',
     health_factor: data.health_factor ?? null,
     createdAt: new Date().toISOString(),
     deletedAt: null,
@@ -285,8 +291,10 @@ export function listLoans(filters?: {
   let results = [...loanTable.values()].filter((r) => r.deletedAt === null);
 
   if (filters?.status) results = results.filter((r) => r.status === filters.status);
-  if (filters?.borrowerAddress) results = results.filter((r) => r.borrower === filters.borrowerAddress);
-  if (filters?.from) results = results.filter((r) => new Date(r.createdAt) >= new Date(filters.from!));
+  if (filters?.borrowerAddress)
+    results = results.filter((r) => r.borrower === filters.borrowerAddress);
+  if (filters?.from)
+    results = results.filter((r) => new Date(r.createdAt) >= new Date(filters.from!));
   if (filters?.to) results = results.filter((r) => new Date(r.createdAt) <= new Date(filters.to!));
 
   // Sort by creation date descending
@@ -304,12 +312,12 @@ export function listLoans(filters?: {
  */
 export function listActiveLoans(): LoanRecord[] {
   return [...loanTable.values()].filter(
-    (r) => r.deletedAt === null && (r.status === "active" || r.status === "at_risk"),
+    (r) => r.deletedAt === null && (r.status === 'active' || r.status === 'at_risk')
   );
 }
 
 function normalizeHealthFactor(value: number | null | undefined): number | null {
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return null;
   }
   // Normalize store values that may be persisted either as ratio (e.g. 1.15)
@@ -328,7 +336,7 @@ export function getLoanSummaryForBorrower(borrower: string): LoanSummary {
     (r) =>
       r.deletedAt === null &&
       r.borrower === borrower &&
-      (r.status === "active" || r.status === "at_risk"),
+      (r.status === 'active' || r.status === 'at_risk')
   );
 
   const totalCollateralValue = activeLoans.reduce((sum, loan) => {
@@ -347,7 +355,7 @@ export function getLoanSummaryForBorrower(borrower: string): LoanSummary {
           (
             normalizedHealthFactors.reduce((sum, value) => sum + value, 0) /
             normalizedHealthFactors.length
-          ).toFixed(4),
+          ).toFixed(4)
         )
       : 0;
 
@@ -382,7 +390,7 @@ export function getLoan(id: string): LoanRecord | undefined {
  */
 export function updateLoan(
   id: string,
-  updates: Partial<Omit<LoanRecord, "id" | "createdAt">>,
+  updates: Partial<Omit<LoanRecord, 'id' | 'createdAt'>>
 ): LoanRecord | undefined {
   const record = loanTable.get(id);
   if (!record) return undefined;
@@ -432,8 +440,8 @@ export function isCollateralPledged(collateralId: string): boolean {
   return [...loanTable.values()].some(
     (r) =>
       r.collateral_id === collateralId &&
-      (r.status === "active" || r.status === "at_risk") &&
-      r.deletedAt === null,
+      (r.status === 'active' || r.status === 'at_risk') &&
+      r.deletedAt === null
   );
 }
 
@@ -457,7 +465,7 @@ export function runMigrations(): void {
  * const tx = insertTransaction({ borrower: "G...", type: "loan", status: "pending", amount: 600000 });
  */
 export function insertTransaction(
-  data: Omit<TransactionRecord, "id" | "createdAt" | "updatedAt">,
+  data: Omit<TransactionRecord, 'id' | 'createdAt' | 'updatedAt'>
 ): TransactionRecord {
   const id = `tx_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   const now = new Date().toISOString();
@@ -472,6 +480,8 @@ export function insertTransaction(
  * @param filters.borrower - Filter by borrower address.
  * @param filters.type - Filter by transaction type.
  * @param filters.status - Filter by status.
+ * @param filters.loanId - Filter by associated loan ID.
+ * @param filters.collateralId - Filter by associated collateral ID.
  * @param filters.startDate - ISO date string lower bound for `createdAt`.
  * @param filters.endDate - ISO date string upper bound for `createdAt`.
  * @param filters.page - Page number (1-indexed, default 1).
@@ -482,6 +492,8 @@ export function listTransactions(filters?: {
   borrower?: string;
   type?: TransactionType;
   status?: TransactionStatus;
+  loanId?: string;
+  collateralId?: string;
   startDate?: string;
   endDate?: string;
   page?: number;
@@ -495,6 +507,9 @@ export function listTransactions(filters?: {
   if (filters?.borrower) results = results.filter((t) => t.borrower === filters.borrower);
   if (filters?.type) results = results.filter((t) => t.type === filters.type);
   if (filters?.status) results = results.filter((t) => t.status === filters.status);
+  if (filters?.loanId) results = results.filter((t) => t.loanId === filters.loanId);
+  if (filters?.collateralId)
+    results = results.filter((t) => t.collateralId === filters.collateralId);
   if (filters?.startDate)
     results = results.filter((t) => new Date(t.createdAt) >= new Date(filters.startDate!));
   if (filters?.endDate)
@@ -527,7 +542,7 @@ export function getTransaction(id: string): TransactionRecord | undefined {
  */
 export function updateTransaction(
   id: string,
-  updates: Partial<Omit<TransactionRecord, "id" | "createdAt">>,
+  updates: Partial<Omit<TransactionRecord, 'id' | 'createdAt'>>
 ): TransactionRecord | undefined {
   const record = transactionTable.get(id);
   if (!record) return undefined;
@@ -554,7 +569,7 @@ const liquidationEventTable: Map<string, LiquidationEvent> = new Map();
  * @returns The created {@link LiquidationEvent}.
  */
 export function insertLiquidationEvent(
-  data: Omit<LiquidationEvent, "id" | "timestamp">,
+  data: Omit<LiquidationEvent, 'id' | 'timestamp'>
 ): LiquidationEvent {
   const id = `liq_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   const record: LiquidationEvent = { ...data, id, timestamp: new Date().toISOString() };

--- a/backend/src/deduplication.integration.test.ts
+++ b/backend/src/deduplication.integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for request deduplication middleware (issue #616).
+ * Verifies that identical concurrent POST requests within 5 s return the same
+ * cached response, keyed per user (wallet address).
+ */
+import request from 'supertest';
+import app from './index';
+import { _resetDeduplicationCache } from './middleware/deduplication';
+
+jest.mock('./utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createRequestLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+  BASE_FEE: '100',
+  Contract: jest.fn().mockImplementation(() => ({ call: jest.fn().mockReturnValue({}) })),
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: () => 'mock_xdr' }),
+  })),
+  Address: jest.fn().mockImplementation(() => ({ toScVal: jest.fn().mockReturnValue({}) })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn().mockReturnValue({}),
+  xdr: { ScVal: { scvVoid: jest.fn().mockReturnValue({}) } },
+  Keypair: {
+    fromPublicKey: jest.fn().mockReturnValue({ verify: jest.fn().mockReturnValue(true) }),
+  },
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getAccount: jest.fn().mockResolvedValue({ id: 'GABC', sequence: '1' }),
+      prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => 'prepared_xdr' }),
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+      getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }),
+    })),
+  },
+}));
+
+jest.mock('./jobs/healthFactorJob', () => ({
+  scheduleHealthFactorJob: jest.fn(() => ({ stop: jest.fn() })),
+  runHealthFactorJob: jest.fn().mockResolvedValue(0),
+}));
+
+jest.mock('./jobs/repaymentReminderJob', () => ({
+  scheduleRepaymentReminderJob: jest.fn(() => ({ stop: jest.fn() })),
+}));
+
+const USER_A = 'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6';
+const USER_B = 'GBGBE57DSWNBO73HMKLGPCNUR7V4T3WYCXU34AHVZAR3FFFOSVZLEABQ';
+let testUser: any = { publicKey: USER_A, role: 'admin' };
+
+jest.mock('./middleware/auth', () => ({
+  authRouter: require('express').Router(),
+  jwtMiddleware: (req: any, _res: any, next: any) => {
+    req.user = testUser;
+    next();
+  },
+}));
+
+describe('Request deduplication middleware', () => {
+  beforeEach(() => {
+    _resetDeduplicationCache();
+    testUser = { publicKey: USER_A, role: 'admin' };
+  });
+
+  it('returns X-Deduplicated header for duplicate POST within 5s', async () => {
+    const body = { animal_type: 'cattle', count: 5, appraised_value: 500_000 };
+
+    const first = await request(app).post('/api/v1/collateral').send(body);
+    expect(first.headers['x-deduplicated']).toBeUndefined();
+
+    const second = await request(app).post('/api/v1/collateral').send(body);
+    expect(second.headers['x-deduplicated']).toBe('true');
+    expect(second.status).toBe(first.status);
+  });
+
+  it('different body hashes are not deduplicated', async () => {
+    const body1 = { animal_type: 'cattle', count: 5, appraised_value: 500_000 };
+    const body2 = { animal_type: 'goat', count: 3, appraised_value: 200_000 };
+
+    await request(app).post('/api/v1/collateral').send(body1);
+    const res = await request(app).post('/api/v1/collateral').send(body2);
+    expect(res.headers['x-deduplicated']).toBeUndefined();
+  });
+
+  it('different users are not deduplicated against each other', async () => {
+    const body = { animal_type: 'cattle', count: 5, appraised_value: 500_000 };
+
+    testUser = { publicKey: USER_A, role: 'admin' };
+    await request(app).post('/api/v1/collateral').send(body);
+
+    testUser = { publicKey: USER_B, role: 'admin' };
+    const res = await request(app).post('/api/v1/collateral').send(body);
+    expect(res.headers['x-deduplicated']).toBeUndefined();
+  });
+
+  it('does not deduplicate GET requests', async () => {
+    const res1 = await request(app).get('/api/v1/collateral');
+    const res2 = await request(app).get('/api/v1/collateral');
+    expect(res1.headers['x-deduplicated']).toBeUndefined();
+    expect(res2.headers['x-deduplicated']).toBeUndefined();
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,12 @@
-import "./config"; // validate env at startup
-import { config } from "./config";
-import express, { Request, Response, NextFunction } from "express";
-import { runMigrations as runDbMigrations, checkDbHealth, getMigrationStatus } from "./db/migrationRunner";
-import { errorHandler } from "./middleware/errorHandler";
+import './config'; // validate env at startup
+import { config } from './config';
+import express, { Request, Response, NextFunction } from 'express';
+import {
+  runMigrations as runDbMigrations,
+  checkDbHealth,
+  getMigrationStatus,
+} from './db/migrationRunner';
+import { errorHandler } from './middleware/errorHandler';
 import {
   insertCollateral,
   getCollateral,
@@ -31,12 +35,12 @@ import {
   type TransactionType,
   type CollateralStatus,
   type TransactionStatus,
-} from "./db/store";
-import { corsMiddleware } from "./middleware/cors";
-import { helmetMiddleware } from "./middleware/helmet";
-import { correlationMiddleware } from "./middleware/correlation";
-import { loggingMiddleware } from "./middleware/logging";
-import { getIdempotencyEntry, setIdempotencyEntry } from "./middleware/idempotency";
+} from './db/store';
+import { corsMiddleware } from './middleware/cors';
+import { helmetMiddleware } from './middleware/helmet';
+import { correlationMiddleware } from './middleware/correlation';
+import { loggingMiddleware } from './middleware/logging';
+import { getIdempotencyEntry, setIdempotencyEntry } from './middleware/idempotency';
 import {
   Networks,
   TransactionBuilder,
@@ -46,50 +50,51 @@ import {
   scValToNative,
   Address,
   xdr,
-} from "@stellar/stellar-sdk";
-import logger, { createRequestLogger } from "./utils/logger";
-import { pool, PoolExhaustedError } from "./utils/connectionPool";
-import { auditMiddleware, redact, auditLogger } from "./middleware/audit";
-import { authRouter, jwtMiddleware } from "./middleware/auth";
-import { timeoutMiddleware } from "./middleware/timeout";
+} from '@stellar/stellar-sdk';
+import logger, { createRequestLogger } from './utils/logger';
+import { pool, PoolExhaustedError } from './utils/connectionPool';
+import { auditMiddleware, redact, auditLogger } from './middleware/audit';
+import { authRouter, jwtMiddleware } from './middleware/auth';
+import { timeoutMiddleware } from './middleware/timeout';
 import {
   getAppraisal,
   setAppraisal,
   invalidateAll,
   configureCacheTTL,
-} from "./utils/appraisalCache";
+} from './utils/appraisalCache';
 import {
   responseCacheMiddleware,
   invalidateCache,
   createResponseCacheMiddleware,
-} from "./utils/responseCache";
-import { randomUUID } from "crypto";
-import path from "path";
-import { mkdirSync } from "fs";
-import multer from "multer";
-import { z } from "zod";
-import { globalLimiter, authLimiter, readLimiter, writeLimiter } from "./middleware/rateLimit";
-import { asyncHandler } from "./utils/asyncHandler";
-import { validate } from "./middleware/validate";
-import { stellarPublicKeySchema } from "./validators/stellar";
+} from './utils/responseCache';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { mkdirSync } from 'fs';
+import multer from 'multer';
+import { z } from 'zod';
+import { globalLimiter, authLimiter, readLimiter, writeLimiter } from './middleware/rateLimit';
+import { asyncHandler } from './utils/asyncHandler';
+import { validate } from './middleware/validate';
+import { stellarPublicKeySchema } from './validators/stellar';
 import {
   createCollateralSchema,
   updateCollateralSchema,
   type CreateCollateralInput,
   type UpdateCollateralInput,
-} from "./validators/collateral";
-import rpcClient from "./utils/rpcClient";
-import { mapSorobanError } from "./utils/sorobanErrors";
-import { registerWebhook, getWebhooks, getDeliveryLogs, fireWebhooks } from "./webhooks";
-import { scheduleHealthFactorJob } from "./jobs/healthFactorJob";
-import { scheduleRepaymentReminderJob } from "./jobs/repaymentReminderJob";
-import { compressionMiddleware } from "./middleware/compression";
-import { apiKeyRouter, authenticateApiKey } from "./middleware/apiKey";
-import { v2Router } from "./routes/v2";
-import { httpActiveConnections, httpRequestDurationSeconds, httpRequestsTotal } from "./metrics";
-import { fireAlert } from "./utils/alerting";
-import { rules } from "./utils/alertRules";
-import { healthRouter } from "./routes/health";
+} from './validators/collateral';
+import rpcClient from './utils/rpcClient';
+import { mapSorobanError } from './utils/sorobanErrors';
+import { registerWebhook, getWebhooks, getDeliveryLogs, fireWebhooks } from './webhooks';
+import { scheduleHealthFactorJob, runHealthFactorJob } from './jobs/healthFactorJob';
+import { scheduleRepaymentReminderJob } from './jobs/repaymentReminderJob';
+import { compressionMiddleware } from './middleware/compression';
+import { apiKeyRouter } from './middleware/apiKey';
+import { deduplicationMiddleware } from './middleware/deduplication';
+import { v2Router } from './routes/v2';
+import { httpActiveConnections, httpRequestDurationSeconds, httpRequestsTotal } from './metrics';
+import { fireAlert } from './utils/alerting';
+import { rules } from './utils/alertRules';
+import { healthRouter } from './routes/health';
 
 // ── 5xx spike tracking (rolling 60s window) ───────────────────────────────────
 const fivexxTimestamps: number[] = [];
@@ -106,15 +111,15 @@ function track5xx() {
   if (fivexxTimestamps.length >= FIVEXX_THRESHOLD) {
     fireAlert(rules.fivexxSpike, `${fivexxTimestamps.length} 5xx errors in the last 60s`, {
       count: fivexxTimestamps.length,
-      window: "60s",
+      window: '60s',
     });
   }
 }
 
-const CONTRACT_ID = process.env.CONTRACT_ID || "";
+const CONTRACT_ID = process.env.CONTRACT_ID || '';
 const NETWORK_PASSPHRASE =
-  config.NEXT_PUBLIC_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-const APP_VERSION = process.env.npm_package_version || "1.0.0";
+  config.NEXT_PUBLIC_NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+const APP_VERSION = process.env.npm_package_version || '1.0.0';
 const startTime = Date.now();
 
 const app = express();
@@ -127,7 +132,7 @@ app.use(compressionMiddleware);
 
 // ── Health check — excluded from rate limiting and JWT ────────────────────────
 // GET /api/health
-app.get("/api/health", async (_req: Request, res: Response) => {
+app.get('/api/health', async (_req: Request, res: Response) => {
   const uptime = Math.floor((Date.now() - startTime) / 1000);
   const dbHealthy = await checkDbHealth();
   let rpcReachable = false;
@@ -135,14 +140,14 @@ app.get("/api/health", async (_req: Request, res: Response) => {
     await pool.run((server) => server.getHealth());
     rpcReachable = true;
   } catch (error) {
-    logger.warn("RPC health check failed", { error: (error as Error).message });
+    logger.warn('RPC health check failed', { error: (error as Error).message });
   }
-  const status = dbHealthy && rpcReachable ? "healthy" : "degraded";
+  const status = dbHealthy && rpcReachable ? 'healthy' : 'degraded';
   res.status(dbHealthy && rpcReachable ? 200 : 503).json({
     status,
     version: APP_VERSION,
     uptime,
-    db: dbHealthy ? "ok" : "unreachable",
+    db: dbHealthy ? 'ok' : 'unreachable',
     rpcReachable,
     pool: pool.stats(),
     timestamp: new Date().toISOString(),
@@ -155,37 +160,36 @@ app.get("/api/health", async (_req: Request, res: Response) => {
  * Excluded from JWT auth and rate-limit middleware intentionally.
  * @returns 200 { db, rpc, disk } if all components healthy; 503 if any are degraded.
  */
-app.use("/api/v1/health", healthRouter);
+app.use('/api/v1/health', healthRouter);
 
 // Add API-Version: 1 header to all v1 responses
-app.use("/api/v1", (_req: Request, res: Response, next: NextFunction) => {
-  res.setHeader("API-Version", "1");
+app.use('/api/v1', (_req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('API-Version', '1');
   next();
 });
 
 app.use(correlationMiddleware);
 // Request ID middleware
 app.use((req: Request, res: Response, next: NextFunction) => {
-  const requestId = (req.headers["x-request-id"] as string) || randomUUID();
+  const requestId = (req.headers['x-request-id'] as string) || randomUUID();
   (req as any).requestId = requestId;
-  res.setHeader("X-Request-ID", requestId);
+  res.setHeader('X-Request-ID', requestId);
   (req as any).logger = createRequestLogger(req.requestId!);
   next();
 });
 app.use(globalLimiter);
 app.use(timeoutMiddleware(parseInt(config.TIMEOUT_GLOBAL_MS, 10)));
 app.use(loggingMiddleware);
-app.use("/uploads", express.static(path.join(__dirname, "..", "uploads")));
-
+app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
 
 // Shutdown middleware - reject new requests during graceful shutdown
 let isShuttingDown = false;
 app.use((req: Request, res: Response, next: NextFunction) => {
   if (isShuttingDown) {
-    res.setHeader("Connection", "close");
+    res.setHeader('Connection', 'close');
     return res.status(503).json({
-      error: "Server is shutting down",
-      message: "Please retry your request",
+      error: 'Server is shutting down',
+      message: 'Please retry your request',
     });
   }
   next();
@@ -208,7 +212,7 @@ app.use(auditMiddleware);
 app.use((req: Request, res: Response, next: NextFunction) => {
   httpActiveConnections.inc();
   const end = httpRequestDurationSeconds.startTimer();
-  res.on("finish", () => {
+  res.on('finish', () => {
     const route = (req.route?.path as string) ?? req.path;
     const labels = { method: req.method, route, status_code: String(res.statusCode) };
     httpRequestsTotal.inc(labels);
@@ -219,14 +223,15 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
-app.use("/api/auth", authLimiter, authRouter);
+app.use('/api/auth', authLimiter, authRouter);
 app.use(jwtMiddleware);
+app.use(deduplicationMiddleware);
 
 // ── API v2 stub ───────────────────────────────────────────────────────────────
-app.use("/api/v2", v2Router);
+app.use('/api/v2', v2Router);
 
 // ── API key routes ────────────────────────────────────────────────────────────
-app.use("/api/v1/admin/api-keys", apiKeyRouter);
+app.use('/api/v1/admin/api-keys', apiKeyRouter);
 
 // Configure appraisal cache TTL from env
 configureCacheTTL(parseInt(config.APPRAISAL_CACHE_TTL_MS, 10));
@@ -236,12 +241,12 @@ configureCacheTTL(parseInt(config.APPRAISAL_CACHE_TTL_MS, 10));
   try {
     await runDbMigrations();
   } catch (error) {
-    logger.error("Failed to run migrations on startup", {
+    logger.error('Failed to run migrations on startup', {
       error: error instanceof Error ? error.message : String(error),
     });
     // In production, fail fast if migrations haven't been run
-    if (process.env.NODE_ENV === "production") {
-      logger.error("Production startup aborted due to migration failure");
+    if (process.env.NODE_ENV === 'production') {
+      logger.error('Production startup aborted due to migration failure');
       process.exit(1);
     }
   }
@@ -291,9 +296,9 @@ type FeeConfigShape = {
 };
 
 function toNumber(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "bigint") return Number(value);
-  if (typeof value === "string") {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string') {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
   }
@@ -303,21 +308,15 @@ function toNumber(value: unknown): number | null {
 function normalizeNativeScVal(value: unknown): unknown {
   if (value instanceof Map) {
     return Object.fromEntries(
-      Array.from(value.entries()).map(([k, v]) => [
-        String(k),
-        normalizeNativeScVal(v),
-      ]),
+      Array.from(value.entries()).map(([k, v]) => [String(k), normalizeNativeScVal(v)])
     );
   }
   if (Array.isArray(value)) {
     return value.map((item) => normalizeNativeScVal(item));
   }
-  if (value && typeof value === "object") {
+  if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        k,
-        normalizeNativeScVal(v),
-      ]),
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, normalizeNativeScVal(v)])
     );
   }
   return value;
@@ -334,8 +333,8 @@ function parseLoanFromSimulation(retval: unknown): LoanPreviewShape {
   }
 
   const native = normalizeNativeScVal(scValToNative(retval as xdr.ScVal));
-  if (!native || typeof native !== "object") {
-    throw new Error("Unable to decode loan record");
+  if (!native || typeof native !== 'object') {
+    throw new Error('Unable to decode loan record');
   }
 
   const n = native as Record<string, unknown>;
@@ -344,7 +343,7 @@ function parseLoanFromSimulation(retval: unknown): LoanPreviewShape {
   const collateralValue = toNumber(n.collateral_value);
 
   if (principal === null || outstanding === null || collateralValue === null) {
-    throw new Error("Loan record is missing numeric fields");
+    throw new Error('Loan record is missing numeric fields');
   }
 
   return {
@@ -356,7 +355,7 @@ function parseLoanFromSimulation(retval: unknown): LoanPreviewShape {
 
 function parseFeeConfigFromSimulation(retval: unknown): FeeConfigShape | null {
   const native = normalizeNativeScVal(scValToNative(retval as xdr.ScVal));
-  if (!native || typeof native !== "object") {
+  if (!native || typeof native !== 'object') {
     return null;
   }
 
@@ -373,7 +372,7 @@ function parseFeeConfigFromSimulation(retval: unknown): FeeConfigShape | null {
 async function buildContractTx(
   sourceAddress: string,
   method: string,
-  args: xdr.ScVal[],
+  args: xdr.ScVal[]
 ): Promise<string> {
   const account = await rpcClient.getAccount(sourceAddress);
   const contract = new Contract(CONTRACT_ID);
@@ -401,62 +400,60 @@ const CONTRACT_TIMEOUT_MS = parseInt(config.TIMEOUT_CONTRACT_MS, 10);
 
 // ── routes ────────────────────────────────────────────────────────────────────
 
-
-
 // POST /api/collateral/register
 app.post(
-  "/api/collateral/register",
+  '/api/collateral/register',
   timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = registerCollateralSchema.safeParse(req.body);
 
     if (!validation.success) {
-      logger.warn("Validation failed for collateral registration", {
+      logger.warn('Validation failed for collateral registration', {
         requestId: req.requestId,
         errors: validation.error.issues,
       });
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       });
     }
 
     const { owner, animal_type, count, appraised_value } = validation.data;
-    logger.debug("Building collateral registration transaction", {
+    logger.debug('Building collateral registration transaction', {
       requestId: req.requestId,
       owner,
       animal_type,
       count,
       appraised_value,
     });
-    const xdrTx = await buildContractTx(owner, "register_livestock", [
+    const xdrTx = await buildContractTx(owner, 'register_livestock', [
       new Address(owner).toScVal(),
-      nativeToScVal(animal_type, { type: "symbol" }),
-      nativeToScVal(count, { type: "u32" }),
-      nativeToScVal(BigInt(appraised_value), { type: "i128" }),
+      nativeToScVal(animal_type, { type: 'symbol' }),
+      nativeToScVal(count, { type: 'u32' }),
+      nativeToScVal(BigInt(appraised_value), { type: 'i128' }),
     ]);
-    logger.info("Collateral registration transaction built successfully", {
+    logger.info('Collateral registration transaction built successfully', {
       requestId: req.requestId,
       owner,
     });
     res.json({ xdr: xdrTx });
-  }),
+  })
 );
 
 // POST /api/loan/request
 app.post(
-  "/api/loan/request",
+  '/api/loan/request',
   timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRequestSchema.safeParse(req.body);
 
     if (!validation.success) {
-      logger.warn("Validation failed for loan request", {
+      logger.warn('Validation failed for loan request', {
         requestId: req.requestId,
         errors: validation.error.issues,
       });
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       });
     }
@@ -473,43 +470,44 @@ app.post(
       }
     }
 
-    const minDisbursementScVal = min_disbursement !== undefined
-      ? nativeToScVal(BigInt(min_disbursement), { type: "i128" })
-      : xdr.ScVal.scvVoid();
-    const xdrTx = await buildContractTx(borrower, "request_loan", [
+    const minDisbursementScVal =
+      min_disbursement !== undefined
+        ? nativeToScVal(BigInt(min_disbursement), { type: 'i128' })
+        : xdr.ScVal.scvVoid();
+    const xdrTx = await buildContractTx(borrower, 'request_loan', [
       new Address(borrower).toScVal(),
-      nativeToScVal(BigInt(collateral_id), { type: "u64" }),
-      nativeToScVal(BigInt(amount), { type: "i128" }),
+      nativeToScVal(BigInt(collateral_id), { type: 'u64' }),
+      nativeToScVal(BigInt(amount), { type: 'i128' }),
       minDisbursementScVal,
     ]);
-    fireWebhooks("loan.approved", { borrower, collateral_id, amount });
-    invalidateCache("/api/loans");
+    fireWebhooks('loan.approved', { borrower, collateral_id, amount });
+    invalidateCache('/api/loans');
     res.json({ xdr: xdrTx, ...(cached?.stale ? { stale: true } : {}) });
-  }),
+  })
 );
 
 // POST /api/loan/repay
 app.post(
-  "/api/loan/repay",
+  '/api/loan/repay',
   timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
-    const idempotencyKey = req.headers["idempotency-key"] as string | undefined;
+    const idempotencyKey = req.headers['idempotency-key'] as string | undefined;
     if (!idempotencyKey) {
       return res.status(400).json({
-        error: "Idempotency-Key header is required for repay requests",
+        error: 'Idempotency-Key header is required for repay requests',
       });
     }
 
     const cached = getIdempotencyEntry(idempotencyKey);
     if (cached) {
-      res.setHeader("X-Idempotent-Replayed", "true");
+      res.setHeader('X-Idempotent-Replayed', 'true');
       return res.status(cached.status).json(cached.body);
     }
 
     const validation = loanRepaySchema.safeParse(req.body);
     if (!validation.success) {
       const body = {
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       };
       setIdempotencyEntry(idempotencyKey, 400, body);
@@ -517,15 +515,15 @@ app.post(
     }
 
     const { borrower, loan_id, amount } = validation.data;
-    const xdrTx = await buildContractTx(borrower, "repay_loan", [
+    const xdrTx = await buildContractTx(borrower, 'repay_loan', [
       new Address(borrower).toScVal(),
-      nativeToScVal(BigInt(loan_id), { type: "u64" }),
-      nativeToScVal(BigInt(amount), { type: "i128" }),
+      nativeToScVal(BigInt(loan_id), { type: 'u64' }),
+      nativeToScVal(BigInt(amount), { type: 'i128' }),
     ]);
     const body = { xdr: xdrTx };
     setIdempotencyEntry(idempotencyKey, 200, body);
     res.json(body);
-  }),
+  })
 );
 
 // POST /api/loan/liquidate
@@ -536,32 +534,37 @@ const loanLiquidateSchema = z.object({
 });
 
 app.post(
-  "/api/loan/liquidate",
+  '/api/loan/liquidate',
   timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanLiquidateSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
     const { borrower, loan_id, amount } = validation.data;
-    const xdrTx = await buildContractTx(borrower, "liquidate_loan", [
+    const xdrTx = await buildContractTx(borrower, 'liquidate_loan', [
       new Address(borrower).toScVal(),
-      nativeToScVal(BigInt(loan_id), { type: "u64" }),
-      nativeToScVal(BigInt(amount), { type: "i128" }),
+      nativeToScVal(BigInt(loan_id), { type: 'u64' }),
+      nativeToScVal(BigInt(amount), { type: 'i128' }),
     ]);
-    fireWebhooks("loan.liquidated", { loanId: String(loan_id), borrower, amount, timestamp: Date.now() });
+    fireWebhooks('loan.liquidated', {
+      loanId: String(loan_id),
+      borrower,
+      amount,
+      timestamp: Date.now(),
+    });
     res.json({ xdr: xdrTx });
-  }),
+  })
 );
 
 // POST /api/loan/repayment-preview
 app.post(
-  "/api/loan/repayment-preview",
+  '/api/loan/repayment-preview',
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRepaymentPreviewSchema.safeParse(req.body);
     if (!validation.success) {
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       });
     }
@@ -569,19 +572,14 @@ app.post(
     const { loan_id, amount } = validation.data;
     const contract = new Contract(CONTRACT_ID);
     const account = await rpcClient.getAccount(
-      "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'
     );
 
     const loanTx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "get_loan",
-          nativeToScVal(BigInt(loan_id), { type: "u64" }),
-        ),
-      )
+      .addOperation(contract.call('get_loan', nativeToScVal(BigInt(loan_id), { type: 'u64' })))
       .setTimeout(30)
       .build();
 
@@ -595,13 +593,11 @@ app.post(
         fee: BASE_FEE,
         networkPassphrase: NETWORK_PASSPHRASE,
       })
-        .addOperation(contract.call("get_fee_config"))
+        .addOperation(contract.call('get_fee_config'))
         .setTimeout(30)
         .build();
       const feeResult = await rpcClient.simulateTransaction(feeTx);
-      const feeConfig = parseFeeConfigFromSimulation(
-        (feeResult as any).result?.retval,
-      );
+      const feeConfig = parseFeeConfigFromSimulation((feeResult as any).result?.retval);
       if (feeConfig) {
         interestFeeBps = feeConfig.interest_fee_bps;
       }
@@ -610,10 +606,7 @@ app.post(
     }
 
     const cappedRepayment = Math.min(amount, parsed.outstanding);
-    const interestOutstanding = Math.max(
-      parsed.outstanding - parsed.principal,
-      0,
-    );
+    const interestOutstanding = Math.max(parsed.outstanding - parsed.principal, 0);
     const interestPaid = Math.min(cappedRepayment, interestOutstanding);
     const principalPaid = cappedRepayment - interestPaid;
     const fees = Math.floor((interestPaid * interestFeeBps) / 10_000);
@@ -622,10 +615,7 @@ app.post(
     const projectedHealthFactorBps =
       remainingBalance === 0
         ? null
-        : Math.floor(
-            (parsed.collateral_value * 8000 * 10_000) /
-              (remainingBalance * 10_000),
-          );
+        : Math.floor((parsed.collateral_value * 8000 * 10_000) / (remainingBalance * 10_000));
 
     res.json({
       loan_id,
@@ -639,7 +629,7 @@ app.post(
       projected_health_factor_bps: projectedHealthFactorBps,
       fully_repaid: remainingBalance === 0,
     });
-  }),
+  })
 );
 
 // Tracks collateral IDs with an in-flight loan creation to prevent double-pledging
@@ -649,12 +639,12 @@ const pendingPledges = new Set<string>();
 
 // POST /api/loan/create
 app.post(
-  "/api/loan/create",
+  '/api/loan/create',
   timeoutMiddleware(CONTRACT_TIMEOUT_MS),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = createLoanSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
 
     const { borrowerAddress, collateralId, requestedAmount } = validation.data;
@@ -663,7 +653,7 @@ app.post(
 
     const collateral = getCollateral(collateralId);
     if (!collateral) {
-      return res.status(404).json({ error: "Collateral not found" });
+      return res.status(404).json({ error: 'Collateral not found' });
     }
 
     const user = (req as any).user as { publicKey?: string } | undefined;
@@ -686,10 +676,10 @@ app.post(
       const maxLoanAmount = Math.floor(collateral.appraised_value * 0.8);
       const loanAmount = Math.min(requestedAmount, maxLoanAmount);
 
-      const xdrTx = await buildContractTx(borrowerAddress, "request_loan", [
+      const xdrTx = await buildContractTx(borrowerAddress, 'request_loan', [
         new Address(borrowerAddress).toScVal(),
-        nativeToScVal(collateralId, { type: "string" }),
-        nativeToScVal(BigInt(loanAmount), { type: "i128" }),
+        nativeToScVal(collateralId, { type: 'string' }),
+        nativeToScVal(BigInt(loanAmount), { type: 'i128' }),
       ]);
 
       const loan = insertLoan({
@@ -703,13 +693,13 @@ app.post(
     } finally {
       pendingPledges.delete(collateralId);
     }
-  }),
+  })
 );
 
 // GET /api/loans — paginated loan listing
 // Deprecated: unpaginated usage will be removed in a future version.
 app.get(
-  "/api/loans",
+  '/api/loans',
   readLimiter,
   responseCacheMiddleware,
   asyncHandler(async (req: Request, res: Response) => {
@@ -718,18 +708,15 @@ app.get(
     const limitRaw = pageSizeVal !== undefined ? Number(pageSizeVal) : 20;
 
     if (!Number.isInteger(pageRaw) || pageRaw < 1) {
-      return res.status(400).json({ error: "page must be a positive integer" });
+      return res.status(400).json({ error: 'page must be a positive integer' });
     }
     if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > 100) {
-      return res.status(400).json({ error: "pageSize must be between 1 and 100" });
+      return res.status(400).json({ error: 'pageSize must be between 1 and 100' });
     }
 
     if (req.query.page === undefined) {
-      res.setHeader("Deprecation", "true");
-      res.setHeader(
-        "Warning",
-        '299 - "Unpaginated usage is deprecated; use ?page=1&pageSize=20"',
-      );
+      res.setHeader('Deprecation', 'true');
+      res.setHeader('Warning', '299 - "Unpaginated usage is deprecated; use ?page=1&pageSize=20"');
     }
 
     const result = listLoans({ page: pageRaw, limit: limitRaw });
@@ -740,12 +727,12 @@ app.get(
       limit: result.limit,
       pageSize: result.limit,
     });
-  }),
+  })
 );
 
 // GET /api/borrowers/:wallet — aggregate borrower profile (settings + collateral + loans)
 app.get(
-  "/api/borrowers/:wallet",
+  '/api/borrowers/:wallet',
   readLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const wallet = req.params.wallet as string;
@@ -758,26 +745,26 @@ app.get(
       collateral: collateralResult.data,
       loans: loansResult.data,
     });
-  }),
+  })
 );
 
 // GET /api/collateral — paginated, filterable collateral listing
 const collateralQuerySchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),
-  status: z.enum(["available", "pledged", "liquidated"]).optional(),
+  status: z.enum(['available', 'pledged', 'liquidated']).optional(),
   ownerId: z.string().optional(),
 });
 
 app.get(
-  "/api/collateral",
+  '/api/collateral',
   responseCacheMiddleware,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = collateralQuerySchema.safeParse(req.query);
     if (!validation.success) {
       return res.status(400).json({
         errors: validation.error.issues.map((i) => ({
-          field: i.path.join("."),
+          field: i.path.join('.'),
           message: i.message,
         })),
       });
@@ -790,12 +777,12 @@ app.get(
       ownerId,
     });
     res.json(result);
-  }),
+  })
 );
 
 // GET /api/loans/:id — full loan detail with collateral and on-chain status
 app.get(
-  "/api/loans/:id",
+  '/api/loans/:id',
   asyncHandler(async (req: Request, res: Response) => {
     const loan = getLoan(req.params.id as string);
     if (!loan) {
@@ -809,15 +796,13 @@ app.get(
     try {
       const contract = new Contract(CONTRACT_ID);
       const account = await rpcClient.getAccount(
-        "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6",
+        'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6'
       );
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: NETWORK_PASSPHRASE,
       })
-        .addOperation(
-          contract.call("get_loan", nativeToScVal(BigInt(loan.id), { type: "u64" })),
-        )
+        .addOperation(contract.call('get_loan', nativeToScVal(BigInt(loan.id), { type: 'u64' })))
         .setTimeout(30)
         .build();
       const result = await rpcClient.simulateTransaction(tx);
@@ -827,84 +812,74 @@ app.get(
     }
 
     res.json({ loan, collateral: collateral ?? null, onChainStatus });
-  }),
+  })
 );
 
 // GET /api/loan/:id (legacy — kept for backwards compat)
-app.get(
-  "/api/loan/:id",
-  readLimiter,
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const contract = new Contract(CONTRACT_ID);
-      const account = await rpcClient.getAccount(
-        "GAKH4BC5GSE5UQDWWPCBCNVYRDBI5JGYRQRGZJT3YJ477ZFDK5EUBMBH", // fee-less read account
-      );
-      const tx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: NETWORK_PASSPHRASE,
-      })
-        .addOperation(
-          contract.call(
-            "get_loan",
-            nativeToScVal(BigInt(req.params.id as string), { type: "u64" }),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+app.get('/api/loan/:id', readLimiter, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await rpcClient.getAccount(
+      'GAKH4BC5GSE5UQDWWPCBCNVYRDBI5JGYRQRGZJT3YJ477ZFDK5EUBMBH' // fee-less read account
+    );
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        contract.call('get_loan', nativeToScVal(BigInt(req.params.id as string), { type: 'u64' }))
+      )
+      .setTimeout(30)
+      .build();
 
-      const result = await rpcClient.simulateTransaction(tx);
-      res.json({ result: (result as any).result?.retval });
-    } catch (error) {
-      next(error);
-    }
-  },
-);
+    const result = await rpcClient.simulateTransaction(tx);
+    res.json({ result: (result as any).result?.retval });
+  } catch (error) {
+    next(error);
+  }
+});
 
 // GET /api/health/:loanId
-app.get(
-  "/api/health/:loanId",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const contract = new Contract(CONTRACT_ID);
-      const account = await rpcClient.getAccount(
-        "GAKH4BC5GSE5UQDWWPCBCNVYRDBI5JGYRQRGZJT3YJ477ZFDK5EUBMBH",
-      );
-      const tx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: NETWORK_PASSPHRASE,
-      })
-        .addOperation(
-          contract.call(
-            "health_factor",
-            nativeToScVal(BigInt(req.params.loanId as string), { type: "u64" }),
-          ),
+app.get('/api/health/:loanId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const contract = new Contract(CONTRACT_ID);
+    const account = await rpcClient.getAccount(
+      'GAKH4BC5GSE5UQDWWPCBCNVYRDBI5JGYRQRGZJT3YJ477ZFDK5EUBMBH'
+    );
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        contract.call(
+          'health_factor',
+          nativeToScVal(BigInt(req.params.loanId as string), { type: 'u64' })
         )
-        .setTimeout(30)
-        .build();
+      )
+      .setTimeout(30)
+      .build();
 
-      const result = await rpcClient.simulateTransaction(tx);
-      res.json({ health_factor: (result as any).result?.retval });
-    } catch (error) {
-      next(error);
-    }
-  },
-);
+    const result = await rpcClient.simulateTransaction(tx);
+    res.json({ health_factor: (result as any).result?.retval });
+  } catch (error) {
+    next(error);
+  }
+});
 
 // POST /api/loan/repayment-preview
 app.post(
-  "/api/loan/repayment-preview",
+  '/api/loan/repayment-preview',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRepaymentPreviewSchema.safeParse(req.body);
 
     if (!validation.success) {
-      logger.warn("Validation failed for loan repayment preview", {
+      logger.warn('Validation failed for loan repayment preview', {
         requestId: req.requestId,
         errors: validation.error.issues,
       });
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       });
     }
@@ -914,18 +889,13 @@ app.post(
     // Fetch loan details from contract (simulated)
     const contract = new Contract(CONTRACT_ID);
     const account = await rpcClient.getAccount(
-      "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6", // fee-less read account
+      'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6' // fee-less read account
     );
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "get_loan",
-          nativeToScVal(BigInt(loan_id), { type: "u64" }),
-        ),
-      )
+      .addOperation(contract.call('get_loan', nativeToScVal(BigInt(loan_id), { type: 'u64' })))
       .setTimeout(30)
       .build();
 
@@ -939,13 +909,11 @@ app.post(
         fee: BASE_FEE,
         networkPassphrase: NETWORK_PASSPHRASE,
       })
-        .addOperation(contract.call("fee_config"))
+        .addOperation(contract.call('fee_config'))
         .setTimeout(30)
         .build();
       const feeResult = await rpcClient.simulateTransaction(feeTx);
-      const feeConfig = parseFeeConfigFromSimulation(
-        (feeResult as any).result?.retval,
-      );
+      const feeConfig = parseFeeConfigFromSimulation((feeResult as any).result?.retval);
       if (feeConfig) {
         interestFeeBps = feeConfig.interest_fee_bps;
       }
@@ -954,10 +922,7 @@ app.post(
     }
 
     const cappedRepayment = Math.min(amount, parsed.outstanding);
-    const interestOutstanding = Math.max(
-      parsed.outstanding - parsed.principal,
-      0,
-    );
+    const interestOutstanding = Math.max(parsed.outstanding - parsed.principal, 0);
     const interestPaid = Math.min(cappedRepayment, interestOutstanding);
     const principalPaid = cappedRepayment - interestPaid;
     const fees = Math.floor((interestPaid * interestFeeBps) / 10_000);
@@ -966,10 +931,7 @@ app.post(
     const projectedHealthFactorBps =
       remainingBalance === 0
         ? null
-        : Math.floor(
-            (parsed.collateral_value * 8000 * 10_000) /
-              (remainingBalance * 10_000),
-          );
+        : Math.floor((parsed.collateral_value * 8000 * 10_000) / (remainingBalance * 10_000));
 
     res.json({
       loan_id,
@@ -983,29 +945,29 @@ app.post(
       projected_health_factor_bps: projectedHealthFactorBps,
       fully_repaid: remainingBalance === 0,
     });
-  }),
+  })
 );
 
 // POST /api/oracle/price-update — invalidate appraisal cache on oracle update
 app.post(
-  "/api/oracle/price-update",
+  '/api/oracle/price-update',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   (req: Request, res: Response) => {
     invalidateAll();
     res.json({ invalidated: true });
-  },
+  }
 );
 
 // ── webhook routes ────────────────────────────────────────────────────────────
 
 // POST /api/webhooks — register a webhook URL
 app.post(
-  "/api/webhooks",
+  '/api/webhooks',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   (req: Request, res: Response) => {
     const { url } = req.body;
-    if (!url || typeof url !== "string") {
-      return res.status(400).json({ error: "url is required" });
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ error: 'url is required' });
     }
     try {
       const reg = registerWebhook(url);
@@ -1013,26 +975,26 @@ app.post(
     } catch (err: any) {
       return res.status(400).json({ error: err.message });
     }
-  },
+  }
 );
 
 // GET /api/admin/webhooks — list registered webhooks
-app.get("/api/admin/webhooks", (req: Request, res: Response) => {
+app.get('/api/admin/webhooks', (req: Request, res: Response) => {
   res.json(getWebhooks());
 });
 
 // GET /api/admin/webhooks/logs — delivery logs
-app.get("/api/admin/webhooks/logs", (req: Request, res: Response) => {
+app.get('/api/admin/webhooks/logs', (req: Request, res: Response) => {
   res.json(getDeliveryLogs());
 });
 
 // GET /api/admin/migrations/status — migration status
 app.get(
-  "/api/admin/migrations/status",
+  '/api/admin/migrations/status',
   asyncHandler(async (req: Request, res: Response) => {
     const status = await getMigrationStatus();
     res.json({ status });
-  }),
+  })
 );
 
 /**
@@ -1051,12 +1013,12 @@ app.get(
  *   limit    records per page (default 20, max 100)
  */
 app.get(
-  "/api/v1/admin/audit",
+  '/api/v1/admin/audit',
   asyncHandler(async (req: Request, res: Response) => {
     // Admin-only: require role === "admin" in JWT payload
     const user = (req as any).user as { publicKey?: string; role?: string } | undefined;
-    if (!user || user.role !== "admin") {
-      return res.status(403).json({ error: "Forbidden: admin role required" });
+    if (!user || user.role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden: admin role required' });
     }
 
     const { from, to, userId } = req.query as Record<string, string | undefined>;
@@ -1064,24 +1026,24 @@ app.get(
     const limitRaw = req.query.limit !== undefined ? Number(req.query.limit) : 20;
 
     if (!Number.isInteger(pageRaw) || pageRaw < 1) {
-      return res.status(400).json({ error: "page must be a positive integer" });
+      return res.status(400).json({ error: 'page must be a positive integer' });
     }
     if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > 100) {
-      return res.status(400).json({ error: "limit must be between 1 and 100" });
+      return res.status(400).json({ error: 'limit must be between 1 and 100' });
     }
 
     // Validate and enforce 90-day max range
     const MS_90_DAYS = 90 * 24 * 60 * 60 * 1000;
     if (from && isNaN(new Date(from).getTime())) {
-      return res.status(400).json({ error: "from must be a valid ISO date" });
+      return res.status(400).json({ error: 'from must be a valid ISO date' });
     }
     if (to && isNaN(new Date(to).getTime())) {
-      return res.status(400).json({ error: "to must be a valid ISO date" });
+      return res.status(400).json({ error: 'to must be a valid ISO date' });
     }
     if (from && to) {
       const rangeMs = new Date(to).getTime() - new Date(from).getTime();
       if (rangeMs > MS_90_DAYS) {
-        return res.status(400).json({ error: "Date range must not exceed 90 days" });
+        return res.status(400).json({ error: 'Date range must not exceed 90 days' });
       }
     }
 
@@ -1091,21 +1053,33 @@ app.get(
     const data = result.data.map((e) => ({ ...e, requestBody: redact(e.requestBody as object) }));
 
     res.json({ data, total: result.total, page: result.page, limit: result.limit });
-  }),
+  })
+);
+
+// POST /api/v1/admin/liquidation-check — manually trigger health factor job (#615)
+app.post(
+  '/api/v1/admin/liquidation-check',
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = (req as any).user as { publicKey?: string; role?: string } | undefined;
+    if (!user || user.role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden: admin role required' });
+    }
+    const updated = await runHealthFactorJob();
+    res.json({ updated, triggeredAt: new Date().toISOString() });
+  })
 );
 
 // ── soft-delete admin routes ──────────────────────────────────────────────────
 
 // GET /api/admin/deleted/collateral — list soft-deleted collateral records
-app.get("/api/admin/deleted/collateral", (req: Request, res: Response) => {
+app.get('/api/admin/deleted/collateral', (req: Request, res: Response) => {
   res.json(listDeletedCollateral());
 });
 
 // POST /api/admin/restore/collateral/:id — restore a soft-deleted collateral record
-app.post("/api/admin/restore/collateral/:id", (req: Request, res: Response) => {
+app.post('/api/admin/restore/collateral/:id', (req: Request, res: Response) => {
   const ok = restoreCollateral(req.params.id as string);
-  if (!ok)
-    return res.status(404).json({ error: "Record not found or not deleted" });
+  if (!ok) return res.status(404).json({ error: 'Record not found or not deleted' });
   res.json({ restored: true, id: req.params.id });
 });
 
@@ -1120,37 +1094,41 @@ const handleDeleteCollateral = (req: Request, res: Response) => {
   const id = req.params.id as string;
   const record = getCollateral(id);
   if (!record) {
-    return res.status(404).json({ error: "Record not found" });
+    return res.status(404).json({ error: 'Record not found' });
   }
 
   // Check if pledged to an active loan
   if (isCollateralPledged(id)) {
-    return res.status(409).json({ error: "Collateral is currently pledged to an active loan" });
+    return res.status(409).json({ error: 'Collateral is currently pledged to an active loan' });
   }
 
   // Check authorization: owner or admin
   const user = (req as Request & { user?: { publicKey: string; role?: string } }).user;
   const isOwner = user && user.publicKey === record.owner;
   const isUserAdmin =
-    (user && user.role === "admin") ||
+    (user && user.role === 'admin') ||
     (config.ADMIN_API_KEY && user && user.publicKey === config.ADMIN_API_KEY) ||
-    (config.ADMIN_API_KEY && ((req.headers["x-admin-key"] as string) === config.ADMIN_API_KEY || (req.headers["admin-api-key"] as string) === config.ADMIN_API_KEY));
+    (config.ADMIN_API_KEY &&
+      ((req.headers['x-admin-key'] as string) === config.ADMIN_API_KEY ||
+        (req.headers['admin-api-key'] as string) === config.ADMIN_API_KEY));
 
   if (!isOwner && !isUserAdmin) {
-    return res.status(403).json({ error: "Forbidden: Only the owner or an admin can delete this collateral" });
+    return res
+      .status(403)
+      .json({ error: 'Forbidden: Only the owner or an admin can delete this collateral' });
   }
 
   const ok = softDeleteCollateral(id);
-  if (!ok) return res.status(404).json({ error: "Record not found" });
+  if (!ok) return res.status(404).json({ error: 'Record not found' });
   res.json({ deleted: true, id });
 };
 
 // DELETE /api/collateral/:id — soft delete a collateral record
-app.delete("/api/collateral/:id", handleDeleteCollateral);
+app.delete('/api/collateral/:id', handleDeleteCollateral);
 
 // ── POST /api/collateral — animal registration with image upload ──────────────
 
-const uploadsDir = path.join(__dirname, "..", "uploads");
+const uploadsDir = path.join(__dirname, '..', 'uploads');
 const upload = multer({
   storage: multer.diskStorage({
     destination: (_req, _file, cb) => cb(null, uploadsDir),
@@ -1158,8 +1136,8 @@ const upload = multer({
   }),
   limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB
   fileFilter: (_req, file, cb) => {
-    if (file.mimetype.startsWith("image/")) cb(null, true);
-    else cb(new Error("Only image files are allowed"));
+    if (file.mimetype.startsWith('image/')) cb(null, true);
+    else cb(new Error('Only image files are allowed'));
   },
 });
 
@@ -1167,10 +1145,10 @@ const upload = multer({
 mkdirSync(uploadsDir, { recursive: true });
 
 app.post(
-  "/api/collateral",
+  '/api/collateral',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
-  upload.single("image"),
+  upload.single('image'),
   asyncHandler(async (req: Request, res: Response) => {
     const { species, breed, age, weight } = req.body as {
       species?: string;
@@ -1179,27 +1157,27 @@ app.post(
       weight?: string;
     };
 
-    if (!species || typeof species !== "string" || species.trim() === "") {
-      return res.status(400).json({ error: "species is required" });
+    if (!species || typeof species !== 'string' || species.trim() === '') {
+      return res.status(400).json({ error: 'species is required' });
     }
-    if (!breed || typeof breed !== "string" || breed.trim() === "") {
-      return res.status(400).json({ error: "breed is required" });
+    if (!breed || typeof breed !== 'string' || breed.trim() === '') {
+      return res.status(400).json({ error: 'breed is required' });
     }
     const ageNum = Number(age);
     if (!age || !Number.isFinite(ageNum) || ageNum < 0) {
-      return res.status(400).json({ error: "age must be a non-negative number" });
+      return res.status(400).json({ error: 'age must be a non-negative number' });
     }
     const weightNum = Number(weight);
     if (!weight || !Number.isFinite(weightNum) || weightNum <= 0) {
-      return res.status(400).json({ error: "weight must be a positive number" });
+      return res.status(400).json({ error: 'weight must be a positive number' });
     }
     if (!req.file) {
-      return res.status(400).json({ error: "image file is required" });
+      return res.status(400).json({ error: 'image file is required' });
     }
 
     const owner = (req as any).user?.publicKey as string | undefined;
     if (!owner) {
-      return res.status(401).json({ error: "Authenticated wallet address required" });
+      return res.status(401).json({ error: 'Authenticated wallet address required' });
     }
 
     const imageUrl = `/uploads/${req.file.filename}`;
@@ -1218,115 +1196,133 @@ app.post(
       image_url: imageUrl,
     });
 
-    invalidateCache("/api/collateral");
+    invalidateCache('/api/collateral');
     res.status(201).json(record);
-  }),
+  })
 );
 
 // ── v1 collateral CRUD ────────────────────────────────────────────────────────
 
 // POST /api/v1/collateral — register collateral (DB record)
 app.post(
-  "/api/v1/collateral",
+  '/api/v1/collateral',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
-  validate(createCollateralSchema, { statusCode: 422, errorShape: "dictionary" }),
+  validate(createCollateralSchema, { statusCode: 422, errorShape: 'dictionary' }),
   asyncHandler(async (req: Request, res: Response) => {
     const owner = (req as Request & { user?: { publicKey?: string } }).user?.publicKey;
     if (!owner) {
-      return res.status(401).json({ error: "Authenticated wallet address required" });
+      return res.status(401).json({ error: 'Authenticated wallet address required' });
     }
 
     const { animal_type, count, appraised_value } = req.body as CreateCollateralInput;
-    const record = insertCollateral({ id: randomUUID(), owner, animal_type, count, appraised_value });
-    invalidateCache("/api/collateral");
+    const record = insertCollateral({
+      id: randomUUID(),
+      owner,
+      animal_type,
+      count,
+      appraised_value,
+    });
+    invalidateCache('/api/collateral');
     res.status(201).json(record);
-  }),
+  })
 );
 
 // PATCH /api/v1/collateral/:id — partially update collateral fields
 app.patch(
-  "/api/v1/collateral/:id",
+  '/api/v1/collateral/:id',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
-  validate(updateCollateralSchema, { statusCode: 422, errorShape: "dictionary" }),
+  validate(updateCollateralSchema, { statusCode: 422, errorShape: 'dictionary' }),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params.id as string;
     const record = getCollateral(id);
     if (!record) {
-      return res.status(404).json({ error: "Record not found" });
+      return res.status(404).json({ error: 'Record not found' });
     }
 
     const updates = req.body as UpdateCollateralInput;
     const updated = updateCollateral(id, updates);
     if (!updated) {
-      return res.status(404).json({ error: "Record not found" });
+      return res.status(404).json({ error: 'Record not found' });
     }
 
-    invalidateCache("/api/collateral");
+    invalidateCache('/api/collateral');
     res.json(updated);
-  }),
+  })
 );
 
 // GET /api/v1/collateral — list collateral with optional filters and pagination
-app.get("/api/v1/collateral", asyncHandler(async (req: Request, res: Response) => {
-  const page = req.query.page !== undefined ? Number(req.query.page) : 1;
-  const pageSize = req.query.pageSize !== undefined ? Number(req.query.pageSize) : 20;
-  if (!Number.isInteger(page) || page < 1) {
-    return res.status(400).json({ error: "page must be a positive integer" });
-  }
-  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
-    return res.status(400).json({ error: "pageSize must be between 1 and 100" });
-  }
-  const ownerId = typeof req.query.owner === "string" ? req.query.owner : undefined;
-  const result = listCollateral({ page, limit: pageSize, ownerId });
-  // Apply animal_type filter post-fetch (not part of the new store API)
-  const animalType = typeof req.query.animal_type === "string" ? req.query.animal_type : undefined;
-  const data = animalType ? result.data.filter((r) => r.animal_type === animalType) : result.data;
-  const total = animalType ? data.length : result.total;
-  res.json({ data, total, page: result.page, pageSize: result.limit });
-}));
+app.get(
+  '/api/v1/collateral',
+  asyncHandler(async (req: Request, res: Response) => {
+    const page = req.query.page !== undefined ? Number(req.query.page) : 1;
+    const pageSize = req.query.pageSize !== undefined ? Number(req.query.pageSize) : 20;
+    if (!Number.isInteger(page) || page < 1) {
+      return res.status(400).json({ error: 'page must be a positive integer' });
+    }
+    if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+      return res.status(400).json({ error: 'pageSize must be between 1 and 100' });
+    }
+    const ownerId = typeof req.query.owner === 'string' ? req.query.owner : undefined;
+    const result = listCollateral({ page, limit: pageSize, ownerId });
+    // Apply animal_type filter post-fetch (not part of the new store API)
+    const animalType =
+      typeof req.query.animal_type === 'string' ? req.query.animal_type : undefined;
+    const data = animalType ? result.data.filter((r) => r.animal_type === animalType) : result.data;
+    const total = animalType ? data.length : result.total;
+    res.json({ data, total, page: result.page, pageSize: result.limit });
+  })
+);
 
 // PUT /api/v1/collateral/:id/appraise — update appraised_value
-app.put("/api/v1/collateral/:id/appraise", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
-  const { appraised_value } = req.body;
-  if (typeof appraised_value !== "number" || !Number.isInteger(appraised_value) || appraised_value <= 0) {
-    return res.status(400).json({ error: "appraised_value must be a positive integer" });
-  }
-  const record = getCollateral(req.params.id as string);
-  if (!record) return res.status(404).json({ error: "Record not found" });
-  record.appraised_value = appraised_value;
-  const appraiser = (req as Request & { user?: { publicKey?: string } }).user?.publicKey;
-  setAppraisal(req.params.id as string, appraised_value);
-  addAppraisal(req.params.id as string, appraised_value, appraiser);
-  invalidateCache(`/api/v1/collateral/${req.params.id}/appraisals`);
-  res.json(record);
-}));
+app.put(
+  '/api/v1/collateral/:id/appraise',
+  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { appraised_value } = req.body;
+    if (
+      typeof appraised_value !== 'number' ||
+      !Number.isInteger(appraised_value) ||
+      appraised_value <= 0
+    ) {
+      return res.status(400).json({ error: 'appraised_value must be a positive integer' });
+    }
+    const record = getCollateral(req.params.id as string);
+    if (!record) return res.status(404).json({ error: 'Record not found' });
+    record.appraised_value = appraised_value;
+    const appraiser = (req as Request & { user?: { publicKey?: string } }).user?.publicKey;
+    setAppraisal(req.params.id as string, appraised_value);
+    addAppraisal(req.params.id as string, appraised_value, appraiser);
+    invalidateCache(`/api/v1/collateral/${req.params.id}/appraisals`);
+    res.json(record);
+  })
+);
 
 // GET /api/v1/collateral/:id/appraisals — paginated appraisal history
 app.get(
-  "/api/v1/collateral/:id/appraisals",
+  '/api/v1/collateral/:id/appraisals',
   createResponseCacheMiddleware(5 * 60 * 1000),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params.id as string;
     const record = getCollateral(id);
-    if (!record) return res.status(404).json({ error: "Collateral not found" });
+    if (!record) return res.status(404).json({ error: 'Collateral not found' });
 
     const user = (req as Request & { user?: { publicKey?: string; role?: string } }).user;
-    if (!user || (user.role !== "admin" && user.publicKey !== record.owner)) {
-      return res.status(404).json({ error: "Collateral not found" });
+    if (!user || (user.role !== 'admin' && user.publicKey !== record.owner)) {
+      return res.status(404).json({ error: 'Collateral not found' });
     }
 
     const pageRaw = req.query.page !== undefined ? Number(req.query.page) : 1;
     const limitRaw = req.query.limit !== undefined ? Number(req.query.limit) : 20;
     if (!Number.isInteger(pageRaw) || pageRaw < 1) {
-      return res.status(400).json({ error: "page must be a positive integer" });
+      return res.status(400).json({ error: 'page must be a positive integer' });
     }
     if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > 100) {
-      return res.status(400).json({ error: "limit must be between 1 and 100" });
+      return res.status(400).json({ error: 'limit must be between 1 and 100' });
     }
 
     const result = getAppraisalHistory(id, pageRaw, limitRaw)!;
     res.json(result);
-  }),
+  })
 );
 
 /**
@@ -1336,88 +1332,94 @@ app.get(
  * Returns 409 if collateral is pledged to an active loan and appraised_value is being reduced.
  * Writes a structured audit log entry on every successful update.
  */
-app.patch("/api/v1/collateral/:id", timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)), asyncHandler(async (req: Request, res: Response) => {
-  const patchSchema = z.object({
-    animal_type: z.string().min(1).optional(),
-    count: z.number().int().positive().optional(),
-    appraised_value: z.number().int().optional(),
-  }).strict();
+app.patch(
+  '/api/v1/collateral/:id',
+  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  asyncHandler(async (req: Request, res: Response) => {
+    const patchSchema = z
+      .object({
+        animal_type: z.string().min(1).optional(),
+        count: z.number().int().positive().optional(),
+        appraised_value: z.number().int().optional(),
+      })
+      .strict();
 
-  const validation = patchSchema.safeParse(req.body);
-  if (!validation.success) {
-    return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
-  }
+    const validation = patchSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
+    }
 
-  const updates = validation.data;
+    const updates = validation.data;
 
-  if (updates.appraised_value !== undefined && updates.appraised_value <= 0) {
-    return res.status(400).json({ error: "appraised_value must be positive" });
-  }
+    if (updates.appraised_value !== undefined && updates.appraised_value <= 0) {
+      return res.status(400).json({ error: 'appraised_value must be positive' });
+    }
 
-  const record = getCollateral(req.params.id);
-  if (!record) return res.status(404).json({ error: "Record not found" });
+    const record = getCollateral(req.params.id);
+    if (!record) return res.status(404).json({ error: 'Record not found' });
 
-  // 409: pledged to active loan and appraised_value is being reduced
-  if (
-    updates.appraised_value !== undefined &&
-    updates.appraised_value < record.appraised_value &&
-    isCollateralPledged(req.params.id)
-  ) {
-    return res.status(409).json({
-      error: "Cannot reduce appraised_value: collateral is pledged to an active loan",
+    // 409: pledged to active loan and appraised_value is being reduced
+    if (
+      updates.appraised_value !== undefined &&
+      updates.appraised_value < record.appraised_value &&
+      isCollateralPledged(req.params.id)
+    ) {
+      return res.status(409).json({
+        error: 'Cannot reduce appraised_value: collateral is pledged to an active loan',
+      });
+    }
+
+    const updated = updateCollateral(req.params.id, updates);
+    if (!updated) return res.status(404).json({ error: 'Record not found' });
+
+    // Audit log entry
+    const user = (req as any).user;
+    insertAuditEntry({
+      userId: user?.publicKey ?? 'anonymous',
+      action: 'collateral.patch',
+      resource: 'collateral',
+      resourceId: req.params.id,
+      requestBody: redact(updates),
+      ip: req.ip,
     });
-  }
+    auditLogger.info('collateral.patch', {
+      requestId: (req as any).requestId,
+      collateralId: req.params.id,
+      userId: user?.publicKey,
+      updates: redact(updates),
+    });
 
-  const updated = updateCollateral(req.params.id, updates);
-  if (!updated) return res.status(404).json({ error: "Record not found" });
-
-  // Audit log entry
-  const user = (req as any).user;
-  insertAuditEntry({
-    userId: user?.publicKey ?? "anonymous",
-    action: "collateral.patch",
-    resource: "collateral",
-    resourceId: req.params.id,
-    requestBody: redact(updates),
-    ip: req.ip,
-  });
-  auditLogger.info("collateral.patch", {
-    requestId: (req as any).requestId,
-    collateralId: req.params.id,
-    userId: user?.publicKey,
-    updates: redact(updates),
-  });
-
-  res.json(updated);
-}));
+    res.json(updated);
+  })
+);
 
 // DELETE /api/v1/collateral/:id — soft delete
-app.delete("/api/v1/collateral/:id", handleDeleteCollateral);
+app.delete('/api/v1/collateral/:id', handleDeleteCollateral);
 
 // PATCH /api/v1/collateral/:id/restore — restore soft-deleted collateral
 app.patch(
-  "/api/v1/collateral/:id/restore",
+  '/api/v1/collateral/:id/restore',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params.id as string;
     const collateral = getCollateralIncludingDeleted(id);
 
     if (!collateral || collateral.deletedAt === null) {
-      return res.status(404).json({ error: "Record not found or not deleted" });
+      return res.status(404).json({ error: 'Record not found or not deleted' });
     }
 
     if (isCollateralPledged(id)) {
-      return res.status(409).json({ error: "Collateral is currently pledged to an active loan" });
+      return res.status(409).json({ error: 'Collateral is currently pledged to an active loan' });
     }
 
     const restored = restoreCollateral(id);
     if (!restored) {
-      return res.status(404).json({ error: "Record not found or not deleted" });
+      return res.status(404).json({ error: 'Record not found or not deleted' });
     }
 
-    invalidateCache("/api/collateral");
+    invalidateCache('/api/collateral');
     res.json({ restored: true, id });
-  }),
+  })
 );
 
 // ── Loan estimate ─────────────────────────────────────────────────────────────
@@ -1441,12 +1443,12 @@ const loanEstimateSchema = z.object({
  * Rejects requests where `principal` is below 1 XLM (10 000 000 stroops).
  */
 app.post(
-  "/api/v1/loans/estimate",
+  '/api/v1/loans/estimate',
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanEstimateSchema.safeParse(req.body);
     if (!validation.success) {
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         details: validation.error.issues,
       });
     }
@@ -1455,7 +1457,7 @@ app.post(
 
     if (principal < ONE_XLM_STROOPS) {
       return res.status(400).json({
-        error: "Validation failed",
+        error: 'Validation failed',
         message: `principal must be at least 1 XLM (${ONE_XLM_STROOPS} stroops)`,
       });
     }
@@ -1466,48 +1468,47 @@ app.post(
     const interestRate = origFeeBps / 100;
 
     return res.json({ principal, originationFee, totalAmount, interestRate });
-  }),
+  })
 );
 
 // GET /api/v1/loans/summary — borrower-scoped portfolio summary
 app.get(
-  "/api/v1/loans/summary",
+  '/api/v1/loans/summary',
   readLimiter,
   createResponseCacheMiddleware(30_000),
   asyncHandler(async (req: Request, res: Response) => {
     const user = (req as Request & { user?: { publicKey?: string } }).user;
     if (!user?.publicKey) {
-      return res.status(401).json({ error: "Authenticated wallet address required" });
+      return res.status(401).json({ error: 'Authenticated wallet address required' });
     }
 
     const summary = getLoanSummaryForBorrower(user.publicKey);
     res.json(summary);
-  }),
+  })
 );
 
 // GET /api/admin/deleted/loans — list soft-deleted loan records
-app.get("/api/admin/deleted/loans", (req: Request, res: Response) => {
+app.get('/api/admin/deleted/loans', (req: Request, res: Response) => {
   res.json(listDeletedLoans());
 });
 
 // POST /api/admin/restore/loans/:id — restore a soft-deleted loan record
-app.post("/api/admin/restore/loans/:id", (req: Request, res: Response) => {
+app.post('/api/admin/restore/loans/:id', (req: Request, res: Response) => {
   const ok = restoreLoan(req.params.id as string);
-  if (!ok)
-    return res.status(404).json({ error: "Record not found or not deleted" });
+  if (!ok) return res.status(404).json({ error: 'Record not found or not deleted' });
   res.json({ restored: true, id: req.params.id });
 });
 
 // DELETE /api/loan/:id — soft delete a loan record
-app.delete("/api/loan/:id", (req: Request, res: Response) => {
+app.delete('/api/loan/:id', (req: Request, res: Response) => {
   const ok = softDeleteLoan(req.params.id as string);
-  if (!ok) return res.status(404).json({ error: "Record not found" });
+  if (!ok) return res.status(404).json({ error: 'Record not found' });
   res.json({ deleted: true, id: req.params.id });
 });
 
 // GET /api/transactions — transaction history with filtering, sorting, and pagination
 app.get(
-  "/api/transactions",
+  '/api/transactions',
   asyncHandler(async (req: Request, res: Response) => {
     const borrower = req.query.borrower as string | undefined;
     const type = req.query.type as TransactionType | undefined;
@@ -1518,18 +1519,18 @@ app.get(
     const pageSizeRaw = req.query.pageSize !== undefined ? Number(req.query.pageSize) : 20;
 
     if (!Number.isInteger(pageRaw) || pageRaw < 1) {
-      return res.status(400).json({ error: "page must be a positive integer" });
+      return res.status(400).json({ error: 'page must be a positive integer' });
     }
     if (!Number.isInteger(pageSizeRaw) || pageSizeRaw < 1 || pageSizeRaw > 100) {
-      return res.status(400).json({ error: "pageSize must be between 1 and 100" });
+      return res.status(400).json({ error: 'pageSize must be between 1 and 100' });
     }
 
     // Validate date range if provided
     if (startDate && isNaN(new Date(startDate).getTime())) {
-      return res.status(400).json({ error: "startDate must be a valid ISO date" });
+      return res.status(400).json({ error: 'startDate must be a valid ISO date' });
     }
     if (endDate && isNaN(new Date(endDate).getTime())) {
-      return res.status(400).json({ error: "endDate must be a valid ISO date" });
+      return res.status(400).json({ error: 'endDate must be a valid ISO date' });
     }
 
     const result = listTransactions({
@@ -1543,83 +1544,127 @@ app.get(
     });
 
     res.json(result);
-  }),
+  })
+);
+
+// GET /api/v1/transactions — paginated transaction history for the authenticated user (#618)
+app.get(
+  '/api/v1/transactions',
+  readLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = (req as any).user as { publicKey?: string } | undefined;
+    if (!user?.publicKey) {
+      return res.status(401).json({ error: 'Authenticated wallet address required' });
+    }
+
+    const type = req.query.type as TransactionType | undefined;
+    const status = req.query.status as TransactionStatus | undefined;
+    const loanId = typeof req.query.loanId === 'string' ? req.query.loanId : undefined;
+    const collateralId =
+      typeof req.query.collateralId === 'string' ? req.query.collateralId : undefined;
+    const pageRaw = req.query.page !== undefined ? Number(req.query.page) : 1;
+    const pageSizeRaw = req.query.pageSize !== undefined ? Number(req.query.pageSize) : 20;
+
+    if (!Number.isInteger(pageRaw) || pageRaw < 1) {
+      return res.status(400).json({ error: 'page must be a positive integer' });
+    }
+    if (!Number.isInteger(pageSizeRaw) || pageSizeRaw < 1 || pageSizeRaw > 100) {
+      return res.status(400).json({ error: 'pageSize must be between 1 and 100' });
+    }
+
+    if (type && !['loan', 'repayment', 'liquidation'].includes(type)) {
+      return res.status(400).json({ error: 'type must be one of: loan, repayment, liquidation' });
+    }
+    if (status && !['pending', 'completed', 'failed'].includes(status)) {
+      return res.status(400).json({ error: 'status must be one of: pending, completed, failed' });
+    }
+
+    const result = listTransactions({
+      borrower: user.publicKey,
+      type,
+      status,
+      loanId,
+      collateralId,
+      page: pageRaw,
+      pageSize: pageSizeRaw,
+    });
+
+    res.json(result);
+  })
 );
 
 // GET /api/transactions/:id — get transaction details
 app.get(
-  "/api/transactions/:id",
+  '/api/transactions/:id',
   asyncHandler(async (req: Request, res: Response) => {
     const transaction = getTransaction(req.params.id as string);
     if (!transaction) {
-      return res.status(404).json({ error: "Transaction not found" });
+      return res.status(404).json({ error: 'Transaction not found' });
     }
     res.json(transaction);
-  }),
+  })
 );
 
 // PUT /api/loans/:id/repay — record a repayment against a loan
 app.put(
-  "/api/loans/:id/repay",
+  '/api/loans/:id/repay',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const { amount, transactionHash } = req.body as { amount?: unknown; transactionHash?: unknown };
 
-    if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
-      return res.status(400).json({ error: "amount must be a positive number" });
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+      return res.status(400).json({ error: 'amount must be a positive number' });
     }
-    if (typeof transactionHash !== "string" || !transactionHash) {
-      return res.status(400).json({ error: "transactionHash is required" });
+    if (typeof transactionHash !== 'string' || !transactionHash) {
+      return res.status(400).json({ error: 'transactionHash is required' });
     }
 
     const loan = getLoan(req.params.id as string);
-    if (!loan) return res.status(404).json({ error: "Loan not found" });
+    if (!loan) return res.status(404).json({ error: 'Loan not found' });
 
     if (amount > loan.amount) {
-      return res.status(400).json({ error: "amount exceeds outstanding balance" });
+      return res.status(400).json({ error: 'amount exceeds outstanding balance' });
     }
 
     const newBalance = loan.amount - amount;
     const updated = updateLoan(req.params.id as string, { amount: newBalance });
-    invalidateCache("/api/loans");
+    invalidateCache('/api/loans');
 
     insertTransaction({
       borrower: loan.borrower,
-      type: "repayment",
-      status: "completed",
+      type: 'repayment',
+      status: 'completed',
       amount,
       loanId: loan.id,
     });
 
     res.json(updated);
-  }),
+  })
 );
 
 // ── error handler ─────────────────────────────────────────────────────────────
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   if (err instanceof PoolExhaustedError) {
-    return res
-      .status(503)
-      .json({ error: "Service unavailable: connection pool exhausted" });
+    return res.status(503).json({ error: 'Service unavailable: connection pool exhausted' });
   }
   track5xx();
   errorHandler(err, req, res, next);
 });
 
-if (process.env.NODE_ENV !== "test") {
-  const PORT = parseInt(process.env.PORT || "3001", 10);
+if (process.env.NODE_ENV !== 'test') {
+  const PORT = parseInt(process.env.PORT || '3001', 10);
   app.listen(PORT, () => {
     logger.info(`StellarKraal API running on port ${PORT}`, {
       port: PORT,
-      environment: process.env.NODE_ENV || "development",
-      logLevel: process.env.LOG_LEVEL || "info",
+      environment: process.env.NODE_ENV || 'development',
+      logLevel: process.env.LOG_LEVEL || 'info',
     });
   });
 }
 
 const healthFactorTask = scheduleHealthFactorJob();
-const repaymentReminderTask = scheduleRepaymentReminderJob();
+scheduleRepaymentReminderJob();
 
 // ── Graceful Shutdown ─────────────────────────────────────────────────────────
 
@@ -1627,7 +1672,7 @@ const SHUTDOWN_TIMEOUT_MS = parseInt(config.SHUTDOWN_TIMEOUT_MS, 10);
 
 async function gracefulShutdown(signal: string): Promise<void> {
   if (isShuttingDown) {
-    logger.warn("Shutdown already in progress, ignoring signal", { signal });
+    logger.warn('Shutdown already in progress, ignoring signal', { signal });
     return;
   }
 
@@ -1636,12 +1681,12 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
   // Stop accepting new connections
   httpServer.close(() => {
-    logger.info("HTTP server closed, no longer accepting connections");
+    logger.info('HTTP server closed, no longer accepting connections');
   });
 
   // Set a timeout to force shutdown if graceful shutdown takes too long
   const forceShutdownTimer = setTimeout(() => {
-    logger.error("Graceful shutdown timeout exceeded, forcing exit", {
+    logger.error('Graceful shutdown timeout exceeded, forcing exit', {
       timeoutMs: SHUTDOWN_TIMEOUT_MS,
     });
     process.exit(1);
@@ -1656,27 +1701,27 @@ async function gracefulShutdown(signal: string): Promise<void> {
           clearInterval(checkInterval);
           resolve();
         } else {
-          logger.info("Waiting for in-flight requests to complete", {
+          logger.info('Waiting for in-flight requests to complete', {
             inUse: stats.inUse,
           });
         }
       }, 1000);
     });
 
-    logger.info("All in-flight requests completed");
+    logger.info('All in-flight requests completed');
 
     // Close database connections
     pool.close();
-    logger.info("Database connection pool closed");
+    logger.info('Database connection pool closed');
 
     healthFactorTask.stop();
-    logger.info("Health factor job stopped");
+    logger.info('Health factor job stopped');
 
     clearTimeout(forceShutdownTimer);
-    logger.info("Graceful shutdown complete");
+    logger.info('Graceful shutdown complete');
     process.exit(0);
   } catch (error) {
-    logger.error("Error during graceful shutdown", {
+    logger.error('Error during graceful shutdown', {
       error: (error as Error).message,
     });
     clearTimeout(forceShutdownTimer);
@@ -1685,36 +1730,43 @@ async function gracefulShutdown(signal: string): Promise<void> {
 }
 
 // Register signal handlers
-process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
-process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 // Handle uncaught errors
-process.on("uncaughtException", (error: Error) => {
-  logger.error("Uncaught exception", {
+process.on('uncaughtException', (error: Error) => {
+  logger.error('Uncaught exception', {
     error: error.message,
     stack: error.stack,
   });
-  gracefulShutdown("uncaughtException");
+  gracefulShutdown('uncaughtException');
 });
 
-process.on("unhandledRejection", (reason: unknown) => {
-  logger.error("Unhandled promise rejection", {
+process.on('unhandledRejection', (reason: unknown) => {
+  logger.error('Unhandled promise rejection', {
     reason: reason instanceof Error ? reason.message : String(reason),
   });
-  gracefulShutdown("unhandledRejection");
+  gracefulShutdown('unhandledRejection');
 });
 
 // Redirect unversioned routes to v1 with deprecation warning
-app.use("/api", (req: Request, res: Response, next: NextFunction) => {
+app.use('/api', (req: Request, res: Response, next: NextFunction) => {
   // Skip if already versioned or is auth/health
-  if (req.path.startsWith("/api/v1") || req.path === "/api/health" || req.path.startsWith("/api/auth")) {
+  if (
+    req.path.startsWith('/api/v1') ||
+    req.path === '/api/health' ||
+    req.path.startsWith('/api/auth')
+  ) {
     return next();
   }
 
-  const newPath = req.path.replace(/^\/api/, "/api/v1");
-  res.setHeader("Deprecation", "true");
-  res.setHeader("Warning", '299 - "Unversioned API routes are deprecated. Use /api/v1/ prefix."');
-  res.redirect(301, newPath + (req.url.includes("?") ? req.url.substring(req.url.indexOf("?")) : ""));
+  const newPath = req.path.replace(/^\/api/, '/api/v1');
+  res.setHeader('Deprecation', 'true');
+  res.setHeader('Warning', '299 - "Unversioned API routes are deprecated. Use /api/v1/ prefix."');
+  res.redirect(
+    301,
+    newPath + (req.url.includes('?') ? req.url.substring(req.url.indexOf('?')) : '')
+  );
 });
 
 export default app;
@@ -1723,4 +1775,3 @@ export default app;
 const httpServer = app.listen(parseInt(config.PORT, 10), () => {
   logger.info(`Server started on port ${config.PORT}`);
 });
-

--- a/backend/src/middleware/deduplication.ts
+++ b/backend/src/middleware/deduplication.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'crypto';
+import { Request, Response, NextFunction } from 'express';
+
+interface DedupeEntry {
+  status: number;
+  body: unknown;
+  createdAt: number;
+}
+
+const DEDUPE_TTL_MS = 5_000;
+const cache = new Map<string, DedupeEntry>();
+
+function dedupeKey(publicKey: string, body: unknown): string {
+  const hash = createHash('sha256')
+    .update(JSON.stringify(body ?? {}))
+    .digest('hex');
+  return `${publicKey}:${hash}`;
+}
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of cache.entries()) {
+    if (now - entry.createdAt >= DEDUPE_TTL_MS) {
+      cache.delete(key);
+    }
+  }
+}
+
+/**
+ * Deduplicates identical concurrent POST requests within a 5-second window.
+ * Keyed by authenticated wallet address + SHA-256 of the request body.
+ * Returns the cached response immediately for duplicates without re-processing.
+ * @param req - Express request object.
+ * @param res - Express response object.
+ * @param next - Next middleware callback.
+ * @returns void
+ */
+export function deduplicationMiddleware(req: Request, res: Response, next: NextFunction): void {
+  if (req.method !== 'POST') return next();
+
+  const user = (req as any).user as { publicKey?: string } | undefined;
+  if (!user?.publicKey) return next();
+
+  evictExpired();
+
+  const key = dedupeKey(user.publicKey, req.body);
+  const cached = cache.get(key);
+
+  if (cached) {
+    res.setHeader('X-Deduplicated', 'true');
+    res.status(cached.status).json(cached.body);
+    return;
+  }
+
+  const originalJson = res.json.bind(res);
+  res.json = (body: unknown) => {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      cache.set(key, { status: res.statusCode, body, createdAt: Date.now() });
+    }
+    return originalJson(body);
+  };
+
+  next();
+}
+
+/** Exported for testing only — clears the deduplication cache. */
+export function _resetDeduplicationCache(): void {
+  cache.clear();
+}

--- a/backend/src/transactions.v1.integration.test.ts
+++ b/backend/src/transactions.v1.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for GET /api/v1/transactions (issue #618).
+ * Verifies auth enforcement, pagination, and per-user/collateral/loan filtering.
+ */
+import request from 'supertest';
+import app from './index';
+import { insertTransaction } from './db/store';
+
+jest.mock('./utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createRequestLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+  BASE_FEE: '100',
+  Contract: jest.fn().mockImplementation(() => ({ call: jest.fn().mockReturnValue({}) })),
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({ toXDR: () => 'mock_xdr' }),
+  })),
+  Address: jest.fn().mockImplementation(() => ({ toScVal: jest.fn().mockReturnValue({}) })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn().mockReturnValue({}),
+  xdr: { ScVal: { scvVoid: jest.fn().mockReturnValue({}) } },
+  Keypair: {
+    fromPublicKey: jest.fn().mockReturnValue({ verify: jest.fn().mockReturnValue(true) }),
+  },
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getAccount: jest.fn().mockResolvedValue({ id: 'GABC', sequence: '1' }),
+      prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => 'prepared_xdr' }),
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+      getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }),
+    })),
+  },
+}));
+
+jest.mock('./jobs/healthFactorJob', () => ({
+  scheduleHealthFactorJob: jest.fn(() => ({ stop: jest.fn() })),
+  runHealthFactorJob: jest.fn().mockResolvedValue(0),
+}));
+
+jest.mock('./jobs/repaymentReminderJob', () => ({
+  scheduleRepaymentReminderJob: jest.fn(() => ({ stop: jest.fn() })),
+}));
+
+const USER_KEY = 'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6';
+const OTHER_KEY = 'GBGBE57DSWNBO73HMKLGPCNUR7V4T3WYCXU34AHVZAR3FFFOSVZLEABQ';
+let testUser: any = { publicKey: USER_KEY };
+
+jest.mock('./middleware/auth', () => ({
+  authRouter: require('express').Router(),
+  jwtMiddleware: (req: any, _res: any, next: any) => {
+    req.user = testUser;
+    next();
+  },
+}));
+
+describe('GET /api/v1/transactions', () => {
+  beforeEach(() => {
+    testUser = { publicKey: USER_KEY };
+
+    insertTransaction({
+      borrower: USER_KEY,
+      type: 'loan',
+      status: 'completed',
+      amount: 500_000,
+      loanId: 'loan-1',
+      collateralId: 'col-1',
+    });
+    insertTransaction({
+      borrower: USER_KEY,
+      type: 'repayment',
+      status: 'completed',
+      amount: 100_000,
+      loanId: 'loan-1',
+    });
+    insertTransaction({
+      borrower: USER_KEY,
+      type: 'liquidation',
+      status: 'failed',
+      amount: 200_000,
+      collateralId: 'col-2',
+    });
+    // transaction for a different user — must never appear in results
+    insertTransaction({ borrower: OTHER_KEY, type: 'loan', status: 'completed', amount: 999_999 });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    testUser = null;
+    const res = await request(app).get('/api/v1/transactions');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns paginated transactions for the authenticated user only', async () => {
+    const res = await request(app).get('/api/v1/transactions');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(typeof res.body.total).toBe('number');
+    expect(res.body.page).toBe(1);
+    expect(typeof res.body.pageSize).toBe('number');
+    res.body.data.forEach((tx: any) => expect(tx.borrower).toBe(USER_KEY));
+  });
+
+  it('filters by type', async () => {
+    const res = await request(app).get('/api/v1/transactions?type=repayment');
+    expect(res.status).toBe(200);
+    res.body.data.forEach((tx: any) => expect(tx.type).toBe('repayment'));
+  });
+
+  it('filters by status', async () => {
+    const res = await request(app).get('/api/v1/transactions?status=failed');
+    expect(res.status).toBe(200);
+    res.body.data.forEach((tx: any) => expect(tx.status).toBe('failed'));
+  });
+
+  it('filters by loanId', async () => {
+    const res = await request(app).get('/api/v1/transactions?loanId=loan-1');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    res.body.data.forEach((tx: any) => expect(tx.loanId).toBe('loan-1'));
+  });
+
+  it('filters by collateralId', async () => {
+    const res = await request(app).get('/api/v1/transactions?collateralId=col-2');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    res.body.data.forEach((tx: any) => expect(tx.collateralId).toBe('col-2'));
+  });
+
+  it('returns 400 for invalid page', async () => {
+    const res = await request(app).get('/api/v1/transactions?page=0');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/page/);
+  });
+
+  it('returns 400 for pageSize > 100', async () => {
+    const res = await request(app).get('/api/v1/transactions?pageSize=101');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/pageSize/);
+  });
+
+  it('returns 400 for invalid type', async () => {
+    const res = await request(app).get('/api/v1/transactions?type=invalid');
+    expect(res.status).toBe(400);
+  });
+
+  it('respects pagination parameters', async () => {
+    const res = await request(app).get('/api/v1/transactions?page=1&pageSize=2');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeLessThanOrEqual(2);
+    expect(res.body.pageSize).toBe(2);
+  });
+});


### PR DESCRIPTION
…dpoint, request deduplication

- #615: Add POST /api/v1/admin/liquidation-check — admin-only endpoint that manually invokes runHealthFactorJob() and returns { updated, triggeredAt }
- #617: Harden pgQuery to require params array (no longer optional) and add explicit SQL injection audit documentation; confirm store.ts uses in-memory Maps with no SQL
- #618: Add GET /api/v1/transactions — JWT-scoped, paginated transaction history with optional loanId, collateralId, type, and status filters; add loanId/collateralId filter support to listTransactions() in store.ts
- #616: Add deduplicationMiddleware — 5 s in-memory cache keyed per user (publicKey)
  + SHA-256 body hash; duplicate POST returns cached response with X-Deduplicated header

Each change is covered by Jest integration tests (23 tests across 4 suites). Also adds Stellar public key allowlist to .gitleaks.toml (public keys are not secrets).

closes #615 closes #616 closes #617 closes #618

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please
