### PR TITLE
feat: batch collateral registration, query indexes, env validation, and OpenAPI CI

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate OpenAPI 3.0 spec
-        run: npx --yes @redocly/cli@1.x lint --extends=minimal backend/openapi.json
-
       - name: Check spec is committed
         run: |
           if [ ! -f backend/openapi.json ]; then
@@ -29,6 +26,9 @@ jobs:
             exit 1
           fi
           echo "openapi.json present"
+
+      - name: Validate OpenAPI 3.0 spec (strict)
+        run: npx --yes @redocly/cli@1.x lint --extends=recommended backend/openapi.json
 
       - name: Verify info.version matches package.json
         run: |
@@ -40,3 +40,97 @@ jobs:
             exit 1
           fi
           echo "info.version matches package.json ($PKG_VERSION)"
+
+  validate-spec-against-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Start backend server
+        env:
+          NODE_ENV: test
+          PORT: "3001"
+          RPC_URL: "https://soroban-testnet.stellar.org"
+          CONTRACT_ID: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"
+          JWT_SECRET: "ci-test-jwt-secret-at-least-16-chars" # gitleaks:allow
+          WEBHOOK_SECRET: "ci-test-webhook-secret-16"
+        run: |
+          npm run build
+          node dist/index.js &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+          # Wait for server to be ready (up to 30 s)
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3001/api/v1/health && break
+            sleep 1
+          done
+        working-directory: backend
+
+      - name: Validate spec routes exist on running server
+        run: |
+          node - <<'EOF'
+          const fs = require("fs");
+          const http = require("http");
+
+          const spec = JSON.parse(fs.readFileSync("backend/openapi.json", "utf8"));
+          const BASE = "http://localhost:3001/api/v1";
+
+          const SKIP_METHODS = new Set(["put", "patch", "delete"]);
+          const SKIP_PATHS = new Set([
+            "/collateral/{id}",
+            "/collateral/{id}/appraise",
+            "/collateral/{id}/restore",
+            "/loan/{id}",
+            "/health/{loanId}",
+            "/transactions/{hash}/status",
+            "/webhooks/{id}",
+            "/admin/restore/collateral/{id}",
+          ]);
+
+          async function probe(method, path) {
+            return new Promise((resolve) => {
+              const url = `${BASE}${path}`;
+              const req = http.request(url, { method: method.toUpperCase() }, (res) => {
+                resolve({ method, path, status: res.statusCode });
+              });
+              req.on("error", () => resolve({ method, path, status: null }));
+              req.end();
+            });
+          }
+
+          (async () => {
+            const failures = [];
+            for (const [path, methods] of Object.entries(spec.paths)) {
+              if (SKIP_PATHS.has(path)) continue;
+              for (const method of Object.keys(methods)) {
+                if (SKIP_METHODS.has(method)) continue;
+                const result = await probe(method, path);
+                // A reachable route returns any status except 404/405
+                if (result.status === 404 || result.status === 405 || result.status === null) {
+                  failures.push(`${method.toUpperCase()} ${path} → ${result.status ?? "unreachable"}`);
+                } else {
+                  console.log(`✓ ${method.toUpperCase()} ${path} → ${result.status}`);
+                }
+              }
+            }
+            if (failures.length > 0) {
+              console.error("\nSpec routes missing from server:");
+              failures.forEach((f) => console.error("  ✗ " + f));
+              process.exit(1);
+            }
+            console.log("\nAll probed spec routes are reachable.");
+          })();
+          EOF
+
+      - name: Stop backend server
+        if: always()
+        run: kill "$SERVER_PID" 2>/dev/null || true

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -105,6 +105,22 @@
         }
       }
     },
+    "/collateral/register/batch": {
+      "post": {
+        "tags": ["collateral"],
+        "summary": "Batch register livestock collateral (on-chain)",
+        "description": "Builds unsigned Soroban transactions for up to 50 livestock collateral registrations in a single request.",
+        "operationId": "batchRegisterCollateral",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/BatchRegisterCollateralRequest" } } } },
+        "responses": {
+          "200": { "description": "Array of unsigned XDR transactions, one per item in input order", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/BatchRegisterCollateralResponse" } } } },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
     "/collateral": {
       "post": {
         "tags": ["collateral"],
@@ -618,6 +634,30 @@
           "animal_type": { "type": "string", "example": "cattle" },
           "count": { "type": "integer", "minimum": 1, "example": 5 },
           "appraised_value": { "type": "integer", "minimum": 1, "description": "Total appraised value in token base units", "example": 5000000 }
+        }
+      },
+      "BatchRegisterCollateralRequest": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "description": "List of collateral registrations (1–50 items)",
+            "minItems": 1,
+            "maxItems": 50,
+            "items": { "$ref": "#/components/schemas/RegisterCollateralRequest" }
+          }
+        }
+      },
+      "BatchRegisterCollateralResponse": {
+        "type": "object",
+        "required": ["results"],
+        "properties": {
+          "results": {
+            "type": "array",
+            "description": "Unsigned XDR transactions, one per input item in order",
+            "items": { "$ref": "#/components/schemas/XdrResponse" }
+          }
         }
       },
       "V1CreateCollateralRequest": {

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -1,13 +1,13 @@
-describe("Environment Validation", () => {
+describe('Environment Validation', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let stderrSpy: jest.SpyInstance;
   let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     originalEnv = { ...process.env };
-    stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation(() => true);
-    processExitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit called");
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
     });
   });
 
@@ -18,89 +18,137 @@ describe("Environment Validation", () => {
     jest.resetModules();
   });
 
-  it("should validate required environment variables", () => {
+  it('should validate required environment variables', () => {
     delete process.env.RPC_URL;
     delete process.env.CONTRACT_ID;
 
     expect(() => {
       jest.isolateModules(() => {
-        require("./config");
+        require('./config');
       });
-    }).toThrow("process.exit called");
+    }).toThrow('process.exit called');
 
-    const written = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(written).toContain("Environment validation failed");
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('Environment validation failed');
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("should accept valid environment variables", () => {
-    process.env.RPC_URL = "https://soroban-testnet.stellar.org";
-    process.env.CONTRACT_ID = "test-contract-id";
-    process.env.PORT = "3001";
+  it('should accept valid environment variables', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.PORT = '3001';
 
     expect(() => {
       jest.isolateModules(() => {
-        require("./config");
+        require('./config');
       });
     }).not.toThrow();
   });
 
-  it("should use default values for optional variables", () => {
-    process.env.RPC_URL = "https://soroban-testnet.stellar.org";
-    process.env.CONTRACT_ID = "test-contract-id";
+  it('should use default values for optional variables', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
     delete process.env.PORT;
     delete process.env.RATE_LIMIT_GLOBAL;
 
     let config: any;
     jest.isolateModules(() => {
-      config = require("./config").config;
+      config = require('./config').config;
     });
 
-    expect(config.PORT).toBe("3001");
-    expect(config.RATE_LIMIT_GLOBAL).toBe("60");
+    expect(config.PORT).toBe('3001');
+    expect(config.RATE_LIMIT_GLOBAL).toBe('60');
   });
 
-  it("should validate URL format for RPC_URL", () => {
-    process.env.RPC_URL = "not-a-valid-url";
-    process.env.CONTRACT_ID = "test-contract-id";
+  it('should validate URL format for RPC_URL', () => {
+    process.env.RPC_URL = 'not-a-valid-url';
+    process.env.CONTRACT_ID = 'test-contract-id';
 
     expect(() => {
       jest.isolateModules(() => {
-        require("./config");
+        require('./config');
       });
-    }).toThrow("process.exit called");
+    }).toThrow('process.exit called');
 
-    const written = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(written).toContain("RPC_URL must be a valid URL");
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('RPC_URL must be a valid URL');
   });
 
-  it("should validate numeric string format", () => {
-    process.env.RPC_URL = "https://soroban-testnet.stellar.org";
-    process.env.CONTRACT_ID = "test-contract-id";
-    process.env.PORT = "not-a-number";
+  it('should validate numeric string format', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.PORT = 'not-a-number';
 
     expect(() => {
       jest.isolateModules(() => {
-        require("./config");
+        require('./config');
       });
-    }).toThrow("process.exit called");
+    }).toThrow('process.exit called');
 
-    const written = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(written).toContain("PORT must be a valid number");
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('PORT must be a valid number');
   });
 
-  it("should validate minimum length for secrets", () => {
-    process.env.RPC_URL = "https://soroban-testnet.stellar.org";
-    process.env.CONTRACT_ID = "test-contract-id";
-    process.env.WEBHOOK_SECRET = "short";
+  it('should validate minimum length for secrets', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.WEBHOOK_SECRET = 'short';
 
     expect(() => {
       jest.isolateModules(() => {
-        require("./config");
+        require('./config');
       });
-    }).toThrow("process.exit called");
+    }).toThrow('process.exit called');
 
-    const written = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(written).toContain("WEBHOOK_SECRET must be at least 16 characters");
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('WEBHOOK_SECRET must be at least 16 characters');
+  });
+
+  it('should require JWT_SECRET and WEBHOOK_SECRET in production', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.NODE_ENV = 'production';
+    delete process.env.JWT_SECRET;
+    delete process.env.WEBHOOK_SECRET;
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./config');
+      });
+    }).toThrow('process.exit called');
+
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('Missing required variables for production');
+    expect(written).toContain('JWT_SECRET');
+    expect(written).toContain('WEBHOOK_SECRET');
+  });
+
+  it('should pass in production when JWT_SECRET and WEBHOOK_SECRET are set', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'a-production-jwt-secret-32-chars!'; // gitleaks:allow
+    process.env.WEBHOOK_SECRET = 'a-production-webhook-secret-32!!';
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./config');
+      });
+    }).not.toThrow();
+  });
+
+  it('should validate DATABASE_URL format when provided', () => {
+    process.env.RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.CONTRACT_ID = 'test-contract-id';
+    process.env.DATABASE_URL = 'mysql://localhost/db';
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./config');
+      });
+    }).toThrow('process.exit called');
+
+    const written = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(written).toContain('DATABASE_URL must start with');
   });
 });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,45 +1,60 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const envSchema = z.object({
-  PORT: z.string().regex(/^\d+$/, "PORT must be a valid number").default("3001"),
-  RPC_URL: z.string().url("RPC_URL must be a valid URL"),
-  CONTRACT_ID: z.string().min(1, "CONTRACT_ID is required"),
-  NEXT_PUBLIC_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
+  PORT: z.string().regex(/^\d+$/, 'PORT must be a valid number').default('3001'),
+  RPC_URL: z.string().url('RPC_URL must be a valid URL'),
+  CONTRACT_ID: z.string().min(1, 'CONTRACT_ID is required'),
+  NEXT_PUBLIC_NETWORK: z.enum(['testnet', 'mainnet']).default('testnet'),
   // Rate limiting (optional with defaults)
-  RATE_LIMIT_AUTH: z.string().regex(/^\d+$/, "RATE_LIMIT_AUTH must be a number").default("10"),
-  RATE_LIMIT_READ: z.string().regex(/^\d+$/, "RATE_LIMIT_READ must be a number").default("100"),
-  RATE_LIMIT_GLOBAL: z.string().regex(/^\d+$/, "RATE_LIMIT_GLOBAL must be a number").default("60"),
-  RATE_LIMIT_WRITE: z.string().regex(/^\d+$/, "RATE_LIMIT_WRITE must be a number").default("10"),
+  RATE_LIMIT_AUTH: z.string().regex(/^\d+$/, 'RATE_LIMIT_AUTH must be a number').default('10'),
+  RATE_LIMIT_READ: z.string().regex(/^\d+$/, 'RATE_LIMIT_READ must be a number').default('100'),
+  RATE_LIMIT_GLOBAL: z.string().regex(/^\d+$/, 'RATE_LIMIT_GLOBAL must be a number').default('60'),
+  RATE_LIMIT_WRITE: z.string().regex(/^\d+$/, 'RATE_LIMIT_WRITE must be a number').default('10'),
   // Request timeouts in milliseconds
-  TIMEOUT_GLOBAL_MS: z.string().regex(/^\d+$/, "TIMEOUT_GLOBAL_MS must be a number").default("10000"),
-  TIMEOUT_WRITE_MS: z.string().regex(/^\d+$/, "TIMEOUT_WRITE_MS must be a number").default("15000"),
+  TIMEOUT_GLOBAL_MS: z
+    .string()
+    .regex(/^\d+$/, 'TIMEOUT_GLOBAL_MS must be a number')
+    .default('10000'),
+  TIMEOUT_WRITE_MS: z.string().regex(/^\d+$/, 'TIMEOUT_WRITE_MS must be a number').default('15000'),
   /** Timeout for contract submission routes (e.g. loan request, repay, liquidate). @default 30000 */
-  TIMEOUT_CONTRACT_MS: z.string().regex(/^\d+$/, "TIMEOUT_CONTRACT_MS must be a number").default("30000"),
+  TIMEOUT_CONTRACT_MS: z
+    .string()
+    .regex(/^\d+$/, 'TIMEOUT_CONTRACT_MS must be a number')
+    .default('30000'),
   /** Origination fee in basis points. @default 50 (0.5%) */
-  ORIG_FEE_BPS: z.string().regex(/^\d+$/, "ORIG_FEE_BPS must be a number").default("50"),
+  ORIG_FEE_BPS: z.string().regex(/^\d+$/, 'ORIG_FEE_BPS must be a number').default('50'),
   // Webhook secret
-  WEBHOOK_SECRET: z.string().min(16, "WEBHOOK_SECRET must be at least 16 characters").optional(),
+  WEBHOOK_SECRET: z.string().min(16, 'WEBHOOK_SECRET must be at least 16 characters').optional(),
   // Admin key for webhook admin endpoints
-  ADMIN_API_KEY: z.string().min(8, "ADMIN_API_KEY must be at least 8 characters").optional(),
+  ADMIN_API_KEY: z.string().min(8, 'ADMIN_API_KEY must be at least 8 characters').optional(),
   // Connection pool size
-  POOL_MIN: z.string().regex(/^\d+$/, "POOL_MIN must be a number").default("2"),
-  POOL_MAX: z.string().regex(/^\d+$/, "POOL_MAX must be a number").default("10"),
+  POOL_MIN: z.string().regex(/^\d+$/, 'POOL_MIN must be a number').default('2'),
+  POOL_MAX: z.string().regex(/^\d+$/, 'POOL_MAX must be a number').default('10'),
   // Appraisal cache TTL in milliseconds
-  APPRAISAL_CACHE_TTL_MS: z.string().regex(/^\d+$/, "APPRAISAL_CACHE_TTL_MS must be a number").default("300000"),
+  APPRAISAL_CACHE_TTL_MS: z
+    .string()
+    .regex(/^\d+$/, 'APPRAISAL_CACHE_TTL_MS must be a number')
+    .default('300000'),
   // JWT secret (min 32 chars recommended)
-  JWT_SECRET: z.string().min(16, "JWT_SECRET must be at least 16 characters").optional(),
+  JWT_SECRET: z.string().min(16, 'JWT_SECRET must be at least 16 characters').optional(),
   /** Access token TTL in milliseconds. @default 900000 (15 min) */
-  ACCESS_TTL_MS: z.string().regex(/^\d+$/, "ACCESS_TTL_MS must be a number").default("900000"),
+  ACCESS_TTL_MS: z.string().regex(/^\d+$/, 'ACCESS_TTL_MS must be a number').default('900000'),
   /** Refresh token TTL in milliseconds. @default 604800000 (7 days) */
-  REFRESH_TTL_MS: z.string().regex(/^\d+$/, "REFRESH_TTL_MS must be a number").default("604800000"),
+  REFRESH_TTL_MS: z.string().regex(/^\d+$/, 'REFRESH_TTL_MS must be a number').default('604800000'),
   /** Health factor warning threshold (×10_000). Below this fires a warning alert. @default 13000 (1.3) */
-  HEALTH_FACTOR_WARN: z.string().regex(/^\d+$/, "HEALTH_FACTOR_WARN must be a number").default("13000"),
+  HEALTH_FACTOR_WARN: z
+    .string()
+    .regex(/^\d+$/, 'HEALTH_FACTOR_WARN must be a number')
+    .default('13000'),
   /** Health factor critical threshold (×10_000). Below this fires a critical alert. @default 10000 (1.0) */
-  HEALTH_FACTOR_CRIT: z.string().regex(/^\d+$/, "HEALTH_FACTOR_CRIT must be a number").default("10000"),
+  HEALTH_FACTOR_CRIT: z
+    .string()
+    .regex(/^\d+$/, 'HEALTH_FACTOR_CRIT must be a number')
+    .default('10000'),
   // Node environment
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   // Frontend URL for CORS
-  FRONTEND_URL: z.string().url("FRONTEND_URL must be a valid URL").optional(),
+  FRONTEND_URL: z.string().url('FRONTEND_URL must be a valid URL').optional(),
   // Comma-separated list of allowed CORS origins.
   // Wildcard "*" is rejected in production.
   ALLOWED_ORIGINS: z
@@ -48,15 +63,18 @@ const envSchema = z.object({
     .refine(
       (val) => {
         if (!val) return true;
-        const isProduction = process.env.NODE_ENV === "production";
-        const origins = val.split(",").map((o) => o.trim()).filter(Boolean);
-        if (isProduction && origins.includes("*")) return false;
-        return origins.every((o) => o === "*" || /^https?:\/\/.+/.test(o));
+        const isProduction = process.env.NODE_ENV === 'production';
+        const origins = val
+          .split(',')
+          .map((o) => o.trim())
+          .filter(Boolean);
+        if (isProduction && origins.includes('*')) return false;
+        return origins.every((o) => o === '*' || /^https?:\/\/.+/.test(o));
       },
       {
         message:
           'ALLOWED_ORIGINS must be comma-separated HTTP(S) URLs; wildcard "*" is not allowed in production',
-      },
+      }
     ),
   /**
    * Graceful shutdown drain timeout in milliseconds.
@@ -66,34 +84,73 @@ const envSchema = z.object({
    */
   SHUTDOWN_TIMEOUT_MS: z
     .string()
-    .regex(/^\d+$/, "SHUTDOWN_TIMEOUT_MS must be a number")
-    .default("10000")
+    .regex(/^\d+$/, 'SHUTDOWN_TIMEOUT_MS must be a number')
+    .default('10000')
     .refine((v) => parseInt(v, 10) >= 1000, {
-      message: "SHUTDOWN_TIMEOUT_MS must be at least 1000 ms",
+      message: 'SHUTDOWN_TIMEOUT_MS must be at least 1000 ms',
     }),
   // Audit log directory path
   AUDIT_LOG_DIR: z.string().optional(),
+  // Optional PostgreSQL connection URL; falls back to SQLite when unset.
+  DATABASE_URL: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        return (
+          val.startsWith('postgres://') ||
+          val.startsWith('postgresql://') ||
+          val.startsWith('sqlite:')
+        );
+      },
+      { message: 'DATABASE_URL must start with postgres://, postgresql://, or sqlite:' }
+    ),
 });
 
 const parsed = envSchema.safeParse(process.env);
 
 if (!parsed.success) {
-  const missing = parsed.error.issues.filter((i) => i.code === "invalid_type" && (i as { received?: string }).received === "undefined");
-  const invalid = parsed.error.issues.filter((i) => !(i.code === "invalid_type" && (i as { received?: string }).received === "undefined"));
+  const missing = parsed.error.issues.filter(
+    (i) => i.code === 'invalid_type' && (i as { received?: string }).received === 'undefined'
+  );
+  const invalid = parsed.error.issues.filter(
+    (i) => !(i.code === 'invalid_type' && (i as { received?: string }).received === 'undefined')
+  );
 
-  const lines: string[] = ["\n❌ Environment validation failed\n"];
+  const lines: string[] = ['\n❌ Environment validation failed\n'];
   if (missing.length > 0) {
-    lines.push("Missing required variables:");
-    missing.forEach((i) => lines.push(`  - ${i.path.join(".")}: ${i.message}`));
+    lines.push('Missing required variables:');
+    missing.forEach((i) => lines.push(`  - ${i.path.join('.')}: ${i.message}`));
   }
   if (invalid.length > 0) {
-    lines.push("\nInvalid variable values:");
-    invalid.forEach((i) => lines.push(`  - ${i.path.join(".")}: ${i.message}`));
+    lines.push('\nInvalid variable values:');
+    invalid.forEach((i) => lines.push(`  - ${i.path.join('.')}: ${i.message}`));
   }
-  lines.push("\nPlease check your .env file or environment configuration.");
-  lines.push("See env.example for reference.\n");
-  process.stderr.write(lines.join("\n") + "\n");
+  lines.push('\nPlease check your .env file or environment configuration.');
+  lines.push('See env.example for reference.\n');
+  process.stderr.write(lines.join('\n') + '\n');
   process.exit(1);
+}
+
+// Production-specific required variables: fail fast rather than surface auth errors at request time.
+if (parsed.data.NODE_ENV === 'production') {
+  const productionRequired: Array<{ key: keyof typeof parsed.data; label: string }> = [
+    { key: 'JWT_SECRET', label: 'JWT_SECRET' },
+    { key: 'WEBHOOK_SECRET', label: 'WEBHOOK_SECRET' },
+  ];
+
+  const missingProd = productionRequired.filter(({ key }) => !parsed.data[key]);
+
+  if (missingProd.length > 0) {
+    const lines: string[] = ['\n❌ Missing required variables for production\n'];
+    missingProd.forEach(({ label }) =>
+      lines.push(`  - ${label} is required when NODE_ENV=production`)
+    );
+    lines.push('\nPlease set these in your production environment.\n');
+    process.stderr.write(lines.join('\n') + '\n');
+    process.exit(1);
+  }
 }
 
 export const config = parsed.data;

--- a/backend/src/db/migrations/002_add_query_indexes.sql
+++ b/backend/src/db/migrations/002_add_query_indexes.sql
@@ -1,0 +1,9 @@
+-- Migration 002: Add indexes on frequently filtered columns for collateral and loan queries.
+-- Targets the owner, animal_type, and status filters used by the list endpoints.
+
+CREATE INDEX IF NOT EXISTS idx_collaterals_owner       ON collaterals(owner);
+CREATE INDEX IF NOT EXISTS idx_collaterals_animal_type ON collaterals(animal_type);
+CREATE INDEX IF NOT EXISTS idx_collaterals_status      ON collaterals(status);
+
+CREATE INDEX IF NOT EXISTS idx_loans_borrower ON loans(borrower);
+CREATE INDEX IF NOT EXISTS idx_loans_status   ON loans(status);

--- a/backend/src/routes/v1.integration.test.ts
+++ b/backend/src/routes/v1.integration.test.ts
@@ -3,18 +3,18 @@
  * Covers all 5 main endpoints: register, request, repay, liquidate, health
  * Tests happy paths, edge cases, and error scenarios
  */
-import request from "supertest";
-import express, { Express } from "express";
-import { v1Router } from "./v1";
-import { insertCollateral, insertLoan } from "../db/store";
-import { __resetForTests } from "../webhooks";
+import request from 'supertest';
+import express, { Express } from 'express';
+import { v1Router } from './v1';
+import { insertCollateral, insertLoan } from '../db/store';
+import { __resetForTests } from '../webhooks';
 
-const VALID_ADDRESS = "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6";
-const INVALID_ADDRESS = "INVALID_KEY";
+const VALID_ADDRESS = 'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6';
+const INVALID_ADDRESS = 'INVALID_KEY';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-jest.mock("../utils/logger", () => ({
+jest.mock('../utils/logger', () => ({
   __esModule: true,
   default: {
     info: jest.fn(),
@@ -30,22 +30,22 @@ jest.mock("../utils/logger", () => ({
   })),
 }));
 
-jest.mock("@stellar/stellar-sdk", () => {
-  const actual = jest.requireActual("@stellar/stellar-sdk");
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
   return {
     ...actual,
     Networks: {
-      TESTNET: "Test SDF Network ; September 2015",
-      PUBLIC: "Public Global Stellar Network ; September 2015",
+      TESTNET: 'Test SDF Network ; September 2015',
+      PUBLIC: 'Public Global Stellar Network ; September 2015',
     },
-    BASE_FEE: "100",
+    BASE_FEE: '100',
     Contract: jest.fn().mockImplementation(() => ({
-      call: jest.fn().mockReturnValue({ type: "invokeHostFunction" }),
+      call: jest.fn().mockReturnValue({ type: 'invokeHostFunction' }),
     })),
     TransactionBuilder: jest.fn().mockImplementation(() => ({
       addOperation: jest.fn().mockReturnThis(),
       setTimeout: jest.fn().mockReturnThis(),
-      build: jest.fn().mockReturnValue({ toXDR: () => "mock_xdr_base64" }),
+      build: jest.fn().mockReturnValue({ toXDR: () => 'mock_xdr_base64' }),
     })),
     Address: jest.fn().mockImplementation(() => ({
       toScVal: jest.fn().mockReturnValue({}),
@@ -53,17 +53,22 @@ jest.mock("@stellar/stellar-sdk", () => {
     nativeToScVal: jest.fn().mockReturnValue({}),
     xdr: {
       ScVal: {
-        scvVec: jest.fn((arr) => ({ type: "vec", value: arr })),
+        scvVec: jest.fn((arr) => ({ type: 'vec', value: arr })),
       },
     },
     SorobanRpc: {
       Server: jest.fn().mockImplementation(() => ({
-        getAccount: jest.fn().mockResolvedValue({ id: "GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6", sequence: "1" }),
-        prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => "prepared_xdr" }),
+        getAccount: jest
+          .fn()
+          .mockResolvedValue({
+            id: 'GASPH4OCYOERATXIKLPNURXUP7ISAQU2KWFB5XLUJ3LQHKHOCN3CEGD6',
+            sequence: '1',
+          }),
+        prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => 'prepared_xdr' }),
         simulateTransaction: jest.fn().mockResolvedValue({
           result: { retval: { value: 150 } },
         }),
-        getHealth: jest.fn().mockResolvedValue({ status: "healthy" }),
+        getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }),
       })),
     },
   };
@@ -74,13 +79,13 @@ jest.mock("@stellar/stellar-sdk", () => {
 function createTestApp(): Express {
   const app = express();
   app.use(express.json());
-  app.use("/api/v1", v1Router);
+  app.use('/api/v1', v1Router);
   return app;
 }
 
 // ── Test Suite ────────────────────────────────────────────────────────────────
 
-describe("API v1 Integration Tests", () => {
+describe('API v1 Integration Tests', () => {
   let app: Express;
 
   beforeEach(() => {
@@ -89,108 +94,106 @@ describe("API v1 Integration Tests", () => {
 
   // ── Version Envelope ──────────────────────────────────────────────────────
 
-  describe("Version envelope", () => {
-    it("includes api_version in all responses", async () => {
-      const res = await request(app).get("/api/v1/health");
-      expect(res.body).toHaveProperty("api_version", "v1");
+  describe('Version envelope', () => {
+    it('includes api_version in all responses', async () => {
+      const res = await request(app).get('/api/v1/health');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("includes api_version in error responses", async () => {
-      const res = await request(app).post("/api/v1/collateral/register").send({});
-      expect(res.body).toHaveProperty("api_version", "v1");
+    it('includes api_version in error responses', async () => {
+      const res = await request(app).post('/api/v1/collateral/register').send({});
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
   });
 
   // ── Health Check ──────────────────────────────────────────────────────────
 
-  describe("GET /api/v1/health", () => {
-    it("returns 200 with healthy status", async () => {
-      const res = await request(app).get("/api/v1/health");
+  describe('GET /api/v1/health', () => {
+    it('returns 200 with healthy status', async () => {
+      const res = await request(app).get('/api/v1/health');
       expect(res.status).toBe(200);
-      expect(res.body.status).toBe("healthy");
-      expect(res.body).toHaveProperty("version");
-      expect(res.body).toHaveProperty("uptime");
+      expect(res.body.status).toBe('healthy');
+      expect(res.body).toHaveProperty('version');
+      expect(res.body).toHaveProperty('uptime');
       expect(res.body.rpcReachable).toBe(true);
     });
   });
 
   // ── 1. Register Collateral ────────────────────────────────────────────────
 
-  describe("POST /api/v1/collateral/register", () => {
+  describe('POST /api/v1/collateral/register', () => {
     const validPayload = {
       owner: VALID_ADDRESS,
-      animal_type: "cattle",
+      animal_type: 'cattle',
       count: 5,
       appraised_value: 1_000_000,
     };
 
-    it("happy path: registers collateral and returns XDR", async () => {
-      const res = await request(app)
-        .post("/api/v1/collateral/register")
-        .send(validPayload);
+    it('happy path: registers collateral and returns XDR', async () => {
+      const res = await request(app).post('/api/v1/collateral/register').send(validPayload);
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
-      expect(res.body).toHaveProperty("api_version", "v1");
-      expect(typeof res.body.xdr).toBe("string");
+      expect(res.body).toHaveProperty('xdr');
+      expect(res.body).toHaveProperty('api_version', 'v1');
+      expect(typeof res.body.xdr).toBe('string');
     });
 
-    it("happy path: accepts different animal types", async () => {
-      for (const animal_type of ["cattle", "goat", "sheep"]) {
+    it('happy path: accepts different animal types', async () => {
+      for (const animal_type of ['cattle', 'goat', 'sheep']) {
         const res = await request(app)
-          .post("/api/v1/collateral/register")
+          .post('/api/v1/collateral/register')
           .send({ ...validPayload, animal_type });
         expect(res.status).toBe(200);
-        expect(res.body).toHaveProperty("xdr");
+        expect(res.body).toHaveProperty('xdr');
       }
     });
 
-    it("error: missing required fields returns 400", async () => {
-      const res = await request(app).post("/api/v1/collateral/register").send({});
+    it('error: missing required fields returns 400', async () => {
+      const res = await request(app).post('/api/v1/collateral/register').send({});
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.error).toBe('Validation failed');
       expect(Array.isArray(res.body.details)).toBe(true);
     });
 
-    it("error: invalid Stellar public key returns 400", async () => {
+    it('error: invalid Stellar public key returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
+        .post('/api/v1/collateral/register')
         .send({ ...validPayload, owner: INVALID_ADDRESS });
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.error).toBe('Validation failed');
     });
 
-    it("error: non-positive count returns 400", async () => {
+    it('error: non-positive count returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
+        .post('/api/v1/collateral/register')
         .send({ ...validPayload, count: 0 });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative count returns 400", async () => {
+    it('error: negative count returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
+        .post('/api/v1/collateral/register')
         .send({ ...validPayload, count: -5 });
       expect(res.status).toBe(400);
     });
 
-    it("error: non-positive appraised_value returns 400", async () => {
+    it('error: non-positive appraised_value returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
+        .post('/api/v1/collateral/register')
         .send({ ...validPayload, appraised_value: -100 });
       expect(res.status).toBe(400);
     });
 
-    it("error: empty animal_type returns 400", async () => {
+    it('error: empty animal_type returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
-        .send({ ...validPayload, animal_type: "" });
+        .post('/api/v1/collateral/register')
+        .send({ ...validPayload, animal_type: '' });
       expect(res.status).toBe(400);
     });
 
-    it("error: non-integer count returns 400", async () => {
+    it('error: non-integer count returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
+        .post('/api/v1/collateral/register')
         .send({ ...validPayload, count: 5.5 });
       expect(res.status).toBe(400);
     });
@@ -198,70 +201,68 @@ describe("API v1 Integration Tests", () => {
 
   // ── 2. Request Loan ───────────────────────────────────────────────────────
 
-  describe("POST /api/v1/loan/request", () => {
+  describe('POST /api/v1/loan/request', () => {
     const validPayload = {
       borrower: VALID_ADDRESS,
       collateral_ids: [1, 2],
       amount: 600_000,
     };
 
-    it("happy path: requests loan with multiple collateral IDs", async () => {
-      const res = await request(app)
-        .post("/api/v1/loan/request")
-        .send(validPayload);
+    it('happy path: requests loan with multiple collateral IDs', async () => {
+      const res = await request(app).post('/api/v1/loan/request').send(validPayload);
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('xdr');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("happy path: accepts single collateral ID", async () => {
+    it('happy path: accepts single collateral ID', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, collateral_ids: [1] });
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
+      expect(res.body).toHaveProperty('xdr');
     });
 
-    it("error: empty collateral_ids array returns 400", async () => {
+    it('error: empty collateral_ids array returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, collateral_ids: [] });
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.error).toBe('Validation failed');
     });
 
-    it("error: missing borrower returns 400", async () => {
+    it('error: missing borrower returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ collateral_ids: [1], amount: 600_000 });
       expect(res.status).toBe(400);
     });
 
-    it("error: invalid Stellar public key returns 400", async () => {
+    it('error: invalid Stellar public key returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, borrower: INVALID_ADDRESS });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative amount returns 400", async () => {
+    it('error: negative amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, amount: -1 });
       expect(res.status).toBe(400);
     });
 
-    it("error: zero amount returns 400", async () => {
+    it('error: zero amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, amount: 0 });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative collateral_id returns 400", async () => {
+    it('error: negative collateral_id returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({ ...validPayload, collateral_ids: [-1] });
       expect(res.status).toBe(400);
     });
@@ -269,63 +270,61 @@ describe("API v1 Integration Tests", () => {
 
   // ── 3. Repay Loan ─────────────────────────────────────────────────────────
 
-  describe("POST /api/v1/loan/repay", () => {
+  describe('POST /api/v1/loan/repay', () => {
     const validPayload = {
       borrower: VALID_ADDRESS,
       loan_id: 1,
       amount: 200_000,
     };
 
-    it("happy path: partial repayment returns XDR", async () => {
-      const res = await request(app)
-        .post("/api/v1/loan/repay")
-        .send(validPayload);
+    it('happy path: partial repayment returns XDR', async () => {
+      const res = await request(app).post('/api/v1/loan/repay').send(validPayload);
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('xdr');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("happy path: full repayment returns XDR", async () => {
+    it('happy path: full repayment returns XDR', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
+        .post('/api/v1/loan/repay')
         .send({ ...validPayload, amount: 600_000 });
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
+      expect(res.body).toHaveProperty('xdr');
     });
 
-    it("error: missing loan_id returns 400", async () => {
+    it('error: missing loan_id returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
+        .post('/api/v1/loan/repay')
         .send({ borrower: VALID_ADDRESS, amount: 200_000 });
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.error).toBe('Validation failed');
     });
 
-    it("error: invalid Stellar public key returns 400", async () => {
+    it('error: invalid Stellar public key returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
-        .send({ ...validPayload, borrower: "NOT_VALID" });
+        .post('/api/v1/loan/repay')
+        .send({ ...validPayload, borrower: 'NOT_VALID' });
       expect(res.status).toBe(400);
     });
 
-    it("error: zero amount returns 400", async () => {
+    it('error: zero amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
+        .post('/api/v1/loan/repay')
         .send({ ...validPayload, amount: 0 });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative amount returns 400", async () => {
+    it('error: negative amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
+        .post('/api/v1/loan/repay')
         .send({ ...validPayload, amount: -100 });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative loan_id returns 400", async () => {
+    it('error: negative loan_id returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/repay")
+        .post('/api/v1/loan/repay')
         .send({ ...validPayload, loan_id: -1 });
       expect(res.status).toBe(400);
     });
@@ -333,11 +332,22 @@ describe("API v1 Integration Tests", () => {
 
   // ── 4. Liquidate Loan ─────────────────────────────────────────────────────
 
-  describe("POST /api/v1/loan/liquidate", () => {
+  describe('POST /api/v1/loan/liquidate', () => {
     // Seed a liquidatable loan: collateral 700_000, loan 600_000 → HF = 9_333 (< 10_000)
     beforeEach(() => {
-      insertCollateral({ id: "v1-liq-col", owner: VALID_ADDRESS, animal_type: "cattle", count: 5, appraised_value: 700_000 });
-      insertLoan({ id: "42", borrower: VALID_ADDRESS, collateral_id: "v1-liq-col", amount: 600_000 });
+      insertCollateral({
+        id: 'v1-liq-col',
+        owner: VALID_ADDRESS,
+        animal_type: 'cattle',
+        count: 5,
+        appraised_value: 700_000,
+      });
+      insertLoan({
+        id: '42',
+        borrower: VALID_ADDRESS,
+        collateral_id: 'v1-liq-col',
+        amount: 600_000,
+      });
     });
 
     const validPayload = {
@@ -346,48 +356,46 @@ describe("API v1 Integration Tests", () => {
       repay_amount: 500_000,
     };
 
-    it("happy path: liquidates loan and returns XDR", async () => {
-      const res = await request(app)
-        .post("/api/v1/loan/liquidate")
-        .send(validPayload);
+    it('happy path: liquidates loan and returns XDR', async () => {
+      const res = await request(app).post('/api/v1/loan/liquidate').send(validPayload);
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("xdr");
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('xdr');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("error: missing liquidator returns 400", async () => {
+    it('error: missing liquidator returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/liquidate")
+        .post('/api/v1/loan/liquidate')
         .send({ loan_id: 1, repay_amount: 500_000 });
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.error).toBe('Validation failed');
     });
 
-    it("error: invalid Stellar public key returns 400", async () => {
+    it('error: invalid Stellar public key returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/liquidate")
+        .post('/api/v1/loan/liquidate')
         .send({ ...validPayload, liquidator: INVALID_ADDRESS });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative loan_id returns 400", async () => {
+    it('error: negative loan_id returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/liquidate")
+        .post('/api/v1/loan/liquidate')
         .send({ ...validPayload, loan_id: -1 });
       expect(res.status).toBe(400);
     });
 
-    it("error: zero repay_amount returns 400", async () => {
+    it('error: zero repay_amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/liquidate")
+        .post('/api/v1/loan/liquidate')
         .send({ ...validPayload, repay_amount: 0 });
       expect(res.status).toBe(400);
     });
 
-    it("error: negative repay_amount returns 400", async () => {
+    it('error: negative repay_amount returns 400', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/liquidate")
+        .post('/api/v1/loan/liquidate')
         .send({ ...validPayload, repay_amount: -100 });
       expect(res.status).toBe(400);
     });
@@ -395,144 +403,144 @@ describe("API v1 Integration Tests", () => {
 
   // ── 5. Get Loan ───────────────────────────────────────────────────────────
 
-  describe("GET /api/v1/loan/:id", () => {
-    it("happy path: returns loan result for valid id", async () => {
-      const res = await request(app).get("/api/v1/loan/1");
+  describe('GET /api/v1/loan/:id', () => {
+    it('happy path: returns loan result for valid id', async () => {
+      const res = await request(app).get('/api/v1/loan/1');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("result");
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('result');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("happy path: returns result for id 0", async () => {
-      const res = await request(app).get("/api/v1/loan/0");
+    it('happy path: returns result for id 0', async () => {
+      const res = await request(app).get('/api/v1/loan/0');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("result");
+      expect(res.body).toHaveProperty('result');
     });
 
-    it("happy path: handles large loan IDs", async () => {
-      const res = await request(app).get("/api/v1/loan/999999");
+    it('happy path: handles large loan IDs', async () => {
+      const res = await request(app).get('/api/v1/loan/999999');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("result");
+      expect(res.body).toHaveProperty('result');
     });
   });
 
   // ── 6. Health Factor ──────────────────────────────────────────────────────
 
-  describe("GET /api/v1/health/:loanId", () => {
-    it("happy path: returns health_factor for valid loan", async () => {
-      const res = await request(app).get("/api/v1/health/1");
+  describe('GET /api/v1/health/:loanId', () => {
+    it('happy path: returns health_factor for valid loan', async () => {
+      const res = await request(app).get('/api/v1/health/1');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("health_factor");
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('health_factor');
+      expect(res.body).toHaveProperty('api_version', 'v1');
     });
 
-    it("happy path: health_factor reflects simulated value", async () => {
-      const res = await request(app).get("/api/v1/health/1");
+    it('happy path: health_factor reflects simulated value', async () => {
+      const res = await request(app).get('/api/v1/health/1');
       expect(res.status).toBe(200);
       expect(res.body.health_factor).toBeDefined();
     });
 
-    it("happy path: handles loan ID 0", async () => {
-      const res = await request(app).get("/api/v1/health/0");
+    it('happy path: handles loan ID 0', async () => {
+      const res = await request(app).get('/api/v1/health/0');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("health_factor");
+      expect(res.body).toHaveProperty('health_factor');
     });
   });
 
   // ── 7. List Loans with Pagination ─────────────────────────────────────────
 
-  describe("GET /api/v1/loans", () => {
-    it("happy path: returns paginated loans with default page size", async () => {
-      const res = await request(app).get("/api/v1/loans");
+  describe('GET /api/v1/loans', () => {
+    it('happy path: returns paginated loans with default page size', async () => {
+      const res = await request(app).get('/api/v1/loans');
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("data");
-      expect(res.body).toHaveProperty("total");
-      expect(res.body).toHaveProperty("page", 1);
-      expect(res.body).toHaveProperty("pageSize", 20);
-      expect(res.body).toHaveProperty("api_version", "v1");
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('total');
+      expect(res.body).toHaveProperty('page', 1);
+      expect(res.body).toHaveProperty('pageSize', 20);
+      expect(res.body).toHaveProperty('api_version', 'v1');
       expect(Array.isArray(res.body.data)).toBe(true);
     });
 
-    it("happy path: accepts custom page parameter", async () => {
-      const res = await request(app).get("/api/v1/loans?page=2");
+    it('happy path: accepts custom page parameter', async () => {
+      const res = await request(app).get('/api/v1/loans?page=2');
       expect(res.status).toBe(200);
       expect(res.body.page).toBe(2);
       expect(res.body.pageSize).toBe(20);
     });
 
-    it("happy path: accepts custom pageSize parameter", async () => {
-      const res = await request(app).get("/api/v1/loans?pageSize=50");
+    it('happy path: accepts custom pageSize parameter', async () => {
+      const res = await request(app).get('/api/v1/loans?pageSize=50');
       expect(res.status).toBe(200);
       expect(res.body.pageSize).toBe(50);
       expect(res.body.page).toBe(1);
     });
 
-    it("happy path: accepts both page and pageSize parameters", async () => {
-      const res = await request(app).get("/api/v1/loans?page=3&pageSize=25");
+    it('happy path: accepts both page and pageSize parameters', async () => {
+      const res = await request(app).get('/api/v1/loans?page=3&pageSize=25');
       expect(res.status).toBe(200);
       expect(res.body.page).toBe(3);
       expect(res.body.pageSize).toBe(25);
     });
 
-    it("happy path: enforces maximum pageSize of 100", async () => {
-      const res = await request(app).get("/api/v1/loans?pageSize=200");
+    it('happy path: enforces maximum pageSize of 100', async () => {
+      const res = await request(app).get('/api/v1/loans?pageSize=200');
       expect(res.status).toBe(200);
       expect(res.body.pageSize).toBe(100);
     });
 
-    it("happy path: returns deprecation headers when no pagination params provided", async () => {
-      const res = await request(app).get("/api/v1/loans");
+    it('happy path: returns deprecation headers when no pagination params provided', async () => {
+      const res = await request(app).get('/api/v1/loans');
       expect(res.status).toBe(200);
-      expect(res.headers).toHaveProperty("deprecation", "true");
-      expect(res.headers).toHaveProperty("sunset");
-      expect(res.headers).toHaveProperty("warning");
-      expect(res.headers.warning).toContain("Unpaginated loan listing is deprecated");
+      expect(res.headers).toHaveProperty('deprecation', 'true');
+      expect(res.headers).toHaveProperty('sunset');
+      expect(res.headers).toHaveProperty('warning');
+      expect(res.headers.warning).toContain('Unpaginated loan listing is deprecated');
     });
 
-    it("happy path: does not return deprecation headers when pagination params provided", async () => {
-      const res = await request(app).get("/api/v1/loans?page=1&pageSize=20");
+    it('happy path: does not return deprecation headers when pagination params provided', async () => {
+      const res = await request(app).get('/api/v1/loans?page=1&pageSize=20');
       expect(res.status).toBe(200);
-      expect(res.headers).not.toHaveProperty("deprecation");
+      expect(res.headers).not.toHaveProperty('deprecation');
     });
 
-    it("error: invalid page parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?page=0");
+    it('error: invalid page parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?page=0');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("error: negative page parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?page=-1");
+    it('error: negative page parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?page=-1');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("error: invalid pageSize parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?pageSize=0");
+    it('error: invalid pageSize parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?pageSize=0');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("error: negative pageSize parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?pageSize=-10");
+    it('error: negative pageSize parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?pageSize=-10');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("error: non-numeric page parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?page=abc");
+    it('error: non-numeric page parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?page=abc');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("error: non-numeric pageSize parameter returns 400", async () => {
-      const res = await request(app).get("/api/v1/loans?pageSize=xyz");
+    it('error: non-numeric pageSize parameter returns 400', async () => {
+      const res = await request(app).get('/api/v1/loans?pageSize=xyz');
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe("Invalid pagination parameters");
+      expect(res.body.error).toBe('Invalid pagination parameters');
     });
 
-    it("happy path: returns empty data array when page exceeds total", async () => {
-      const res = await request(app).get("/api/v1/loans?page=999");
+    it('happy path: returns empty data array when page exceeds total', async () => {
+      const res = await request(app).get('/api/v1/loans?page=999');
       expect(res.status).toBe(200);
       expect(res.body.data).toEqual([]);
       expect(res.body.page).toBe(999);
@@ -541,23 +549,21 @@ describe("API v1 Integration Tests", () => {
 
   // ── Full Lifecycle ────────────────────────────────────────────────────────
 
-  describe("Full loan lifecycle: register → request → repay → liquidate → health", () => {
-    it("completes the full lifecycle without errors", async () => {
+  describe('Full loan lifecycle: register → request → repay → liquidate → health', () => {
+    it('completes the full lifecycle without errors', async () => {
       // 1. Register collateral
-      const registerRes = await request(app)
-        .post("/api/v1/collateral/register")
-        .send({
-          owner: VALID_ADDRESS,
-          animal_type: "cattle",
-          count: 5,
-          appraised_value: 1_000_000,
-        });
+      const registerRes = await request(app).post('/api/v1/collateral/register').send({
+        owner: VALID_ADDRESS,
+        animal_type: 'cattle',
+        count: 5,
+        appraised_value: 1_000_000,
+      });
       expect(registerRes.status).toBe(200);
       expect(registerRes.body.xdr).toBeDefined();
 
       // 2. Request loan
       const loanRes = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({
           borrower: VALID_ADDRESS,
           collateral_ids: [1],
@@ -567,36 +573,43 @@ describe("API v1 Integration Tests", () => {
       expect(loanRes.body.xdr).toBeDefined();
 
       // 3. Repay loan (partial)
-      const repayRes = await request(app)
-        .post("/api/v1/loan/repay")
-        .send({
-          borrower: VALID_ADDRESS,
-          loan_id: 1,
-          amount: 200_000,
-        });
+      const repayRes = await request(app).post('/api/v1/loan/repay').send({
+        borrower: VALID_ADDRESS,
+        loan_id: 1,
+        amount: 200_000,
+      });
       expect(repayRes.status).toBe(200);
       expect(repayRes.body.xdr).toBeDefined();
 
       // 4. Check health factor
-      const healthRes = await request(app).get("/api/v1/health/1");
+      const healthRes = await request(app).get('/api/v1/health/1');
       expect(healthRes.status).toBe(200);
       expect(healthRes.body.health_factor).toBeDefined();
 
       // 5. Liquidate loan — seed a liquidatable loan (HF < 10_000)
-      insertCollateral({ id: "lifecycle-col", owner: VALID_ADDRESS, animal_type: "cattle", count: 5, appraised_value: 700_000 });
-      insertLoan({ id: "1", borrower: VALID_ADDRESS, collateral_id: "lifecycle-col", amount: 600_000 });
-      const liquidateRes = await request(app)
-        .post("/api/v1/loan/liquidate")
-        .send({
-          liquidator: VALID_ADDRESS,
-          loan_id: 1,
-          repay_amount: 400_000,
-        });
+      insertCollateral({
+        id: 'lifecycle-col',
+        owner: VALID_ADDRESS,
+        animal_type: 'cattle',
+        count: 5,
+        appraised_value: 700_000,
+      });
+      insertLoan({
+        id: '1',
+        borrower: VALID_ADDRESS,
+        collateral_id: 'lifecycle-col',
+        amount: 600_000,
+      });
+      const liquidateRes = await request(app).post('/api/v1/loan/liquidate').send({
+        liquidator: VALID_ADDRESS,
+        loan_id: 1,
+        repay_amount: 400_000,
+      });
       expect(liquidateRes.status).toBe(200);
       expect(liquidateRes.body.xdr).toBeDefined();
 
       // 6. Get loan record
-      const loanRecordRes = await request(app).get("/api/v1/loan/1");
+      const loanRecordRes = await request(app).get('/api/v1/loan/1');
       expect(loanRecordRes.status).toBe(200);
       expect(loanRecordRes.body.result).toBeDefined();
     });
@@ -604,38 +617,38 @@ describe("API v1 Integration Tests", () => {
 
   // ── DELETE /api/v1/webhooks/:id ───────────────────────────────────────────
 
-  describe("DELETE /api/v1/webhooks/:id", () => {
+  describe('DELETE /api/v1/webhooks/:id', () => {
     beforeEach(() => {
       __resetForTests();
     });
 
-    it("returns 204 and removes an existing webhook", async () => {
+    it('returns 204 and removes an existing webhook', async () => {
       const createRes = await request(app)
-        .post("/api/v1/webhooks")
-        .send({ url: "https://example.com/hook" });
+        .post('/api/v1/webhooks')
+        .send({ url: 'https://example.com/hook' });
       expect(createRes.status).toBe(201);
       const { id } = createRes.body;
 
       const deleteRes = await request(app).delete(`/api/v1/webhooks/${id}`);
       expect(deleteRes.status).toBe(204);
 
-      const listRes = await request(app).get("/api/v1/admin/webhooks");
+      const listRes = await request(app).get('/api/v1/admin/webhooks');
       expect(listRes.body.some((w: { id: string }) => w.id === id)).toBe(false);
     });
 
-    it("returns 404 when the webhook does not exist", async () => {
-      const res = await request(app).delete("/api/v1/webhooks/non-existent-id");
+    it('returns 404 when the webhook does not exist', async () => {
+      const res = await request(app).delete('/api/v1/webhooks/non-existent-id');
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("Webhook not found");
+      expect(res.body.error).toBe('Webhook not found');
     });
   });
 
   // ── Edge Cases ────────────────────────────────────────────────────────────
 
-  describe("Edge cases", () => {
-    it("handles very large amounts", async () => {
+  describe('Edge cases', () => {
+    it('handles very large amounts', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({
           borrower: VALID_ADDRESS,
           collateral_ids: [1],
@@ -644,9 +657,9 @@ describe("API v1 Integration Tests", () => {
       expect(res.status).toBe(200);
     });
 
-    it("handles multiple collateral IDs", async () => {
+    it('handles multiple collateral IDs', async () => {
       const res = await request(app)
-        .post("/api/v1/loan/request")
+        .post('/api/v1/loan/request')
         .send({
           borrower: VALID_ADDRESS,
           collateral_ids: [1, 2, 3, 4, 5],
@@ -655,12 +668,77 @@ describe("API v1 Integration Tests", () => {
       expect(res.status).toBe(200);
     });
 
-    it("rejects malformed JSON", async () => {
+    it('rejects malformed JSON', async () => {
       const res = await request(app)
-        .post("/api/v1/collateral/register")
-        .set("Content-Type", "application/json")
-        .send("{ invalid json }");
+        .post('/api/v1/collateral/register')
+        .set('Content-Type', 'application/json')
+        .send('{ invalid json }');
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Batch Register Collateral ─────────────────────────────────────────────
+
+  describe('POST /api/v1/collateral/register/batch', () => {
+    const validItem = {
+      owner: VALID_ADDRESS,
+      animal_type: 'cattle',
+      count: 5,
+      appraised_value: 1_000_000,
+    };
+
+    it('happy path: returns one XDR per item', async () => {
+      const res = await request(app)
+        .post('/api/v1/collateral/register/batch')
+        .send({ items: [validItem, { ...validItem, animal_type: 'goat', count: 3 }] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('results');
+      expect(Array.isArray(res.body.results)).toBe(true);
+      expect(res.body.results).toHaveLength(2);
+      res.body.results.forEach((r: { xdr: unknown }) => {
+        expect(typeof r.xdr).toBe('string');
+      });
+    });
+
+    it('happy path: single item batch', async () => {
+      const res = await request(app)
+        .post('/api/v1/collateral/register/batch')
+        .send({ items: [validItem] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.results).toHaveLength(1);
+    });
+
+    it('error: empty items array returns 400', async () => {
+      const res = await request(app).post('/api/v1/collateral/register/batch').send({ items: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+    });
+
+    it('error: missing items field returns 400', async () => {
+      const res = await request(app).post('/api/v1/collateral/register/batch').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+    });
+
+    it('error: invalid item inside batch returns 400', async () => {
+      const res = await request(app)
+        .post('/api/v1/collateral/register/batch')
+        .send({ items: [{ ...validItem, count: -1 }] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+    });
+
+    it('error: exceeding 50-item limit returns 400', async () => {
+      const items = Array.from({ length: 51 }, () => validItem);
+      const res = await request(app).post('/api/v1/collateral/register/batch').send({ items });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
     });
   });
 });

--- a/backend/src/routes/v1.ts
+++ b/backend/src/routes/v1.ts
@@ -2,28 +2,29 @@
  * API v1 router — all application routes are mounted here.
  * Accessed via /api/v1/...
  */
-import { Router, Request, Response, NextFunction } from "express";
-import { z } from "zod";
-import { config } from "../config";
-import { pool } from "../utils/connectionPool";
-import { invalidateAll } from "../utils/appraisalCache";
-import { asyncHandler } from "../utils/asyncHandler";
-import { registerWebhook, getWebhooks, getDeliveryLogs, deleteWebhook } from "../webhooks";
-import { timeoutMiddleware } from "../middleware/timeout";
-import { writeLimiter } from "../middleware/rateLimit";
-import rateLimit from "express-rate-limit";
-import { deprecationHeadersWhen } from "../middleware/deprecation";
-import { fireAlert } from "../utils/alerting";
-import { rules } from "../utils/alertRules";
-import rpcClient from "../utils/rpcClient";
-import { healthRouter } from "./health";
-const CONTRACT_ID = process.env.CONTRACT_ID || "";
-const NETWORK_PASSPHRASE =
-  config.NEXT_PUBLIC_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-
-const SCALE = 10_000;
-
-const APP_VERSION = process.env["npm_package_version"] || "1.0.0";
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { config } from '../config';
+import { pool } from '../utils/connectionPool';
+import { invalidateAll } from '../utils/appraisalCache';
+import { asyncHandler } from '../utils/asyncHandler';
+import { registerWebhook, getWebhooks, getDeliveryLogs, deleteWebhook } from '../webhooks';
+import { timeoutMiddleware } from '../middleware/timeout';
+import { writeLimiter } from '../middleware/rateLimit';
+import rateLimit from 'express-rate-limit';
+import { deprecationHeadersWhen } from '../middleware/deprecation';
+import { fireAlert } from '../utils/alerting';
+import { rules } from '../utils/alertRules';
+import rpcClient from '../utils/rpcClient';
+import { healthRouter } from './health';
+import {
+  registerCollateralSchema,
+  registerCollateral,
+  batchRegisterCollateralSchema,
+  batchRegisterCollateral,
+  getCollateralById,
+} from '../services/collateralService';
+const APP_VERSION = process.env['npm_package_version'] || '1.0.0';
 const startTime = Date.now();
 
 const settingsSchema = z.object({
@@ -50,8 +51,8 @@ const v1Router = Router();
 v1Router.use((_req: Request, res: Response, next: NextFunction) => {
   const originalJson = res.json.bind(res);
   res.json = (body: unknown) => {
-    if (body && typeof body === "object" && !Array.isArray(body)) {
-      return originalJson({ api_version: "v1", ...(body as object) });
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      return originalJson({ api_version: 'v1', ...(body as object) });
     }
     return originalJson(body);
   };
@@ -59,10 +60,10 @@ v1Router.use((_req: Request, res: Response, next: NextFunction) => {
 });
 
 // GET /health/deep — deep infrastructure health check (no auth, no rate limit)
-v1Router.use("/health", healthRouter);
+v1Router.use('/health', healthRouter);
 
 // GET /health — shallow liveness check
-v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) => {
+v1Router.get('/health', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const uptime = Math.floor((Date.now() - startTime) / 1000);
     let rpcReachable = false;
@@ -73,7 +74,7 @@ v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) 
       // degraded
     }
     res.status(rpcReachable ? 200 : 503).json({
-      status: rpcReachable ? "healthy" : "degraded",
+      status: rpcReachable ? 'healthy' : 'degraded',
       version: APP_VERSION,
       uptime,
       rpcReachable,
@@ -85,13 +86,13 @@ v1Router.get("/health", async (req: Request, res: Response, next: NextFunction) 
 });
 
 v1Router.post(
-  "/collateral/register",
+  '/collateral/register',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = registerCollateralSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
     const result = await registerCollateral(validation.data);
     res.json(result);
@@ -99,13 +100,27 @@ v1Router.post(
 );
 
 v1Router.post(
-  "/loan/request",
+  '/collateral/register/batch',
+  timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
+  writeLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = batchRegisterCollateralSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
+    }
+    const result = await batchRegisterCollateral(validation.data);
+    res.json(result);
+  })
+);
+
+v1Router.post(
+  '/loan/request',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRequestSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
     const result = await requestLoan(validation.data);
     res.json(result);
@@ -113,13 +128,13 @@ v1Router.post(
 );
 
 v1Router.post(
-  "/loan/repay",
+  '/loan/repay',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanRepaySchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
     const result = await repayLoan(validation.data);
     res.json(result);
@@ -127,13 +142,13 @@ v1Router.post(
 );
 
 v1Router.post(
-  "/loan/liquidate",
+  '/loan/liquidate',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   writeLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const validation = loanLiquidateSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+      return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
     }
     try {
       const result = await liquidateLoan(validation.data);
@@ -143,9 +158,7 @@ v1Router.post(
         return res.status(404).json({ error: err.message });
       }
       if (err instanceof LoanNotLiquidatableError) {
-        return res
-          .status(400)
-          .json({ error: err.message, health_factor: err.healthFactor });
+        return res.status(400).json({ error: err.message, health_factor: err.healthFactor });
       }
       throw err;
     }
@@ -153,7 +166,7 @@ v1Router.post(
 );
 
 v1Router.get(
-  "/loan/:id",
+  '/loan/:id',
   asyncHandler(async (req: Request, res: Response) => {
     const result = await getLoanOnChain(req.params.id as string);
     res.json(result);
@@ -161,31 +174,31 @@ v1Router.get(
 );
 
 v1Router.get(
-  "/health/:loanId",
+  '/health/:loanId',
   asyncHandler(async (req: Request, res: Response) => {
     const result = await getHealthFactor(req.params.loanId as string);
     res.json(result);
   })
 );
 
-v1Router.get("/collateral/:id", (req: Request, res: Response) => {
+v1Router.get('/collateral/:id', (req: Request, res: Response) => {
   const record = getCollateralById(req.params.id as string);
   if (!record) {
-    return res.status(404).json({ error: "Collateral not found" });
+    return res.status(404).json({ error: 'Collateral not found' });
   }
   res.json(record);
 });
 
 v1Router.get(
-  "/loans",
+  '/loans',
   deprecationHeadersWhen(
     (req) =>
       req.query.page === undefined &&
       req.query.pageSize === undefined &&
       req.query.limit === undefined,
     {
-      sunset: new Date("2026-12-31T23:59:59Z"),
-      warning: "Unpaginated loan listing is deprecated; use ?page=1&pageSize=20",
+      sunset: new Date('2026-12-31T23:59:59Z'),
+      warning: 'Unpaginated loan listing is deprecated; use ?page=1&pageSize=20',
       link: '</api/v1/loans?page=1&pageSize=20>; rel="successor-version"',
     }
   ),
@@ -209,7 +222,7 @@ v1Router.get(
 );
 
 v1Router.post(
-  "/oracle/price-update",
+  '/oracle/price-update',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   (_req: Request, res: Response) => {
     invalidateAll();
@@ -218,58 +231,60 @@ v1Router.post(
 );
 
 v1Router.post(
-  "/webhooks",
+  '/webhooks',
   timeoutMiddleware(parseInt(config.TIMEOUT_WRITE_MS, 10)),
   (req: Request, res: Response) => {
     const { url, encrypt } = req.body;
-    if (!url || typeof url !== "string") {
-      return res.status(400).json({ error: "url is required" });
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ error: 'url is required' });
     }
     try {
       return res.status(201).json(registerWebhook(url, encrypt === true));
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to register webhook";
+      const message = err instanceof Error ? err.message : 'Failed to register webhook';
       return res.status(400).json({ error: message });
     }
   }
 );
 
-v1Router.get("/admin/webhooks", (_req: Request, res: Response) => {
+v1Router.get('/admin/webhooks', (_req: Request, res: Response) => {
   res.json(getWebhooks());
 });
 
-v1Router.get("/admin/webhooks/logs", (_req: Request, res: Response) => {
+v1Router.get('/admin/webhooks/logs', (_req: Request, res: Response) => {
   res.json(getDeliveryLogs());
 });
 
-v1Router.delete("/webhooks/:id", (req: Request, res: Response) => {
+v1Router.delete('/webhooks/:id', (req: Request, res: Response) => {
   const { id } = req.params;
   const deleted = deleteWebhook(id as string);
   if (!deleted) {
-    return res.status(404).json({ error: "Webhook not found", message: `No webhook with id '${id}'` });
+    return res
+      .status(404)
+      .json({ error: 'Webhook not found', message: `No webhook with id '${id}'` });
   }
   res.status(204).send();
 });
 
-v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {
+v1Router.post('/alerts/webhook', async (req: Request, res: Response) => {
   const body = req.body;
 
-  if (req.header("x-amz-sns-message-type") === "SubscriptionConfirmation") {
+  if (req.header('x-amz-sns-message-type') === 'SubscriptionConfirmation') {
     const subscribeUrl = body.SubscribeURL;
     if (subscribeUrl) {
       await fetch(subscribeUrl);
-      return res.status(200).send("Subscribed");
+      return res.status(200).send('Subscribed');
     }
   }
 
-  if (req.header("x-amz-sns-message-type") === "Notification") {
+  if (req.header('x-amz-sns-message-type') === 'Notification') {
     try {
       const message = JSON.parse(body.Message);
       if (
-        message["detail-type"] === "Backup Job State Change" &&
-        message.detail.state === "FAILED"
+        message['detail-type'] === 'Backup Job State Change' &&
+        message.detail.state === 'FAILED'
       ) {
-        await fireAlert(rules.backupFailure, "AWS Backup job failed", {
+        await fireAlert(rules.backupFailure, 'AWS Backup job failed', {
           backupJobId: message.detail.backupJobId,
           resourceArn: message.detail.resourceArn,
         });
@@ -279,38 +294,46 @@ v1Router.post("/alerts/webhook", async (req: Request, res: Response) => {
     }
   }
 
-  res.status(200).send("OK");
+  res.status(200).send('OK');
 });
 
 // ── Admin Routes ──────────────────────────────────────────────────────────────
 
 // GET /admin/users — list all registered borrowers derived from loan records
-v1Router.get("/admin/users", asyncHandler(async (_req: Request, res: Response) => {
-  const { data } = listLoans({ page: 1, pageSize: 1000 });
-  const users = [...new Set(data.map((l: any) => l.borrower))].map((borrower) => ({ borrower }));
-  res.json({ data: users, total: users.length });
-}));
+v1Router.get(
+  '/admin/users',
+  asyncHandler(async (_req: Request, res: Response) => {
+    const { data } = listLoans({ page: 1, pageSize: 1000 });
+    const users = [...new Set(data.map((l: any) => l.borrower))].map((borrower) => ({ borrower }));
+    res.json({ data: users, total: users.length });
+  })
+);
 
 // GET /admin/moderation-queue — loans flagged as pending review (status: pending)
-v1Router.get("/admin/moderation-queue", asyncHandler(async (_req: Request, res: Response) => {
-  const { data } = listLoans({ page: 1, pageSize: 1000 });
-  const queue = (data as any[]).filter((l) => l.status === "pending");
-  res.json({ data: queue, total: queue.length });
-}));
+v1Router.get(
+  '/admin/moderation-queue',
+  asyncHandler(async (_req: Request, res: Response) => {
+    const { data } = listLoans({ page: 1, pageSize: 1000 });
+    const queue = (data as any[]).filter((l) => l.status === 'pending');
+    res.json({ data: queue, total: queue.length });
+  })
+);
 
 // GET /admin/statistics — aggregate platform stats
-v1Router.get("/admin/statistics", asyncHandler(async (_req: Request, res: Response) => {
-  const { data, total } = listLoans({ page: 1, pageSize: 1000 });
-  const totalAmount = (data as any[]).reduce((sum, l) => sum + (l.amount || 0), 0);
-  const byStatus = (data as any[]).reduce<Record<string, number>>((acc, l) => {
-    acc[l.status] = (acc[l.status] || 0) + 1;
-    return acc;
-  }, {});
-  res.json({ totalLoans: total, totalAmount, byStatus });
-}));
+v1Router.get(
+  '/admin/statistics',
+  asyncHandler(async (_req: Request, res: Response) => {
+    const { data, total } = listLoans({ page: 1, pageSize: 1000 });
+    const totalAmount = (data as any[]).reduce((sum, l) => sum + (l.amount || 0), 0);
+    const byStatus = (data as any[]).reduce<Record<string, number>>((acc, l) => {
+      acc[l.status] = (acc[l.status] || 0) + 1;
+      return acc;
+    }, {});
+    res.json({ totalLoans: total, totalAmount, byStatus });
+  })
+);
 
-
-v1Router.get("/settings/:wallet", (req: Request, res: Response) => {
+v1Router.get('/settings/:wallet', (req: Request, res: Response) => {
   const wallet = req.params.wallet as string;
   const existing = settingsStore.get(wallet);
   if (!existing) {
@@ -318,25 +341,25 @@ v1Router.get("/settings/:wallet", (req: Request, res: Response) => {
       walletAddress: wallet,
       joinDate: new Date().toISOString(),
       notifications: { loanApproved: true, loanRepaid: true, liquidationWarning: true },
-      language: "en",
-      currency: "USD",
+      language: 'en',
+      currency: 'USD',
     });
   }
   res.json(existing);
 });
 
-v1Router.put("/settings/:wallet", (req: Request, res: Response) => {
+v1Router.put('/settings/:wallet', (req: Request, res: Response) => {
   const wallet = req.params.wallet as string;
   const validation = settingsSchema.safeParse(req.body);
   if (!validation.success) {
-    return res.status(400).json({ error: "Validation failed", details: validation.error.issues });
+    return res.status(400).json({ error: 'Validation failed', details: validation.error.issues });
   }
   const existing = settingsStore.get(wallet) ?? {
     walletAddress: wallet,
     joinDate: new Date().toISOString(),
     notifications: { loanApproved: true, loanRepaid: true, liquidationWarning: true },
-    language: "en",
-    currency: "USD",
+    language: 'en',
+    currency: 'USD',
   };
   const updated: UserSettings = { ...existing, ...validation.data };
   settingsStore.set(wallet, updated);
@@ -361,42 +384,55 @@ const txStatusLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (_req: Request, res: Response) => {
-    res.setHeader("Retry-After", "6");
-    res.status(429).json({ error: "Too many requests", message: "Transaction status polling is rate-limited to 10 req/s", retryAfter: 6 });
+    res.setHeader('Retry-After', '6');
+    res
+      .status(429)
+      .json({
+        error: 'Too many requests',
+        message: 'Transaction status polling is rate-limited to 10 req/s',
+        retryAfter: 6,
+      });
   },
   keyGenerator: (req: Request) => {
     const user = (req as any).user;
-    return user?.publicKey ?? req.ip ?? "anonymous";
+    return user?.publicKey ?? req.ip ?? 'anonymous';
   },
 });
 
 v1Router.get(
-  "/transactions/:hash/status",
+  '/transactions/:hash/status',
   txStatusLimiter,
   asyncHandler(async (req: Request, res: Response) => {
     const { hash } = req.params as { hash: string };
     if (!hash || !/^[a-fA-F0-9]{64}$/.test(hash)) {
-      return res.status(400).json({ error: "Validation failed", message: "hash must be a 64-char hex string" });
+      return res
+        .status(400)
+        .json({ error: 'Validation failed', message: 'hash must be a 64-char hex string' });
     }
 
     let result: any;
     try {
       result = await rpcClient.getTransaction(hash);
     } catch (err: any) {
-      return res.status(502).json({ error: "RPC error", message: err?.message ?? "Failed to query transaction status" });
+      return res
+        .status(502)
+        .json({
+          error: 'RPC error',
+          message: err?.message ?? 'Failed to query transaction status',
+        });
     }
 
     // SorobanRpc.GetTransactionResponse status values: NOT_FOUND, SUCCESS, FAILED
-    const rpcStatus: string = result?.status ?? "NOT_FOUND";
+    const rpcStatus: string = result?.status ?? 'NOT_FOUND';
 
-    if (rpcStatus === "SUCCESS") {
-      return res.json({ status: "success", ledger: result.ledger });
+    if (rpcStatus === 'SUCCESS') {
+      return res.json({ status: 'success', ledger: result.ledger });
     }
-    if (rpcStatus === "FAILED") {
-      return res.json({ status: "failed", errorCode: result.resultXdr ?? undefined });
+    if (rpcStatus === 'FAILED') {
+      return res.json({ status: 'failed', errorCode: result.resultXdr ?? undefined });
     }
     // NOT_FOUND → still pending (in mempool or not yet confirmed)
-    return res.json({ status: "pending" });
+    return res.json({ status: 'pending' });
   })
 );
 

--- a/backend/src/services/collateralService.ts
+++ b/backend/src/services/collateralService.ts
@@ -1,11 +1,11 @@
 /**
  * Collateral business logic — decoupled from HTTP layer for v1/v2 reuse.
  */
-import { Address, nativeToScVal } from "@stellar/stellar-sdk";
-import { z } from "zod";
-import { stellarPublicKeySchema } from "../validators/stellar";
-import { getCollateral } from "../db/store";
-import { buildContractTx } from "./contractTx";
+import { Address, nativeToScVal } from '@stellar/stellar-sdk';
+import { z } from 'zod';
+import { stellarPublicKeySchema } from '../validators/stellar';
+import { getCollateral } from '../db/store';
+import { buildContractTx } from './contractTx';
 
 export const registerCollateralSchema = z.object({
   owner: stellarPublicKeySchema,
@@ -16,6 +16,15 @@ export const registerCollateralSchema = z.object({
 
 export type RegisterCollateralInput = z.infer<typeof registerCollateralSchema>;
 
+export const batchRegisterCollateralSchema = z.object({
+  items: z
+    .array(registerCollateralSchema)
+    .min(1, 'items must contain at least one entry')
+    .max(50, 'items must not exceed 50 entries per batch'),
+});
+
+export type BatchRegisterCollateralInput = z.infer<typeof batchRegisterCollateralSchema>;
+
 /**
  * Builds a register_livestock contract transaction.
  * @param input - Validated collateral registration payload.
@@ -23,13 +32,25 @@ export type RegisterCollateralInput = z.infer<typeof registerCollateralSchema>;
  */
 export async function registerCollateral(input: RegisterCollateralInput): Promise<{ xdr: string }> {
   const { owner, animal_type, count, appraised_value } = input;
-  const xdrTx = await buildContractTx(owner, "register_livestock", [
+  const xdrTx = await buildContractTx(owner, 'register_livestock', [
     new Address(owner).toScVal(),
-    nativeToScVal(animal_type, { type: "symbol" }),
-    nativeToScVal(count, { type: "u32" }),
-    nativeToScVal(BigInt(appraised_value), { type: "i128" }),
+    nativeToScVal(animal_type, { type: 'symbol' }),
+    nativeToScVal(count, { type: 'u32' }),
+    nativeToScVal(BigInt(appraised_value), { type: 'i128' }),
   ]);
   return { xdr: xdrTx };
+}
+
+/**
+ * Builds register_livestock contract transactions for multiple collaterals in one call.
+ * @param input - Validated batch payload with 1–50 items.
+ * @returns Array of unsigned XDR transactions, one per item, in input order.
+ */
+export async function batchRegisterCollateral(
+  input: BatchRegisterCollateralInput
+): Promise<{ results: Array<{ xdr: string }> }> {
+  const results = await Promise.all(input.items.map((item) => registerCollateral(item)));
+  return { results };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/collateral/register/batch` to register up to 50 livestock collaterals in a single request, returning one unsigned XDR transaction per item
- Adds migration `002_add_query_indexes.sql` with indexes on `collaterals(owner, animal_type, status)` and `loans(borrower, status)` to speed up list-endpoint filter queries
- Extends `config.ts` startup validation to require `JWT_SECRET` and `WEBHOOK_SECRET` in production and validate `DATABASE_URL` format, exiting with a clear error message before serving any traffic
- Upgrades `openapi-check.yml` to use `--extends=recommended` (stricter) and adds a second CI job that builds the server, starts it, and probes every non-parameterised spec route to confirm it is reachable

Closes #620
Closes #623
Closes #624
Closes #625

## Test plan

- [ ] `POST /api/v1/collateral/register/batch` with valid 2-item payload returns `{ results: [{ xdr }, { xdr }] }`
- [ ] Empty `items` array and `items` exceeding 50 return 400 with `"Validation failed"`
- [ ] Starting backend with `NODE_ENV=production` and missing `JWT_SECRET` exits with `"Missing required variables for production"`
- [ ] `DATABASE_URL=mysql://...` triggers validation error on startup
- [ ] OpenAPI CI (`validate-spec-against-server` job) passes for all probed routes
- [ ] `backend/src/db/migrations/002_add_query_indexes.sql` applies cleanly (idempotent via `IF NOT EXISTS`)
- [ ] All existing integration tests pass (`npm test` in backend)