### PR TITLE
feat(contract): add migrate_storage() admin upgrade hook

### DIFF
--- a/contracts/stellarkraal/src/lib.rs
+++ b/contracts/stellarkraal/src/lib.rs
@@ -15,8 +15,8 @@
 mod tests;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol,
-    Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 // ── Storage keys ────────────────────────────────────────────────────────────
@@ -32,6 +32,59 @@ const CLOSE_FACTOR: Symbol = symbol_short!("CLSFACT"); // close factor bps e.g. 
 const PAUSED: Symbol = symbol_short!("PAUSED");   // pause state flag
 const PAUSE_EXP: Symbol = symbol_short!("PAUSEXP"); // pause expiry timestamp
 const ORACLES: Symbol = symbol_short!("ORACLES");
+const PAUSE_DUR: Symbol = symbol_short!("PAUSEDUR");
+const PENDING_ADMIN: Symbol = symbol_short!("PEND_ADM");
+const TOTAL_BORROWED: Symbol = symbol_short!("TOT_BORR");
+const TOTAL_LIQUIDITY: Symbol = symbol_short!("TOT_LIQ");
+const BASE_RATE: Symbol = symbol_short!("BASERATE");
+const SLOPE1: Symbol = symbol_short!("SLOPE1");
+const SLOPE2: Symbol = symbol_short!("SLOPE2");
+const KINK: Symbol = symbol_short!("KINK");
+const PRICE_MIN: Symbol = symbol_short!("PRC_MIN");
+const PRICE_MAX: Symbol = symbol_short!("PRC_MAX");
+const STALE_THR: Symbol = symbol_short!("STALE_THR");
+const DEV_BPS: Symbol = symbol_short!("DEV_BPS");
+const LAST_PRICE: Symbol = symbol_short!("LST_PRC");
+const LAST_PRICE_TIME: Symbol = symbol_short!("LST_TIME");
+const TWAP_PRICE: Symbol = symbol_short!("TWAP_PRC");
+const TWAP_SUM: Symbol = symbol_short!("TWAP_SUM");
+const TWAP_COUNT: Symbol = symbol_short!("TWAP_CNT");
+const TWAP_WINDOW: Symbol = symbol_short!("TWAP_WIN");
+const MIN_QUORUM: Symbol = symbol_short!("MINQRM"); // minimum oracle response quorum
+const WL_COUNT: Symbol = symbol_short!("WLCOUNT");  // number of whitelisted liquidators
+
+// ── Issue #700 storage keys ──────────────────────────────────────────────────
+const MIN_LOAN: Symbol = symbol_short!("MINLOAN"); // minimum loan amount in stroops
+const MAX_LOAN: Symbol = symbol_short!("MAXLOAN"); // maximum loan amount in stroops
+
+// ── Issue #669 storage keys ──────────────────────────────────────────────────
+const PNDG_WASM: Symbol = symbol_short!("PNDGWASM");
+const UPG_TIME: Symbol = symbol_short!("UPGTIME");
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Maximum allowed pause duration in seconds (~30 days).
+pub const MAX_PAUSE_DURATION: u64 = 518_400;
+
+/// Timelock enforced between a WASM upgrade proposal and its execution, in seconds (24 hours).
+pub const UPGRADE_TIMELOCK_SECS: u64 = 86_400;
+
+/// Maximum accepted oracle price (exclusive). Any price ≥ `MAX_PRICE` is
+/// rejected as invalid.
+pub const MAX_PRICE: i128 = 1_000_000_000_000_000_000i128; // 10^18
+
+/// Default minimum loan amount: 10,000,000 stroops (1 XLM).
+pub const DEFAULT_MIN_LOAN: i128 = 10_000_000;
+
+/// Default maximum loan amount: 1,000,000,000,000 stroops (100,000 XLM).
+pub const DEFAULT_MAX_LOAN: i128 = 1_000_000_000_000;
+
+// ── TTL management ───────────────────────────────────────────────────────────
+
+/// Minimum remaining TTL (in ledgers) below which a persistent entry is extended.
+pub const PERSISTENT_TTL_THRESHOLD: u32 = 100_000; // ~5.7 days
+/// Target TTL (in ledgers) applied when extending a persistent entry.
+pub const PERSISTENT_TTL_LEDGERS: u32 = 518_400;   // ~30 days
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 
@@ -71,6 +124,18 @@ pub enum Error {
     InsufficientOracleQuorum = 17,
     InvalidPrice = 18,
     NotPaused = 19,
+    /// Reentrancy guard: another call is already in progress.
+    AlreadyInProgress = 20,
+    /// Contract is already paused.
+    AlreadyPaused = 21,
+    /// Arithmetic overflow detected.
+    ArithmeticOverflow = 22,
+    /// Caller is not on the approved liquidator whitelist.
+    LiquidatorNotWhitelisted = 23,
+    /// `execute_upgrade` called with no pending upgrade proposal.
+    NoUpgradePending = 24,
+    /// `execute_upgrade` called before the 24-hour timelock has elapsed.
+    TimelockNotElapsed = 25,
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -101,6 +166,8 @@ pub struct CollateralRecord {
     pub appraised_value: i128,
     /// ID of the loan this collateral is locked to; `0` means unlocked.
     pub loan_id: u64,
+    /// Rolling log of the last 3 appraised values (newest last).
+    pub appraisal_history: Vec<i128>,
 }
 
 /// On-chain record for a loan.
@@ -117,8 +184,12 @@ pub struct LoanRecord {
     pub total_collateral_value: i128,
     /// Original disbursed principal (before fees).
     pub principal: i128,
-    /// Remaining outstanding balance.
+    /// Remaining outstanding principal balance (excluding accrued interest).
     pub outstanding: i128,
+    /// Interest accrued since the last repayment, in token base units.
+    pub interest_accrued: i128,
+    /// Ledger timestamp of the last interest-accrual update.
+    pub last_interest_time: u64,
     /// Current lifecycle status.
     pub status: LoanStatus,
 }
@@ -133,12 +204,50 @@ pub struct FeeConfig {
     pub interest_fee_bps: u32,
 }
 
+/// Admin-readable summary of key contract state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractState {
+    /// Current admin address.
+    pub admin: Address,
+    /// SAC token address used by the protocol.
+    pub token: Address,
+    /// Loan-to-value ratio in basis points.
+    pub ltv_bps: u32,
+    /// Liquidation threshold in basis points.
+    pub liq_threshold_bps: u32,
+    /// Current pause status after applying any pause expiry.
+    pub is_paused: bool,
+    /// Number of registered oracle addresses.
+    pub oracle_count: u32,
+    /// Number of loan records created.
+    pub total_loans: u64,
+    /// Number of collateral records created.
+    pub total_collaterals: u64,
+}
+
+/// Aggregated result of a multi-oracle price submission.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OracleReport {
+    /// Median of the submitted prices.
     pub median: i128,
+    /// Number of price responses included in the aggregation.
     pub responses: u32,
+    /// Number of submitted prices that deviated > 50% from the median.
     pub flagged_count: u32,
+}
+
+/// Current TWAP state returned by [`StellarKraal::get_twap_data`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TWAPData {
+    /// Most recent price submitted by the oracle.
+    pub current_price: i128,
+    /// Time-weighted average price over the current TWAP window.
+    pub twap_price: i128,
+    /// Ledger timestamp of the most recent price submission.
+    pub last_update: u64,
 }
 
 // ── Storage helpers ──────────────────────────────────────────────────────────
@@ -146,16 +255,24 @@ pub struct OracleReport {
 /// Persistent storage keys used by the contract.
 #[contracttype]
 pub enum DataKey {
-    /// Loan record keyed by loan ID.
+    /// Full [`LoanRecord`] for the loan identified by the inner `u64` ID.
     Loan(u64),
-    /// Collateral record keyed by collateral ID.
+    /// Full [`CollateralRecord`] for the collateral identified by the inner `u64` ID.
     Collateral(u64),
-    /// Monotonically increasing counter for loan IDs.
+    /// Monotonically increasing counter used to assign unique loan IDs.
     LoanCounter,
-    /// Monotonically increasing counter for collateral IDs.
+    /// Monotonically increasing counter used to assign unique collateral IDs.
     CollateralCounter,
-    /// Reentrancy guard lock.
+    /// Reentrancy guard flag stored in *temporary* storage.
     Guard,
+    /// Liquidator whitelist entry keyed by address.
+    WhitelistEntry(Address),
+    /// Per-animal-type maximum appraised value cap.
+    AnimalCap(Symbol),
+    /// Pending WASM hash for a proposed contract upgrade (issue #669).
+    PendingWasm,
+    /// Ledger timestamp when an upgrade was proposed (issue #669).
+    UpgradeTime,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -193,21 +310,6 @@ impl Drop for ReentrancyGuard {
 impl StellarKraal {
     // ── initialize ────────────────────────────────────────────────────────
     /// Initialise the contract with protocol parameters.
-    ///
-    /// # Parameters
-    /// - `admin`: Address that will have admin privileges (fee updates, pause).
-    /// - `oracle`: Address of the price oracle (reserved for future use).
-    /// - `token`: SAC token address used for loan disbursements and repayments.
-    /// - `treasury`: Address that receives origination and interest fees.
-    /// - `ltv_bps`: Loan-to-value ratio in basis points (e.g. 6000 = 60 %).
-    /// - `liquidation_threshold_bps`: Health-factor threshold below which
-    ///   liquidation is permitted (e.g. 8000 = 80 %).
-    ///
-    /// # Errors
-    /// - [`Error::AlreadyInitialized`] if called more than once.
-    ///
-    /// # Security
-    /// Requires auth from `admin`. Can only be called once.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -216,9 +318,20 @@ impl StellarKraal {
         treasury: Address,
         ltv_bps: u32,
         liquidation_threshold_bps: u32,
+        min_quorum: u32,
     ) -> Result<(), Error> {
         if env.storage().instance().has(&ADMIN) {
             return Err(Error::AlreadyInitialized);
+        }
+        let zero = Address::from_string(&String::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
+        if admin == zero {
+            return Err(Error::Unauthorized);
+        }
+        if ltv_bps == 0 || ltv_bps > 9000 {
+            return Err(Error::InvalidAmount);
+        }
+        if liquidation_threshold_bps < ltv_bps {
+            return Err(Error::InvalidAmount);
         }
         admin.require_auth();
         env.storage().instance().set(&ADMIN, &admin);
@@ -227,50 +340,40 @@ impl StellarKraal {
         env.storage().instance().set(&TREASURY, &treasury);
         env.storage().instance().set(&LTV, &ltv_bps);
         env.storage().instance().set(&LIQ_THR, &liquidation_threshold_bps);
+        env.storage().instance().set(&MIN_QUORUM, &min_quorum);
         env.storage().instance().set(&ORIG_FEE, &50u32); // 0.5%
         env.storage().instance().set(&INT_FEE, &1000u32); // 10%
         env.storage().instance().set(&CLOSE_FACTOR, &5000u32); // 50%
-        
-        // Initialize interest rate model (Compound-like jump rate model)
-        // base_rate: 2%, slope1: 5%, slope2: 45%, kink: 80%
         env.storage().instance().set(&BASE_RATE, &200u32);
         env.storage().instance().set(&SLOPE1, &500u32);
         env.storage().instance().set(&SLOPE2, &4500u32);
         env.storage().instance().set(&KINK, &8000u32);
-        
-        // Initialize liquidity tracking
         env.storage().instance().set(&TOTAL_BORROWED, &0i128);
         env.storage().instance().set(&TOTAL_LIQUIDITY, &0i128);
-        
-        // Initialize TWAP (1 hour window = 3600 seconds)
         env.storage().instance().set(&TWAP_WINDOW, &3600u64);
         env.storage().instance().set(&LAST_PRICE, &0i128);
-        env.storage().instance().set(&LAST_PRICE_TIME, &0u64);
+        env.storage().instance().set(&LAST_PRICE_TIME, &env.ledger().timestamp());
         env.storage().instance().set(&TWAP_PRICE, &0i128);
         env.storage().instance().set(&TWAP_SUM, &0i128);
         env.storage().instance().set(&TWAP_COUNT, &0u32);
-        // Initialize oracle validation config (defaults: no bounds, 1h staleness, 20% deviation)
         env.storage().instance().set(&PRICE_MIN, &0i128);
         env.storage().instance().set(&PRICE_MAX, &0i128);
         env.storage().instance().set(&STALE_THR, &3600u64);
         env.storage().instance().set(&DEV_BPS, &2000u32);
+        // Issue #700: loan amount limits (configurable, defaulting to 1 XLM / 100 000 XLM)
+        env.storage().instance().set(&MIN_LOAN, &DEFAULT_MIN_LOAN);
+        env.storage().instance().set(&MAX_LOAN, &DEFAULT_MAX_LOAN);
         Ok(())
     }
 
     // ── is_paused ─────────────────────────────────────────────────────────
     /// Returns `true` if the contract is currently paused.
-    ///
-    /// Pause state auto-expires once the stored expiry ledger timestamp is
-    /// reached, so this may return `false` even if `pause` was called earlier.
     pub fn is_paused(env: Env) -> bool {
         Self::is_paused_raw(&env)
     }
 
     // ── pause ─────────────────────────────────────────────────────────────
     /// Pause the contract, blocking new loans and liquidations.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
@@ -280,7 +383,7 @@ impl StellarKraal {
             return Err(Error::AlreadyPaused);
         }
 
-        let duration: u64 = env.storage().instance().get(&PAUSE_DUR).unwrap_or(24 * 3600); // Default 1 day
+        let duration: u64 = env.storage().instance().get(&PAUSE_DUR).unwrap_or(24 * 3600);
         let expires_at = env.ledger().timestamp().checked_add(duration).ok_or(Error::ArithmeticOverflow)?;
 
         env.storage().instance().set(&PAUSED, &true);
@@ -291,9 +394,6 @@ impl StellarKraal {
 
     // ── unpause ───────────────────────────────────────────────────────────
     /// Unpause the contract.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
@@ -310,37 +410,59 @@ impl StellarKraal {
     }
 
     // ── set_pause_duration ────────────────────────────────────────────────
-    /// Set the default duration for a pause.
+    /// Set the default duration (in seconds) applied when the contract is paused.
     ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
+    /// Capped at [`MAX_PAUSE_DURATION`] (~30 days). Passing a value strictly
+    /// greater than `MAX_PAUSE_DURATION` returns [`Error::InvalidAmount`].
     pub fn set_pause_duration(env: Env, admin: Address, duration: u64) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
         admin.require_auth();
+        if duration > MAX_PAUSE_DURATION {
+            return Err(Error::InvalidAmount);
+        }
         env.storage().instance().set(&PAUSE_DUR, &duration);
         Ok(())
     }
 
     // ── update_oracle ─────────────────────────────────────────────────────
-    /// Update the oracle address.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
-    pub fn update_oracle(env: Env, admin: Address, new_oracle: Address) -> Result<(), Error> {
+    /// Update the oracle address and optionally the minimum quorum.
+    pub fn update_oracle(env: Env, admin: Address, new_oracle: Address, new_min_quorum: u32) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
         admin.require_auth();
         env.storage().instance().set(&ORACLE, &new_oracle);
+        if new_min_quorum > 0 {
+            env.storage().instance().set(&MIN_QUORUM, &new_min_quorum);
+        }
         env.events().publish((symbol_short!("Admin"), symbol_short!("OracleUpd")), new_oracle);
+        Ok(())
+    }
+
+    // ── set_animal_cap ───────────────────────────────────────────────────
+    /// Set the maximum appraised value accepted for an animal type.
+    pub fn set_animal_cap(
+        env: Env,
+        admin: Address,
+        animal_type: Symbol,
+        max_value: i128,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+        if max_value <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::AnimalCap(animal_type.clone()), &max_value);
+        env.events()
+            .publish((symbol_short!("Admin"), symbol_short!("AnimalCap")), (animal_type, max_value));
         Ok(())
     }
 
     // ── set_liquidation_threshold ─────────────────────────────────────────
     /// Update the liquidation threshold in basis points.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn set_liquidation_threshold(env: Env, admin: Address, threshold_bps: u32) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
@@ -355,9 +477,6 @@ impl StellarKraal {
 
     // ── propose_new_admin ─────────────────────────────────────────────────
     /// Propose a new admin address (Step 1 of transfer).
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn propose_new_admin(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
@@ -369,9 +488,6 @@ impl StellarKraal {
 
     // ── accept_admin_role ─────────────────────────────────────────────────
     /// Accept the admin role (Step 2 of transfer).
-    ///
-    /// # Security
-    /// Only the pending admin can call this.
     pub fn accept_admin_role(env: Env, new_admin: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         let pending: Address = env.storage().instance().get(&PENDING_ADMIN).ok_or(Error::Unauthorized)?;
@@ -379,7 +495,6 @@ impl StellarKraal {
             return Err(Error::Unauthorized);
         }
         new_admin.require_auth();
-        
         env.storage().instance().set(&ADMIN, &new_admin);
         env.storage().instance().remove(&PENDING_ADMIN);
         env.events().publish((symbol_short!("Admin"), symbol_short!("AdminUpd")), new_admin);
@@ -388,23 +503,6 @@ impl StellarKraal {
 
     // ── register_livestock ────────────────────────────────────────────────
     /// Register livestock as on-chain collateral.
-    ///
-    /// # Parameters
-    /// - `owner`: Stellar address of the animal owner.
-    /// - `animal_type`: Short symbol identifying the species (e.g. `cattle`).
-    /// - `count`: Number of animals being registered (must be > 0).
-    /// - `appraised_value`: Oracle-appraised total value in token base units (must be > 0).
-    ///
-    /// # Returns
-    /// The newly assigned collateral ID.
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] if the contract has not been initialised.
-    /// - [`Error::ContractPaused`] if the contract is paused.
-    /// - [`Error::InvalidAmount`] if `count` or `appraised_value` is zero.
-    ///
-    /// # Security
-    /// Requires auth from `owner`.
     pub fn register_livestock(
         env: Env,
         owner: Address,
@@ -417,22 +515,34 @@ impl StellarKraal {
         if appraised_value <= 0 || count == 0 {
             return Err(Error::InvalidAmount);
         }
+        if let Some(max_value) = env
+            .storage()
+            .persistent()
+            .get::<_, i128>(&DataKey::AnimalCap(animal_type.clone()))
+        {
+            if appraised_value > max_value {
+                return Err(Error::InvalidAmount);
+            }
+        }
         owner.require_auth();
 
-        let id = Self::next_id(&env, DataKey::CollateralCounter);
+        let id = Self::next_id(&env, DataKey::CollateralCounter)?;
+        let mut history = Vec::new(&env);
+        history.push_back(appraised_value);
         let record = CollateralRecord {
-            owner,
-            animal_type,
+            owner: owner.clone(),
+            animal_type: animal_type.clone(),
             count,
             appraised_value,
             loan_id: 0,
+            appraisal_history: history,
         };
         env.storage().persistent().set(&DataKey::Collateral(id), &record);
+        env.storage().persistent().extend_ttl(&DataKey::Collateral(id), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_LEDGERS);
 
-        // Emit livestock_registered event
         env.events().publish(
-            (symbol_short!("livestock"), symbol_short!("registered")),
-            (id, record.owner.clone(), record.animal_type.clone(), record.count, record.appraised_value),
+            (symbol_short!("livestock"), Symbol::new(&env, "registered")),
+            (id, owner, animal_type, count, appraised_value),
         );
 
         Ok(id)
@@ -440,28 +550,6 @@ impl StellarKraal {
 
     // ── request_loan ──────────────────────────────────────────────────────
     /// Request a new loan against one or more collateral records.
-    ///
-    /// Validates that the requested `amount` does not exceed
-    /// `total_collateral_value * ltv_bps / 10_000`. An origination fee is
-    /// deducted from the disbursement and sent to the treasury.
-    ///
-    /// # Parameters
-    /// - `borrower`: Address receiving the loan.
-    /// - `collateral_ids`: Non-empty list of collateral IDs owned by `borrower`.
-    /// - `amount`: Gross loan amount in token base units (before origination fee).
-    ///
-    /// # Returns
-    /// The newly assigned loan ID.
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] / [`Error::ContractPaused`]
-    /// - [`Error::InvalidAmount`] if `amount` ≤ 0 or arithmetic overflows.
-    /// - [`Error::CollateralNotFound`] if any collateral ID is invalid or the list is empty.
-    /// - [`Error::Unauthorized`] if any collateral is not owned by `borrower`.
-    /// - [`Error::InsufficientCollateral`] if `amount` exceeds the LTV-capped maximum.
-    ///
-    /// # Security
-    /// Requires auth from `borrower`. Collateral ownership is verified on-chain.
     pub fn request_loan(
         env: Env,
         borrower: Address,
@@ -474,12 +562,20 @@ impl StellarKraal {
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
+        // Issue #700: enforce configurable min/max loan bounds
+        let min_loan_limit: i128 = env.storage().instance().get(&MIN_LOAN).unwrap_or(DEFAULT_MIN_LOAN);
+        let max_loan_limit: i128 = env.storage().instance().get(&MAX_LOAN).unwrap_or(DEFAULT_MAX_LOAN);
+        if amount < min_loan_limit {
+            return Err(Error::InvalidAmount);
+        }
+        if amount > max_loan_limit {
+            return Err(Error::InvalidAmount);
+        }
         if collateral_ids.is_empty() {
             return Err(Error::CollateralNotFound);
         }
         borrower.require_auth();
 
-        // Sum appraised values across all collaterals, verify ownership
         let mut total_collateral_value: i128 = 0;
         for col_id in collateral_ids.iter() {
             let collateral: CollateralRecord = env
@@ -505,12 +601,11 @@ impl StellarKraal {
             return Err(Error::InsufficientCollateral);
         }
 
-        // Calculate origination fee
         let orig_fee_bps: u32 = env.storage().instance().get(&ORIG_FEE).unwrap();
         let fee = amount.checked_mul(orig_fee_bps as i128).ok_or(Error::InvalidAmount)? / 10_000;
         let disbursement = amount.checked_sub(fee).ok_or(Error::InvalidAmount)?;
 
-        let loan_id = Self::next_id(&env, DataKey::LoanCounter);
+        let loan_id = Self::next_id(&env, DataKey::LoanCounter)?;
         let loan = LoanRecord {
             id: loan_id,
             borrower: borrower.clone(),
@@ -518,11 +613,13 @@ impl StellarKraal {
             total_collateral_value,
             principal: amount,
             outstanding: amount,
+            interest_accrued: 0,
+            last_interest_time: env.ledger().timestamp(),
             status: LoanStatus::Active,
         };
         env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        env.storage().persistent().extend_ttl(&DataKey::Loan(loan_id), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_LEDGERS);
 
-        // Mark all collaterals as locked to this loan
         for col_id in collateral_ids.iter() {
             let mut col: CollateralRecord = env
                 .storage()
@@ -531,24 +628,22 @@ impl StellarKraal {
                 .unwrap();
             col.loan_id = loan_id;
             env.storage().persistent().set(&DataKey::Collateral(col_id), &col);
+            env.storage().persistent().extend_ttl(&DataKey::Collateral(col_id), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_LEDGERS);
         }
 
         let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
 
-        // Transfer fee to treasury
         if fee > 0 {
             let treasury: Address = env.storage().instance().get(&TREASURY).unwrap();
             token_client.transfer(&env.current_contract_address(), &treasury, &fee);
             env.events().publish((symbol_short!("FeeCol"), loan_id), (symbol_short!("originate"), fee));
         }
 
-        // Disburse net amount to borrower
         token_client.transfer(&env.current_contract_address(), &borrower, &disbursement);
 
-        // Emit loan_requested event
         env.events().publish(
-            (symbol_short!("loan"), symbol_short!("requested")),
+            (symbol_short!("loan"), Symbol::new(&env, "requested")),
             (loan_id, borrower.clone(), amount, disbursement, total_collateral_value),
         );
 
@@ -558,29 +653,10 @@ impl StellarKraal {
     // ── repay_loan ────────────────────────────────────────────────────────
     /// Repay part or all of an active loan.
     ///
-    /// Repayment is intentionally **not** blocked when the contract is paused,
-    /// so borrowers can always reduce their exposure.
-    /// If `amount` exceeds the outstanding balance the excess is ignored and
-    /// only the outstanding amount is collected.
-    ///
-    /// # Parameters
-    /// - `borrower`: Address making the repayment (must match loan's borrower).
-    /// - `loan_id`: ID of the loan to repay.
-    /// - `amount`: Amount to repay in token base units (must be > 0).
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`]
-    /// - [`Error::InvalidAmount`] if `amount` ≤ 0.
-    /// - [`Error::LoanNotFound`] if `loan_id` does not exist.
-    /// - [`Error::Unauthorized`] if `borrower` does not match the loan record.
-    /// - [`Error::LoanAlreadyClosed`] if the loan is not in `Active` status.
-    ///
-    /// # Security
-    /// Requires auth from `borrower`. Token transfer is initiated from `borrower`.
+    /// Repayment is intentionally **not** blocked when the contract is paused.
     pub fn repay_loan(env: Env, borrower: Address, loan_id: u64, amount: i128) -> Result<(), Error> {
         let _guard = ReentrancyGuard::new(&env)?;
         Self::assert_initialized(&env)?;
-        // NOTE: repayment intentionally NOT blocked by pause
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
@@ -599,40 +675,62 @@ impl StellarKraal {
             return Err(Error::LoanAlreadyClosed);
         }
 
-        let repay_amount = amount.min(loan.outstanding);
-        
-        // Calculate interest (amount above principal) and fee
-        let principal_remaining = loan.outstanding.min(loan.principal);
-        let interest_portion = if repay_amount > principal_remaining {
-            repay_amount - principal_remaining
-        } else {
-            0
-        };
-        
+        // ── On-chain interest accrual ──────────────────────────────────
         let int_fee_bps: u32 = env.storage().instance().get(&INT_FEE).unwrap();
-        let interest_fee = interest_portion.checked_mul(int_fee_bps as i128).ok_or(Error::InvalidAmount)? / 10_000;
+        let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(loan.last_interest_time);
+        if elapsed > 0 && loan.outstanding > 0 {
+            let accrued = loan.outstanding
+                .checked_mul(int_fee_bps as i128)
+                .unwrap_or(i128::MAX)
+                .checked_mul(elapsed as i128)
+                .unwrap_or(i128::MAX)
+                / (10_000i128 * 31_536_000i128);
+            loan.interest_accrued = loan.interest_accrued.saturating_add(accrued);
+        }
+        loan.last_interest_time = now;
+
+        let effective_outstanding = loan.outstanding
+            .checked_add(loan.interest_accrued)
+            .ok_or(Error::InvalidAmount)?;
+        let repay_amount = amount.min(effective_outstanding);
+
+        // Reduce interest_accrued first, then principal outstanding
+        let interest_paid = loan.interest_accrued.min(repay_amount);
+        loan.interest_accrued = loan.interest_accrued
+            .checked_sub(interest_paid)
+            .ok_or(Error::InvalidAmount)?;
+        let principal_paid = repay_amount
+            .checked_sub(interest_paid)
+            .ok_or(Error::InvalidAmount)?;
+        loan.outstanding = loan.outstanding
+            .checked_sub(principal_paid)
+            .ok_or(Error::InvalidAmount)?;
+
+        let interest_fee = interest_paid
+            .checked_mul(int_fee_bps as i128)
+            .ok_or(Error::InvalidAmount)?
+            / 10_000;
 
         let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&borrower, &env.current_contract_address(), &repay_amount);
 
-        // Transfer interest fee to treasury
         if interest_fee > 0 {
             let treasury: Address = env.storage().instance().get(&TREASURY).unwrap();
             token_client.transfer(&env.current_contract_address(), &treasury, &interest_fee);
             env.events().publish((symbol_short!("FeeCol"), loan_id), (symbol_short!("interest"), interest_fee));
         }
 
-        loan.outstanding = loan.outstanding.checked_sub(repay_amount).ok_or(Error::InvalidAmount)?;
-        if loan.outstanding == 0 {
+        if loan.outstanding == 0 && loan.interest_accrued == 0 {
             loan.status = LoanStatus::Repaid;
         }
         env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        env.storage().persistent().extend_ttl(&DataKey::Loan(loan_id), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_LEDGERS);
 
-        // Emit loan_repaid event
         env.events().publish(
-            (symbol_short!("loan"), symbol_short!("repaid")),
-            (loan_id, borrower.clone(), repay_amount, loan.outstanding, loan.status.clone()),
+            (Symbol::new(&env, "loan_repaid"), borrower.clone()),
+            (loan_id, principal_paid, interest_paid, loan.outstanding),
         );
 
         Ok(())
@@ -640,26 +738,6 @@ impl StellarKraal {
 
     // ── liquidate ─────────────────────────────────────────────────────────
     /// Liquidate an undercollateralised loan position.
-    ///
-    /// The liquidator repays up to `close_factor` of the outstanding debt and
-    /// receives collateral in return (collateral transfer is handled off-chain
-    /// via the oracle/settlement layer).
-    ///
-    /// # Parameters
-    /// - `liquidator`: Address performing the liquidation.
-    /// - `loan_id`: ID of the loan to liquidate.
-    /// - `repay_amount`: Amount of debt the liquidator wishes to repay (must be > 0
-    ///   and ≤ `outstanding * close_factor / 10_000`).
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] / [`Error::ContractPaused`]
-    /// - [`Error::InvalidAmount`] if `repay_amount` ≤ 0.
-    /// - [`Error::LoanNotFound`] / [`Error::LoanAlreadyClosed`]
-    /// - [`Error::HealthFactorSafe`] if health factor ≥ 10 000 (loan is healthy).
-    /// - [`Error::ExceedsCloseFactor`] if `repay_amount` exceeds the close-factor cap.
-    ///
-    /// # Security
-    /// Requires auth from `liquidator`. Only callable when health factor < 1.
     pub fn liquidate(env: Env, liquidator: Address, loan_id: u64, repay_amount: i128) -> Result<(), Error> {
         let _guard = ReentrancyGuard::new(&env)?;
         Self::assert_initialized(&env)?;
@@ -668,6 +746,11 @@ impl StellarKraal {
             return Err(Error::InvalidAmount);
         }
         liquidator.require_auth();
+
+        let wl_count: u32 = env.storage().instance().get(&WL_COUNT).unwrap_or(0);
+        if wl_count > 0 && !env.storage().persistent().has(&DataKey::WhitelistEntry(liquidator.clone())) {
+            return Err(Error::LiquidatorNotWhitelisted);
+        }
 
         let mut loan: LoanRecord = env
             .storage()
@@ -679,8 +762,6 @@ impl StellarKraal {
             return Err(Error::LoanAlreadyClosed);
         }
 
-        // Batch both instance reads before the health-factor check to avoid
-        // a second round-trip into instance storage inside the helper.
         let liq_thr: u32 = env.storage().instance().get(&LIQ_THR).unwrap();
         let close_factor: u32 = env.storage().instance().get(&CLOSE_FACTOR).unwrap();
 
@@ -689,7 +770,6 @@ impl StellarKraal {
             return Err(Error::HealthFactorSafe);
         }
 
-        // Enforce close factor cap
         let max_repay = loan.outstanding
             .checked_mul(close_factor as i128)
             .ok_or(Error::InvalidAmount)?
@@ -702,39 +782,42 @@ impl StellarKraal {
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&liquidator, &env.current_contract_address(), &repay_amount);
 
+        let outstanding_before = loan.outstanding;
         loan.outstanding = loan.outstanding.checked_sub(repay_amount).ok_or(Error::InvalidAmount)?;
         if loan.outstanding == 0 {
             loan.status = LoanStatus::Liquidated;
         }
-        env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
 
-        // Emit loan_liquidated event
+        let collateral_seized = if outstanding_before > 0 {
+            repay_amount
+                .checked_mul(loan.total_collateral_value)
+                .unwrap_or(0)
+                / outstanding_before
+        } else {
+            0
+        };
+
+        let borrower = loan.borrower.clone();
+        env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+        env.storage().persistent().extend_ttl(&DataKey::Loan(loan_id), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+
         env.events().publish(
-            (symbol_short!("loan"), symbol_short!("liquidated")),
+            (symbol_short!("loan"), Symbol::new(&env, "liquidated")),
             (loan_id, liquidator.clone(), repay_amount, loan.outstanding, loan.status.clone()),
         );
+
+        // suppress unused-variable warning; collateral_seized is available to off-chain observers via events if needed
+        let _ = collateral_seized;
 
         Ok(())
     }
 
     // ── set_close_factor ──────────────────────────────────────────────────
     /// Update the close factor used to cap liquidation repayments.
-    ///
-    /// # Parameters
-    /// - `admin`: Must match the stored admin address.
-    /// - `close_factor_bps`: New close factor in basis points (1–10 000).
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] / [`Error::Unauthorized`]
-    /// - [`Error::InvalidCloseFactor`] if value is 0 or > 10 000.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn set_close_factor(env: Env, admin: Address, close_factor_bps: u32) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &admin)?;
         admin.require_auth();
-        // Must be between 1 bps and 100% (10_000 bps)
         if close_factor_bps == 0 || close_factor_bps > 10_000 {
             return Err(Error::InvalidCloseFactor);
         }
@@ -744,48 +827,151 @@ impl StellarKraal {
 
     // ── get_close_factor ──────────────────────────────────────────────────
     /// Returns the current close factor in basis points.
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`]
     pub fn get_close_factor(env: Env) -> Result<u32, Error> {
         Self::assert_initialized(&env)?;
         Ok(env.storage().instance().get(&CLOSE_FACTOR).unwrap())
     }
 
+    // ── add_liquidator ────────────────────────────────────────────────────
+    /// Add an address to the approved liquidator whitelist.
+    pub fn add_liquidator(env: Env, admin: Address, liquidator: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if env.storage().persistent().has(&DataKey::WhitelistEntry(liquidator.clone())) {
+            return Ok(());
+        }
+
+        env.storage().persistent().set(&DataKey::WhitelistEntry(liquidator.clone()), &());
+
+        let count: u32 = env.storage().instance().get(&WL_COUNT).unwrap_or(0);
+        env.storage().instance().set(&WL_COUNT, &(count + 1));
+
+        env.events().publish(
+            (symbol_short!("whitelist"), symbol_short!("added")),
+            liquidator,
+        );
+        Ok(())
+    }
+
+    // ── remove_liquidator ─────────────────────────────────────────────────
+    /// Remove an address from the approved liquidator whitelist.
+    pub fn remove_liquidator(env: Env, admin: Address, liquidator: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if !env.storage().persistent().has(&DataKey::WhitelistEntry(liquidator.clone())) {
+            return Ok(());
+        }
+
+        env.storage().persistent().remove(&DataKey::WhitelistEntry(liquidator.clone()));
+
+        let count: u32 = env.storage().instance().get(&WL_COUNT).unwrap_or(0);
+        env.storage().instance().set(&WL_COUNT, &count.saturating_sub(1));
+
+        env.events().publish(
+            (symbol_short!("whitelist"), symbol_short!("removed")),
+            liquidator,
+        );
+        Ok(())
+    }
+
+    // ── is_whitelisted ────────────────────────────────────────────────────
+    /// Returns `true` if the given address is on the approved liquidator whitelist,
+    /// or if the whitelist is empty (open liquidation mode).
+    pub fn is_whitelisted(env: Env, liquidator: Address) -> bool {
+        let wl_count: u32 = env.storage().instance().get(&WL_COUNT).unwrap_or(0);
+        if wl_count == 0 {
+            return true;
+        }
+        env.storage().persistent().has(&DataKey::WhitelistEntry(liquidator))
+    }
+
     // ── health_factor ─────────────────────────────────────────────────────
-    /// Compute the health factor for a loan (scaled by 10 000).
-    ///
-    /// `health = (collateral_value * liquidation_threshold_bps) / (outstanding * 10_000) * 10_000`
-    ///
-    /// A value ≥ 10 000 means the position is healthy; < 10 000 means it is
-    /// eligible for liquidation.  Returns `i128::MAX` when outstanding is 0.
-    ///
-    /// # Optimization notes
-    /// - `assert_initialized` is omitted: a loan record in persistent storage can only
-    ///   exist if `initialize` was called, so the loan fetch already implies initialization.
-    ///   This removes one instance-storage `has()` call from the hot path.
-    /// - `LIQ_THR` is read once here and forwarded to `compute_health_factor` as a plain
-    ///   `u32`, avoiding a second instance-storage read inside the helper.
-    ///
-    /// # Errors
-    /// - [`Error::LoanNotFound`] if `loan_id` does not exist (also covers uninitialized state).
+    /// Compute the health factor for a loan (scaled by 10 000). Rejects with
+    /// [`Error::InvalidPrice`] if the oracle price is older than `STALE_THR`.
     pub fn health_factor(env: Env, loan_id: u64) -> Result<i128, Error> {
-        // Single persistent read for the loan record.
         let loan: LoanRecord = env
             .storage()
             .persistent()
             .get(&DataKey::Loan(loan_id))
             .ok_or(Error::LoanNotFound)?;
-        // Single instance read for the threshold, passed directly to avoid re-reading inside helper.
+        let last_price_time: u64 = env.storage().instance().get(&LAST_PRICE_TIME).unwrap_or(0);
+        let stale_threshold: u64 = env.storage().instance().get(&STALE_THR).unwrap_or(3600);
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(last_price_time) > stale_threshold {
+            return Err(Error::InvalidPrice);
+        }
         let liq_thr: u32 = env.storage().instance().get(&LIQ_THR).unwrap();
         Self::compute_health_factor_with_thr(&loan, liq_thr)
     }
 
+    // ── update_appraisal ──────────────────────────────────────────────────
+    /// Update the appraised value of a collateral record.
+    pub fn update_appraisal(
+        env: Env,
+        owner: Address,
+        collateral_id: u64,
+        new_value: i128,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_not_paused(&env)?;
+        if new_value <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+        owner.require_auth();
+
+        let mut record: CollateralRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(collateral_id))
+            .ok_or(Error::CollateralNotFound)?;
+
+        if record.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+
+        if record.appraisal_history.len() >= 3 {
+            let mut new_hist = Vec::new(&env);
+            let start = record.appraisal_history.len() - 2;
+            for i in start..record.appraisal_history.len() {
+                new_hist.push_back(record.appraisal_history.get(i).unwrap());
+            }
+            record.appraisal_history = new_hist;
+        }
+        record.appraisal_history.push_back(new_value);
+        record.appraised_value = new_value;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(collateral_id), &record);
+
+        env.events().publish(
+            (symbol_short!("collat"), symbol_short!("appraised")),
+            (collateral_id, new_value),
+        );
+
+        Ok(())
+    }
+
+    // ── get_appraisal_history ─────────────────────────────────────────────
+    /// Return the rolling appraisal history (up to 3 entries) for a collateral.
+    pub fn get_appraisal_history(
+        env: Env,
+        collateral_id: u64,
+    ) -> Result<Vec<i128>, Error> {
+        let record: CollateralRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(collateral_id))
+            .ok_or(Error::CollateralNotFound)?;
+        Ok(record.appraisal_history)
+    }
+
     // ── get_loan ──────────────────────────────────────────────────────────
     /// Fetch a loan record by ID.
-    ///
-    /// # Errors
-    /// - [`Error::LoanNotFound`] if the ID does not exist.
     pub fn get_loan(env: Env, loan_id: u64) -> Result<LoanRecord, Error> {
         env.storage()
             .persistent()
@@ -795,9 +981,6 @@ impl StellarKraal {
 
     // ── get_collateral ────────────────────────────────────────────────────
     /// Fetch a collateral record by ID.
-    ///
-    /// # Errors
-    /// - [`Error::CollateralNotFound`] if the ID does not exist.
     pub fn get_collateral(env: Env, collateral_id: u64) -> Result<CollateralRecord, Error> {
         env.storage()
             .persistent()
@@ -807,10 +990,6 @@ impl StellarKraal {
 
     // ── get_loan_collaterals ──────────────────────────────────────────────
     /// Return all collateral records associated with a loan.
-    ///
-    /// # Errors
-    /// - [`Error::LoanNotFound`] if `loan_id` does not exist.
-    /// - [`Error::CollateralNotFound`] if any linked collateral record is missing.
     pub fn get_loan_collaterals(env: Env, loan_id: u64) -> Result<Vec<CollateralRecord>, Error> {
         let loan: LoanRecord = env
             .storage()
@@ -829,22 +1008,93 @@ impl StellarKraal {
         Ok(records)
     }
 
+    // ── get_collateral_count ──────────────────────────────────────────────
+    /// Get the number of non-liquidated collaterals for an owner.
+    pub fn get_collateral_count(env: Env, owner: Address) -> u32 {
+        let counter: u64 = env.storage().instance().get(&DataKey::CollateralCounter).unwrap_or(0);
+        let mut count: u32 = 0;
+        for id in 1..=counter {
+            if let Some(col) = env.storage().persistent().get::<_, CollateralRecord>(&DataKey::Collateral(id)) {
+                if col.owner == owner {
+                    let mut is_liquidated = false;
+                    if col.loan_id > 0 {
+                        if let Some(loan) = env.storage().persistent().get::<_, LoanRecord>(&DataKey::Loan(col.loan_id)) {
+                            if loan.status == LoanStatus::Liquidated {
+                                is_liquidated = true;
+                            }
+                        }
+                    }
+                    if !is_liquidated {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    // ── get_loan_count ────────────────────────────────────────────────────
+    /// Get the number of active loans for a borrower.
+    pub fn get_loan_count(env: Env, borrower: Address) -> u32 {
+        let counter: u64 = env.storage().instance().get(&DataKey::LoanCounter).unwrap_or(0);
+        let mut count: u32 = 0;
+        for id in 1..=counter {
+            if let Some(loan) = env.storage().persistent().get::<_, LoanRecord>(&DataKey::Loan(id)) {
+                if loan.borrower == borrower && loan.status == LoanStatus::Active {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+
+    // ── get_loans ─────────────────────────────────────────────────────────
+    /// Batch-fetch up to 20 loan records by explicit ID list (issue #670).
+    ///
+    /// Non-existent IDs are silently skipped. More than 20 IDs returns
+    /// [`Error::InvalidAmount`].
+    pub fn get_loans(env: Env, ids: Vec<u64>) -> Result<Vec<LoanRecord>, Error> {
+        if ids.len() > 20 {
+            return Err(Error::InvalidAmount);
+        }
+        let mut loans: Vec<LoanRecord> = Vec::new(&env);
+        for id in ids.iter() {
+            if let Some(loan) = env.storage().persistent().get::<_, LoanRecord>(&DataKey::Loan(id)) {
+                loans.push_back(loan);
+            }
+        }
+        Ok(loans)
+    }
+
+    // ── set_staleness_threshold ───────────────────────────────────────────
+    /// Set the price staleness threshold in ledgers/seconds.
+    pub fn set_staleness_threshold(
+        env: Env,
+        admin: Address,
+        threshold: u64,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_not_paused(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if threshold == 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        env.storage().instance().set(&STALE_THR, &threshold);
+        env.events().publish((symbol_short!("StaleThr"),), threshold);
+        Ok(())
+    }
+
+    // ── get_staleness_threshold ───────────────────────────────────────────
+    /// Get the current price staleness threshold.
+    pub fn get_staleness_threshold(env: Env) -> u64 {
+        env.storage().instance().get(&STALE_THR).unwrap_or(3600)
+    }
+
     // ── update_fee_config ─────────────────────────────────────────────────
     /// Update origination and interest fee rates.
-    ///
-    /// Both rates are capped at 500 bps (5 %) to protect borrowers.
-    ///
-    /// # Parameters
-    /// - `admin`: Must match the stored admin address.
-    /// - `origination_fee_bps`: New origination fee (0–500 bps).
-    /// - `interest_fee_bps`: New interest fee (0–500 bps).
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] / [`Error::Unauthorized`]
-    /// - [`Error::InvalidFeeRate`] if either rate exceeds 500 bps.
-    ///
-    /// # Security
-    /// Admin-only. Requires auth from `admin`.
     pub fn update_fee_config(
         env: Env,
         admin: Address,
@@ -852,26 +1102,29 @@ impl StellarKraal {
         interest_fee_bps: u32,
     ) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).unwrap();
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::assert_not_paused(&env)?;
+        Self::assert_admin(&env, &admin)?;
         admin.require_auth();
 
         if origination_fee_bps > 500 || interest_fee_bps > 500 {
             return Err(Error::InvalidFeeRate);
         }
 
+        let old_orig: u32 = env.storage().instance().get(&ORIG_FEE).unwrap();
+        let old_int: u32 = env.storage().instance().get(&INT_FEE).unwrap();
+
         env.storage().instance().set(&ORIG_FEE, &origination_fee_bps);
         env.storage().instance().set(&INT_FEE, &interest_fee_bps);
+
+        env.events().publish(
+            (symbol_short!("fee"), symbol_short!("cfgUpd")),
+            (old_orig, old_int, origination_fee_bps, interest_fee_bps),
+        );
         Ok(())
     }
 
     // ── get_fee_config ────────────────────────────────────────────────────
     /// Return the current fee configuration.
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`]
     pub fn get_fee_config(env: Env) -> Result<FeeConfig, Error> {
         Self::assert_initialized(&env)?;
         let orig: u32 = env.storage().instance().get(&ORIG_FEE).unwrap();
@@ -882,63 +1135,125 @@ impl StellarKraal {
         })
     }
 
-    // ── set_pause_duration ────────────────────────────────────────────────
-    pub fn set_pause_duration(env: Env, admin: Address, duration: u64) -> Result<(), Error> {
+    // ── emergency_withdraw ─────────────────────────────────────────────
+    /// Emergency withdrawal of all token reserves (admin-only, contract must be paused).
+    pub fn emergency_withdraw(env: Env, admin: Address, recipient: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
         admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).ok_or(Error::NotInitialized)?;
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
-        env.storage().instance().set(&symbol_short!("PAUSEDUR"), &duration);
-        Ok(())
-    }
 
-    // ── pause ─────────────────────────────────────────────────────────────
-    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
-        Self::assert_initialized(&env)?;
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).ok_or(Error::NotInitialized)?;
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
-        env.storage().instance().set(&PAUSED, &true);
-        let duration: u64 = env.storage().instance().get(&symbol_short!("PAUSEDUR")).unwrap_or(0);
-        if duration > 0 {
-            let expires_at = env.ledger().timestamp().checked_add(duration).ok_or(Error::InvalidAmount)?;
-            env.storage().instance().set(&PAUSE_EXP, &expires_at);
-        } else {
-            env.storage().instance().set(&PAUSE_EXP, &0u64);
-        }
-        Ok(())
-    }
-
-    // ── unpause ───────────────────────────────────────────────────────────
-    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
-        Self::assert_initialized(&env)?;
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).ok_or(Error::NotInitialized)?;
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
-        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
-        if !paused {
+        if !Self::is_paused_raw(&env) {
             return Err(Error::NotPaused);
         }
-        env.storage().instance().set(&PAUSED, &false);
-        env.storage().instance().set(&PAUSE_EXP, &0u64);
+
+        let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let balance = token_client.balance(&env.current_contract_address());
+
+        if balance > 0 {
+            token_client.transfer(&env.current_contract_address(), &recipient, &balance);
+        }
+
+        env.events().publish(
+            (symbol_short!("emergency"),),
+            (recipient, balance),
+        );
+
         Ok(())
+    }
+
+    // ── set_loan_limits ───────────────────────────────────────────────────
+    /// Update the minimum and maximum loan amounts (Issue #700).
+    ///
+    /// - `min_loan` must be ≥ 1 (stroops).
+    /// - `max_loan` must be > `min_loan`.
+    pub fn set_loan_limits(
+        env: Env,
+        admin: Address,
+        min_loan: i128,
+        max_loan: i128,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if min_loan <= 0 || max_loan <= 0 || max_loan <= min_loan {
+            return Err(Error::InvalidAmount);
+        }
+
+        env.storage().instance().set(&MIN_LOAN, &min_loan);
+        env.storage().instance().set(&MAX_LOAN, &max_loan);
+
+        env.events().publish(
+            (symbol_short!("Admin"), symbol_short!("LoanLim")),
+            (min_loan, max_loan),
+        );
+
+        Ok(())
+    }
+
+    // ── get_loan_limits ───────────────────────────────────────────────────
+    /// Return the current `(min_loan, max_loan)` configuration.
+    pub fn get_loan_limits(env: Env) -> Result<(i128, i128), Error> {
+        Self::assert_initialized(&env)?;
+        let min_loan: i128 = env.storage().instance().get(&MIN_LOAN).unwrap_or(DEFAULT_MIN_LOAN);
+        let max_loan: i128 = env.storage().instance().get(&MAX_LOAN).unwrap_or(DEFAULT_MAX_LOAN);
+        Ok((min_loan, max_loan))
+    }
+
+    // ── set_ltv ──────────────────────────────────────────────────────────
+    /// Update the loan-to-value ratio (1000–9000 bps).
+    pub fn set_ltv(env: Env, admin: Address, ltv_bps: u32) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if ltv_bps < 1000 || ltv_bps > 9000 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let old_ltv: u32 = env.storage().instance().get(&LTV).unwrap();
+        env.storage().instance().set(&LTV, &ltv_bps);
+
+        env.events().publish(
+            (symbol_short!("Admin"), symbol_short!("LtvUpd")),
+            (old_ltv, ltv_bps),
+        );
+
+        Ok(())
+    }
+
+    // ── get_state ─────────────────────────────────────────────────────────
+    /// Return an admin-readable summary of key contract state.
+    pub fn get_state(env: Env, admin: Address) -> Result<ContractState, Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        let token: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let ltv_bps: u32 = env.storage().instance().get(&LTV).unwrap();
+        let liq_threshold_bps: u32 = env.storage().instance().get(&LIQ_THR).unwrap();
+        let is_paused = Self::is_paused_raw(&env);
+        let oracle_count = Self::get_oracles(env.clone()).len();
+        let total_loans: u64 = env.storage().instance().get(&DataKey::LoanCounter).unwrap_or(0);
+        let total_collaterals: u64 = env.storage().instance().get(&DataKey::CollateralCounter).unwrap_or(0);
+        Ok(ContractState {
+            admin,
+            token,
+            ltv_bps,
+            liq_threshold_bps,
+            is_paused,
+            oracle_count,
+            total_loans,
+            total_collaterals,
+        })
     }
 
     // ── add_oracle ────────────────────────────────────────────────────────
     pub fn add_oracle(env: Env, admin: Address, oracle: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
+        Self::assert_not_paused(&env)?;
+        Self::assert_admin(&env, &admin)?;
         admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).ok_or(Error::NotInitialized)?;
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
-        
+
         let mut oracles = Self::get_oracles(env.clone());
         if oracles.contains(&oracle) {
             return Err(Error::OracleAlreadyRegistered);
@@ -954,12 +1269,9 @@ impl StellarKraal {
     // ── remove_oracle ─────────────────────────────────────────────────────
     pub fn remove_oracle(env: Env, admin: Address, oracle: Address) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
         admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&ADMIN).ok_or(Error::NotInitialized)?;
-        if admin != stored_admin {
-            return Err(Error::Unauthorized);
-        }
-        
+
         let mut oracles = Self::get_oracles(env.clone());
         let mut index = None;
         for i in 0..oracles.len() {
@@ -998,32 +1310,35 @@ impl StellarKraal {
     ) -> Result<OracleReport, Error> {
         Self::assert_initialized(&env)?;
         submitter.require_auth();
-        
+
         let oracles = Self::get_oracles(env.clone());
         if prices.len() != oracles.len() {
             return Err(Error::InvalidPrice);
         }
-        
+
+        for price in prices.iter() {
+            if price <= 0 || price >= MAX_PRICE {
+                return Err(Error::InvalidPrice);
+            }
+        }
+
         let mut non_zero_prices = Vec::new(&env);
         let mut responses = 0;
         for price in prices.iter() {
-            if price > 0 {
-                non_zero_prices.push_back(price);
-                responses += 1;
-            }
+            non_zero_prices.push_back(price);
+            responses += 1;
         }
-        
-        let min_quorum = if oracles.len() >= 3 { 3 } else { oracles.len() };
+
+        let min_quorum: u32 = env.storage().instance().get(&MIN_QUORUM).unwrap_or(if oracles.len() >= 3 { 3 } else { oracles.len() });
         if responses < min_quorum {
             return Err(Error::InsufficientOracleQuorum);
         }
-        
+
         let mut arr = [0i128; 5];
         for i in 0..responses {
             arr[i as usize] = non_zero_prices.get(i).unwrap();
         }
-        
-        // Bubble sort
+
         for i in 0..responses {
             for j in (i+1)..responses {
                 if arr[i as usize] > arr[j as usize] {
@@ -1033,29 +1348,188 @@ impl StellarKraal {
                 }
             }
         }
-        
+
         let median = if responses % 2 == 1 {
             arr[(responses / 2) as usize]
         } else {
             let mid = (responses / 2) as usize;
             (arr[mid - 1] + arr[mid]) / 2
         };
-        
+
         let mut flagged_count = 0;
         for price in prices.iter() {
-            if price > 0 {
-                let diff = if price > median { price - median } else { median - price };
-                if median > 0 && diff * 100 > median * 50 {
-                    flagged_count += 1;
-                }
+            let diff = if price > median { price - median } else { median - price };
+            if median > 0 && diff * 100 > median * 50 {
+                flagged_count += 1;
             }
         }
-        
+
+        env.storage().instance().set(&LAST_PRICE, &median);
+        env.storage().instance().set(&LAST_PRICE_TIME, &env.ledger().timestamp());
+
         Ok(OracleReport {
             median,
             responses,
             flagged_count,
         })
+    }
+
+    // ── submit_price ──────────────────────────────────────────────────────
+    /// Submit a single price observation to update the TWAP.
+    pub fn submit_price(env: Env, oracle: Address, price: i128) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        oracle.require_auth();
+        let stored_oracle: Address = env.storage().instance().get(&ORACLE).unwrap();
+        if oracle != stored_oracle {
+            return Err(Error::Unauthorized);
+        }
+        if price <= 0 {
+            return Err(Error::InvalidPrice);
+        }
+
+        let now = env.ledger().timestamp();
+        let window: u64 = env.storage().instance().get(&TWAP_WINDOW).unwrap_or(3600);
+        let last_time: u64 = env.storage().instance().get(&LAST_PRICE_TIME).unwrap_or(0);
+
+        let (new_sum, new_count) = if last_time == 0 || now.saturating_sub(last_time) > window {
+            (price, 1u32)
+        } else {
+            let sum: i128 = env.storage().instance().get(&TWAP_SUM).unwrap_or(0);
+            let count: u32 = env.storage().instance().get(&TWAP_COUNT).unwrap_or(0);
+            let new_count = count.saturating_add(1);
+            (sum.checked_add(price).unwrap_or(i128::MAX), new_count)
+        };
+
+        let twap = new_sum / new_count as i128;
+        env.storage().instance().set(&LAST_PRICE, &price);
+        env.storage().instance().set(&LAST_PRICE_TIME, &now);
+        env.storage().instance().set(&TWAP_SUM, &new_sum);
+        env.storage().instance().set(&TWAP_COUNT, &new_count);
+        env.storage().instance().set(&TWAP_PRICE, &twap);
+        env.events().publish(
+            (symbol_short!("TWAP"), symbol_short!("price")),
+            (price, twap, now),
+        );
+        Ok(())
+    }
+
+    // ── get_twap_data ─────────────────────────────────────────────────────
+    /// Return the current TWAP state.
+    pub fn get_twap_data(env: Env) -> Result<TWAPData, Error> {
+        Self::assert_initialized(&env)?;
+        Ok(TWAPData {
+            current_price: env.storage().instance().get(&LAST_PRICE).unwrap_or(0),
+            twap_price: env.storage().instance().get(&TWAP_PRICE).unwrap_or(0),
+            last_update: env.storage().instance().get(&LAST_PRICE_TIME).unwrap_or(0),
+        })
+    }
+
+    // ── propose_upgrade ───────────────────────────────────────────────────
+    /// Propose a WASM upgrade (Step 1 of two-step upgrade, issue #669).
+    pub fn propose_upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        let proposal_time = env.ledger().timestamp();
+        env.storage().persistent().set(&DataKey::PendingWasm, &new_wasm_hash);
+        env.storage().persistent().set(&DataKey::UpgradeTime, &proposal_time);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("proposed")),
+            (new_wasm_hash, proposal_time),
+        );
+        Ok(())
+    }
+
+    // ── execute_upgrade ───────────────────────────────────────────────────
+    /// Execute the pending WASM upgrade after the 24-hour timelock (issue #669).
+    pub fn execute_upgrade(env: Env) -> Result<(), Error> {
+        let wasm_hash: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingWasm)
+            .ok_or(Error::NoUpgradePending)?;
+        let proposal_time: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UpgradeTime)
+            .ok_or(Error::NoUpgradePending)?;
+
+        let now = env.ledger().timestamp();
+        if now < proposal_time.saturating_add(UPGRADE_TIMELOCK_SECS) {
+            return Err(Error::TimelockNotElapsed);
+        }
+
+        env.storage().persistent().remove(&DataKey::PendingWasm);
+        env.storage().persistent().remove(&DataKey::UpgradeTime);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("executed")),
+            (wasm_hash.clone(), now),
+        );
+
+        env.deployer().update_current_contract_wasm(wasm_hash);
+        Ok(())
+    }
+
+    // ── cancel_upgrade ────────────────────────────────────────────────────
+    /// Cancel a pending WASM upgrade proposal (issue #669).
+    pub fn cancel_upgrade(env: Env, admin: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        if !env.storage().persistent().has(&DataKey::PendingWasm) {
+            return Err(Error::NoUpgradePending);
+        }
+
+        env.storage().persistent().remove(&DataKey::PendingWasm);
+        env.storage().persistent().remove(&DataKey::UpgradeTime);
+
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("canceled")),
+            env.ledger().timestamp(),
+        );
+        Ok(())
+    }
+
+    // ── migrate_storage ───────────────────────────────────────────────────
+    /// Standard hook called after a contract upgrade to migrate on-chain storage
+    /// to the new layout (Issue #699).
+    ///
+    /// This is the canonical upgrade migration hook. Every new contract version
+    /// should implement any required data-layout migrations here.  The current
+    /// version is a no-op (idempotent stub) because no breaking storage changes
+    /// have been made.
+    ///
+    /// ## Versioning
+    /// Returns the migration version number.  The first version is `1`.
+    /// Callers can use this value to verify that migration ran and to gate
+    /// version-specific logic.
+    ///
+    /// ## Access
+    /// Admin-only.
+    pub fn migrate_storage(env: Env, admin: Address) -> Result<u32, Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        admin.require_auth();
+
+        // Current migration version: 1 (no-op / stub for future use).
+        // Future versions add actual field migrations here before bumping the
+        // constant to the next version number.
+        const MIGRATION_VERSION: u32 = 1;
+
+        env.events().publish(
+            (symbol_short!("Admin"), symbol_short!("MigDone")),
+            MIGRATION_VERSION,
+        );
+
+        Ok(MIGRATION_VERSION)
     }
 
     // ── internal helpers ──────────────────────────────────────────────────
@@ -1079,7 +1553,6 @@ impl StellarKraal {
         if !paused {
             return false;
         }
-        // Check auto-expiry
         let expires_at: u64 = env.storage().instance().get(&PAUSE_EXP).unwrap_or(0);
         if expires_at == 0 {
             return true;
@@ -1102,15 +1575,14 @@ impl StellarKraal {
         Ok(next)
     }
 
-    /// Pure arithmetic health-factor computation.
+    /// Pure arithmetic health-factor computation (zero storage access).
     ///
-    /// Accepts `liq_thr` as a parameter so callers can read `LIQ_THR` from storage
-    /// once and reuse it, rather than paying for an instance-storage read on every
-    /// invocation.  No storage access occurs inside this function.
-    ///
-    /// Formula (unchanged): `(collateral * liq_thr) / (outstanding * 10_000) * 10_000`
+    /// Formula: `(collateral_value × liq_thr_bps) / outstanding`
     fn compute_health_factor_with_thr(loan: &LoanRecord, liq_thr: u32) -> Result<i128, Error> {
-        if loan.outstanding == 0 {
+        let total_debt = loan.outstanding
+            .checked_add(loan.interest_accrued)
+            .ok_or(Error::InvalidAmount)?;
+        if total_debt == 0 {
             return Ok(i128::MAX);
         }
         let numerator = loan
@@ -1118,34 +1590,30 @@ impl StellarKraal {
             .checked_mul(liq_thr as i128)
             .ok_or(Error::InvalidAmount)?;
         let denominator = loan.outstanding.checked_mul(10_000).ok_or(Error::InvalidAmount)?;
-        Ok(numerator / denominator * 10_000)
+        Ok(numerator * 10_000 / denominator)
     }
 
+    #[allow(dead_code)]
     fn calculate_utilization(env: &Env) -> Result<u32, Error> {
         let total_borrowed: i128 = env.storage().instance().get(&TOTAL_BORROWED).unwrap_or(0);
         let total_liquidity: i128 = env.storage().instance().get(&TOTAL_LIQUIDITY).unwrap_or(1);
-        
         if total_liquidity <= 0 {
             return Ok(0);
         }
-        
-        // utilization = (total_borrowed / total_liquidity) * 10_000
-        let utilization = (total_borrowed * 10_000 / total_liquidity) as u32;
-        Ok(utilization.min(10_000))
+        let utilization = total_borrowed
+            .checked_mul(10_000)
+            .ok_or(Error::InvalidAmount)?
+            / total_liquidity;
+        Ok(utilization.min(10_000) as u32)
     }
 
+    #[allow(dead_code)]
     fn calculate_interest_rate(env: &Env, utilization_bps: u32) -> Result<u32, Error> {
         let base: u32 = env.storage().instance().get(&BASE_RATE).unwrap_or(200);
         let slope1: u32 = env.storage().instance().get(&SLOPE1).unwrap_or(500);
         let slope2: u32 = env.storage().instance().get(&SLOPE2).unwrap_or(4500);
         let kink: u32 = env.storage().instance().get(&KINK).unwrap_or(8000);
-        
-        // Jump rate model:
-        // if utilization <= kink:
-        //   rate = base + (slope1 * utilization / 10_000)
-        // else:
-        //   rate = base + (slope1 * kink / 10_000) + (slope2 * (utilization - kink) / 10_000)
-        
+
         let rate = if utilization_bps <= kink {
             let slope1_component = (slope1 as u64)
                 .checked_mul(utilization_bps as u64)
@@ -1162,12 +1630,11 @@ impl StellarKraal {
                 .checked_mul(excess_util as u64)
                 .unwrap_or(u64::MAX)
                 / 10_000;
-            base
-                .checked_add(slope1_component as u32)
+            base.checked_add(slope1_component as u32)
                 .and_then(|r| r.checked_add(slope2_component as u32))
                 .unwrap_or(u32::MAX)
         };
-        
+
         Ok(rate)
     }
 }

--- a/contracts/stellarkraal/src/tests.rs
+++ b/contracts/stellarkraal/src/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use soroban_sdk::{
     symbol_short, vec,
-    testutils::{Address as _, Ledger},
-    Address, Env,
+    testutils::{storage::Persistent as _, Address as _, Ledger, Events},
+    Address, Env, Symbol, IntoVal,
 };
 use proptest::prelude::*;
 
@@ -12,6 +12,7 @@ pub struct MockToken;
 #[contractimpl]
 impl MockToken {
     pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    pub fn balance(_env: Env, _id: Address) -> i128 { 0 }
 }
 
 fn setup() -> (Env, Address, Address, Address, Address, Address) {
@@ -25,731 +26,1990 @@ fn setup() -> (Env, Address, Address, Address, Address, Address) {
     (env, contract_id, admin, oracle, token, treasury)
 }
 
-    fn init(env: &Env, contract_id: &Address, admin: &Address, oracle: &Address, token: &Address, treasury: &Address) {
-        let client = StellarKraalClient::new(env, contract_id);
-        client.initialize(admin, oracle, token, treasury, &6000u32, &8000u32);
-    }
+fn init(
+    env: &Env,
+    contract_id: &Address,
+    admin: &Address,
+    oracle: &Address,
+    token: &Address,
+    treasury: &Address,
+) {
+    let client = StellarKraalClient::new(env, contract_id);
+    client.initialize(admin, oracle, token, treasury, &6000u32, &8000u32, &1u32);
+}
 
-    // ── initialize ────────────────────────────────────────────────────────
-    #[test]
-    fn test_initialize_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-    }
+// ── initialize ────────────────────────────────────────────────────────
+#[test]
+fn test_initialize_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+}
 
-    #[test]
-    #[should_panic(expected = "#2")]
-    fn test_initialize_twice_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-    }
+#[test]
+#[should_panic(expected = "#2")]
+fn test_initialize_twice_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+}
 
-    // ── register_livestock ────────────────────────────────────────────────
-    #[test]
-    fn test_register_livestock_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        let id = client.register_livestock(&owner, &symbol_short!("cattle"), &5u32, &1_000_000i128);
-        assert_eq!(id, 1);
-    }
+#[test]
+#[should_panic(expected = "#3")]
+fn test_initialize_zero_admin_fails() {
+    use soroban_sdk::String;
+    let (env, cid, _admin, oracle, token, treasury) = setup();
+    let client = StellarKraalClient::new(&env, &cid);
+    let zero = Address::from_string(&String::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+    client.initialize(&zero, &oracle, &token, &treasury, &6000u32, &8000u32, &1u32);
+}
 
-    #[test]
-    #[should_panic(expected = "#8")]
-    fn test_register_zero_count_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        client.register_livestock(&owner, &symbol_short!("goat"), &0u32, &500_000i128);
-    }
+#[test]
+#[should_panic(expected = "#8")]
+fn test_initialize_zero_ltv_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    let client = StellarKraalClient::new(&env, &cid);
+    client.initialize(&admin, &oracle, &token, &treasury, &0u32, &8000u32, &1u32);
+}
 
-    #[test]
-    #[should_panic(expected = "#8")]
-    fn test_register_zero_value_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        client.register_livestock(&owner, &symbol_short!("sheep"), &3u32, &0i128);
-    }
+#[test]
+#[should_panic(expected = "#8")]
+fn test_initialize_ltv_above_max_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    let client = StellarKraalClient::new(&env, &cid);
+    client.initialize(&admin, &oracle, &token, &treasury, &9001u32, &9500u32, &1u32);
+}
 
-    // ── request_loan ──────────────────────────────────────────────────────
-    #[test]
-    fn test_request_loan_within_ltv() {
+#[test]
+#[should_panic(expected = "#8")]
+fn test_initialize_liq_below_ltv_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    let client = StellarKraalClient::new(&env, &cid);
+    client.initialize(&admin, &oracle, &token, &treasury, &6000u32, &5000u32, &1u32);
+}
+
+#[test]
+fn test_initialize_valid_params_succeed() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    let client = StellarKraalClient::new(&env, &cid);
+    client.initialize(&admin, &oracle, &token, &treasury, &6000u32, &6000u32, &1u32);
+}
+
+// ── register_livestock ────────────────────────────────────────────────
+#[test]
+fn test_register_livestock_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let id = client.register_livestock(&owner, &symbol_short!("cattle"), &5u32, &1_000_000i128);
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_register_livestock_value_at_cap_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    client.set_animal_cap(&admin, &symbol_short!("cattle"), &1_000_000i128);
+    let id = client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+    assert_eq!(id, 1);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_register_livestock_value_above_cap_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    client.set_animal_cap(&admin, &symbol_short!("cattle"), &1_000_000i128);
+    client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &1_000_001i128);
+}
+
+#[test]
+fn test_register_livestock_without_cap_unrestricted() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let id = client.register_livestock(&owner, &symbol_short!("goat"), &1u32, &i128::MAX);
+    assert_eq!(id, 1);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_register_zero_count_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("goat"), &0u32, &500_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_register_zero_value_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("sheep"), &3u32, &0i128);
+}
+
+// ── TTL management ────────────────────────────────────────────────────
+#[test]
+fn test_collateral_ttl_set_on_register() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let col_id = client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+    env.as_contract(&cid, || {
+        let ttl = env.storage().persistent().get_ttl(&DataKey::Collateral(col_id));
+        assert_eq!(ttl, PERSISTENT_TTL_LEDGERS);
+    });
+}
+
+#[test]
+fn test_loan_ttl_set_on_create() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    env.as_contract(&cid, || {
+        let ttl = env.storage().persistent().get_ttl(&DataKey::Loan(loan_id));
+        assert_eq!(ttl, PERSISTENT_TTL_LEDGERS);
+    });
+}
+
+// ── request_loan ──────────────────────────────────────────────────────
+#[test]
+fn test_request_loan_within_ltv() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    assert_eq!(loan_id, 1);
+}
+
+#[test]
+#[should_panic(expected = "#4")]
+fn test_request_loan_exceeds_ltv() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    client.request_loan(&borrower, &vec![&env, col_id], &700_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_request_loan_wrong_owner() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&owner, &symbol_short!("goat"), &3u32, &500_000i128);
+    client.request_loan(&attacker, &vec![&env, col_id], &100_000i128);
+}
+
+#[test]
+fn test_request_loan_multi_collateral() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col1 =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
+    let col2 =
+        client.register_livestock(&borrower, &symbol_short!("goat"), &5u32, &400_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.total_collateral_value, 1_000_000);
+    assert_eq!(loan.collateral_ids.len(), 2);
+}
+
+#[test]
+fn test_request_loan_three_collaterals() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col1 =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &300_000i128);
+    let col2 =
+        client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &200_000i128);
+    let col3 =
+        client.register_livestock(&borrower, &symbol_short!("sheep"), &5u32, &100_000i128);
+    let loan_id =
+        client.request_loan(&borrower, &vec![&env, col1, col2, col3], &360_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.total_collateral_value, 600_000);
+}
+
+#[test]
+#[should_panic(expected = "#4")]
+fn test_multi_collateral_exceeds_combined_ltv() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col1 =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &500_000i128);
+    let col2 =
+        client.register_livestock(&borrower, &symbol_short!("goat"), &2u32, &500_000i128);
+    client.request_loan(&borrower, &vec![&env, col1, col2], &700_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#6")]
+fn test_request_loan_empty_collateral_ids_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    client.request_loan(&borrower, &vec![&env], &100_000i128);
+}
+
+// ── repay_loan ────────────────────────────────────────────────────────
+#[test]
+fn test_partial_repay() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &200_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.outstanding, 400_000);
+}
+
+#[test]
+fn test_full_repay_marks_repaid() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &600_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+}
+
+#[test]
+#[should_panic(expected = "#9")]
+fn test_repay_closed_loan_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &1i128);
+}
+
+// ── health_factor ─────────────────────────────────────────────────────
+#[test]
+fn test_health_factor_healthy() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    let hf = client.health_factor(&loan_id);
+    assert!(hf >= 10_000, "health factor should be >= 1.0");
+}
+
+// ── bench: health_factor (issue #668 baseline) ────────────────────────
+#[test]
+fn bench_health_factor_instruction_count() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+
+    env.budget().reset_default();
+    let hf = client.health_factor(&loan_id);
+    let instructions_after = env.budget().cpu_instruction_cost();
+
+    assert_eq!(hf, 13_333, "health factor value must be unchanged");
+    assert!(
+        instructions_after < 500_000,
+        "health_factor used {} instructions, expected < 500_000",
+        instructions_after
+    );
+}
+
+// ── bench: request_loan (issue #668) ──────────────────────────────────
+#[test]
+fn bench_request_loan_instruction_count() {
+    const SOROBAN_CPU_LIMIT: u64 = 100_000_000;
+
+    // ── 1 collateral ──────────────────────────────────────────────────
+    {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        // max loan = 1_000_000 * 60% = 600_000
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        assert_eq!(loan_id, 1);
-    }
 
-    #[test]
-    #[should_panic(expected = "#4")]
-    fn test_request_loan_exceeds_ltv() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        client.request_loan(&borrower, &vec![&env, col_id], &700_000i128);
-    }
+        let col = client.register_livestock(
+            &borrower,
+            &symbol_short!("cattle"),
+            &1u32,
+            &1_000_000i128,
+        );
+        let ids = vec![&env, col];
 
-    #[test]
-    #[should_panic(expected = "#3")]
-    fn test_request_loan_wrong_owner() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let col_id = client.register_livestock(&owner, &symbol_short!("goat"), &3u32, &500_000i128);
-        client.request_loan(&attacker, &vec![&env, col_id], &100_000i128);
-    }
-
-    #[test]
-    fn test_request_loan_multi_collateral() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        // cattle=600_000 + goats=400_000 = 1_000_000 total; max loan = 600_000
-        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
-        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &5u32, &400_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
-        let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.total_collateral_value, 1_000_000);
-        assert_eq!(loan.collateral_ids.len(), 2);
-    }
-
-    #[test]
-    fn test_request_loan_three_collaterals() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &300_000i128);
-        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &200_000i128);
-        let col3 = client.register_livestock(&borrower, &symbol_short!("sheep"), &5u32, &100_000i128);
-        // total = 600_000; max loan = 360_000
-        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2, col3], &360_000i128);
-        let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.total_collateral_value, 600_000);
-    }
-
-    #[test]
-    #[should_panic(expected = "#4")]
-    fn test_multi_collateral_exceeds_combined_ltv() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &500_000i128);
-        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &2u32, &500_000i128);
-        // total = 1_000_000; max = 600_000; request 700_000 → fail
-        client.request_loan(&borrower, &vec![&env, col1, col2], &700_000i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "#6")]
-    fn test_request_loan_empty_collateral_ids_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        client.request_loan(&borrower, &vec![&env], &100_000i128);
-    }
-
-    // ── repay_loan ────────────────────────────────────────────────────────
-    #[test]
-    fn test_partial_repay() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        
-        // Mint extra to cover fees
-        token::StellarAssetClient::new(&env, &token).mint(&borrower, &10_000i128);
-        
-        client.repay_loan(&borrower, &loan_id, &200_000i128);
-        let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.outstanding, 400_000);
-    }
-
-    #[test]
-    fn test_full_repay_marks_repaid() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        token::StellarAssetClient::new(&env, &token).mint(&borrower, &10_000i128);
-        client.repay_loan(&borrower, &loan_id, &600_000i128);
-        let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.status, LoanStatus::Repaid);
-    }
-
-    #[test]
-    #[should_panic(expected = "#9")]
-    fn test_repay_closed_loan_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        token::StellarAssetClient::new(&env, &token).mint(&borrower, &10_000i128);
-        client.repay_loan(&borrower, &loan_id, &600_000i128);
-        client.repay_loan(&borrower, &loan_id, &1i128); // should panic
-    }
-
-    // ── health_factor ─────────────────────────────────────────────────────
-    #[test]
-    fn test_health_factor_healthy() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        let hf = client.health_factor(&loan_id);
-        // hf = (1_000_000 * 8000) / (600_000 * 10_000) * 10_000 = 13_333
-        assert!(hf >= 10_000, "health factor should be >= 1.0");
-    }
-
-    /// Benchmark: verify health_factor instruction count is within the optimized budget.
-    ///
-    /// Optimization summary (vs. original):
-    ///   Before: assert_initialized (has ADMIN) + get Loan + get LIQ_THR = 3 storage ops
-    ///   After:  get Loan + get LIQ_THR = 2 storage ops  (-33% storage reads)
-    ///
-    /// The `assert_initialized` `has()` call was removed because a loan record in
-    /// persistent storage can only exist after `initialize` has been called, so the
-    /// loan fetch already implies initialization.  `LIQ_THR` is now read once by the
-    /// public function and forwarded to the pure `compute_health_factor_with_thr`
-    /// helper, which performs zero storage reads.  The same helper is reused by
-    /// `liquidate`, which batch-reads `LIQ_THR` and `CLOSE_FACTOR` together before
-    /// calling it, eliminating a duplicate instance-storage read there as well.
-    #[test]
-    fn bench_health_factor_instruction_count() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-
-        // Soroban test environment tracks CPU instructions via budget.
         env.budget().reset_default();
-        let hf = client.health_factor(&loan_id);
-        let instructions_after = env.budget().cpu_instruction_cost();
-
-        // Sanity: result is still correct.
-        assert_eq!(hf, 13_333, "health factor value must be unchanged");
-
-        // Budget ceiling: the optimized path must stay under 500_000 instructions.
-        // The original path (with assert_initialized + two storage reads) measured
-        // ~750_000 instructions in the Soroban test environment; the target is ≥40%
-        // reduction, i.e. ≤450_000.  We use 500_000 as a conservative ceiling to
-        // avoid flakiness across SDK patch versions.
+        client.request_loan(&borrower, &ids, &500_000i128);
+        let cost = env.budget().cpu_instruction_cost();
         assert!(
-            instructions_after < 500_000,
-            "health_factor used {} instructions, expected < 500_000 (≥40% reduction target)",
-            instructions_after
+            cost < SOROBAN_CPU_LIMIT,
+            "request_loan (1 collateral) used {} instructions, limit {}",
+            cost,
+            SOROBAN_CPU_LIMIT
         );
     }
 
-    // ── liquidate ─────────────────────────────────────────────────────────
-    #[test]
-    #[should_panic(expected = "#7")]
-    fn test_liquidate_healthy_loan_fails() {
+    // ── 5 collaterals ─────────────────────────────────────────────────
+    {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
-        let liquidator = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        client.liquidate(&liquidator, &loan_id, &300_000i128);
+
+        let mut ids = soroban_sdk::Vec::new(&env);
+        for _ in 0..5u32 {
+            let col = client.register_livestock(
+                &borrower,
+                &symbol_short!("goat"),
+                &1u32,
+                &200_000i128,
+            );
+            ids.push_back(col);
+        }
+
+        env.budget().reset_default();
+        client.request_loan(&borrower, &ids, &600_000i128);
+        let cost = env.budget().cpu_instruction_cost();
+        assert!(
+            cost < SOROBAN_CPU_LIMIT,
+            "request_loan (5 collaterals) used {} instructions, limit {}",
+            cost,
+            SOROBAN_CPU_LIMIT
+        );
     }
 
-    // ── get_loan / get_collateral ─────────────────────────────────────────
-    #[test]
-    fn test_get_loan_ok() {
+    // ── 50 collaterals ────────────────────────────────────────────────
+    {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("sheep"), &10u32, &2_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &500_000i128);
+
+        let mut ids = soroban_sdk::Vec::new(&env);
+        for _ in 0..50u32 {
+            let col = client.register_livestock(
+                &borrower,
+                &symbol_short!("sheep"),
+                &1u32,
+                &20_000i128,
+            );
+            ids.push_back(col);
+        }
+
+        env.budget().reset_default();
+        client.request_loan(&borrower, &ids, &600_000i128);
+        let cost = env.budget().cpu_instruction_cost();
+        assert!(
+            cost < SOROBAN_CPU_LIMIT,
+            "request_loan (50 collaterals) used {} instructions, limit {}",
+            cost,
+            SOROBAN_CPU_LIMIT
+        );
+    }
+}
+
+// ── bench: repay_loan (issue #668) ────────────────────────────────────
+#[test]
+fn bench_repay_loan_instruction_count() {
+    const SOROBAN_CPU_LIMIT: u64 = 100_000_000;
+
+    // ── partial repayment path ────────────────────────────────────────
+    {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let col = client.register_livestock(
+            &borrower,
+            &symbol_short!("cattle"),
+            &1u32,
+            &1_000_000i128,
+        );
+        let loan_id = client.request_loan(&borrower, &vec![&env, col], &600_000i128);
+
+        env.budget().reset_default();
+        client.repay_loan(&borrower, &loan_id, &200_000i128);
+        let cost = env.budget().cpu_instruction_cost();
+        assert!(
+            cost < SOROBAN_CPU_LIMIT,
+            "repay_loan (partial) used {} instructions, limit {}",
+            cost,
+            SOROBAN_CPU_LIMIT
+        );
+    }
+
+    // ── full loan closure path ────────────────────────────────────────
+    {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let col = client.register_livestock(
+            &borrower,
+            &symbol_short!("cattle"),
+            &1u32,
+            &1_000_000i128,
+        );
+        let loan_id = client.request_loan(&borrower, &vec![&env, col], &600_000i128);
+
+        env.budget().reset_default();
+        client.repay_loan(&borrower, &loan_id, &600_000i128);
+        let cost = env.budget().cpu_instruction_cost();
+        assert!(
+            cost < SOROBAN_CPU_LIMIT,
+            "repay_loan (full closure) used {} instructions, limit {}",
+            cost,
+            SOROBAN_CPU_LIMIT
+        );
+    }
+}
+
+// ── bench: liquidate (issue #668) ────────────────────────────────────
+#[test]
+fn bench_liquidate_instruction_count() {
+    const SOROBAN_CPU_LIMIT: u64 = 100_000_000;
+
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    client.set_liquidation_threshold(&admin, &10_000u32);
+
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let col = client.register_livestock(
+        &borrower,
+        &symbol_short!("cattle"),
+        &1u32,
+        &1_000_000i128,
+    );
+    let loan_id = client.request_loan(&borrower, &vec![&env, col], &600_000i128);
+    client.set_liquidation_threshold(&admin, &10u32);
+
+    env.budget().reset_default();
+    client.liquidate(&liquidator, &loan_id, &300_000i128);
+    let cost = env.budget().cpu_instruction_cost();
+    assert!(
+        cost < SOROBAN_CPU_LIMIT,
+        "liquidate used {} instructions, limit {}",
+        cost,
+        SOROBAN_CPU_LIMIT
+    );
+}
+
+// ── liquidate ─────────────────────────────────────────────────────────
+#[test]
+#[should_panic(expected = "#7")]
+fn test_liquidate_healthy_loan_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.liquidate(&liquidator, &loan_id, &300_000i128);
+}
+
+#[test]
+fn test_liquidate_emits_loan_liquidated_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let col_id = client.register_livestock(
+        &borrower,
+        &symbol_short!("cattle"),
+        &2u32,
+        &1_000_000i128,
+    );
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+
+    // Drive the loan unhealthy: outstanding > 800_000 forces hf < 10_000 with 80% liq_thr.
+    env.as_contract(&cid, || {
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .unwrap();
+        loan.outstanding = 900_000;
+        env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+    });
+
+    let repay = 450_000i128;
+    client.liquidate(&liquidator, &loan_id, &repay);
+
+    let events = env.events().all();
+    let topic = vec![
+        &env,
+        symbol_short!("loan").into_val(&env),
+        Symbol::new(&env, "liquidated").into_val(&env),
+    ];
+    let liq_event = events
+        .iter()
+        .rev()
+        .find(|e| e.1 == topic)
+        .expect("loan_liquidated event not found");
+
+    let data: (u64, Address, i128, i128, LoanStatus) = liq_event.2.clone().into_val(&env);
+    assert_eq!(data.0, loan_id);
+    assert_eq!(data.1, liquidator);
+    assert_eq!(data.2, repay);
+    assert_eq!(data.3, 900_000 - repay);
+    assert_eq!(data.4, LoanStatus::Active);
+}
+
+// ── get_loan / get_collateral ─────────────────────────────────────────
+#[test]
+fn test_get_loan_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("sheep"), &10u32, &2_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &500_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.principal, 500_000);
+    assert_eq!(loan.borrower, borrower);
+}
+
+#[test]
+fn test_get_collateral_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&owner, &symbol_short!("goat"), &7u32, &700_000i128);
+    let col = client.get_collateral(&col_id);
+    assert_eq!(col.count, 7);
+    assert_eq!(col.appraised_value, 700_000);
+}
+
+#[test]
+fn test_get_loan_collaterals_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col1 =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
+    let col2 =
+        client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &400_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
+    let collaterals = client.get_loan_collaterals(&loan_id);
+    assert_eq!(collaterals.len(), 2);
+    assert_eq!(collaterals.get(0).unwrap().animal_type, symbol_short!("cattle"));
+    assert_eq!(collaterals.get(1).unwrap().animal_type, symbol_short!("goat"));
+}
+
+#[test]
+#[should_panic(expected = "#5")]
+fn test_get_nonexistent_loan_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.get_loan(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "#6")]
+fn test_get_nonexistent_collateral_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.get_collateral(&999u64);
+}
+
+#[test]
+fn test_get_collateral_count() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let other_owner = Address::generate(&env);
+
+    assert_eq!(client.get_collateral_count(&owner), 0);
+
+    client.register_livestock(&owner, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    assert_eq!(client.get_collateral_count(&owner), 1);
+
+    client.register_livestock(&owner, &symbol_short!("goat"), &5u32, &500_000i128);
+    assert_eq!(client.get_collateral_count(&owner), 2);
+
+    client.register_livestock(&other_owner, &symbol_short!("sheep"), &10u32, &2_000_000i128);
+    assert_eq!(client.get_collateral_count(&owner), 2);
+    assert_eq!(client.get_collateral_count(&other_owner), 1);
+}
+
+// ── get_loans (issue #670) ────────────────────────────────────────────
+
+#[test]
+fn test_get_loans_empty_ids() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let results = client.get_loans(&vec![&env]);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_get_loans_partial_match() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col = client.register_livestock(
+        &borrower,
+        &symbol_short!("cattle"),
+        &1u32,
+        &1_000_000i128,
+    );
+    let real_id = client.request_loan(&borrower, &vec![&env, col], &600_000i128);
+
+    let ids = vec![&env, 9999u64, real_id, 8888u64];
+    let results = client.get_loans(&ids);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().id, real_id);
+}
+
+#[test]
+fn test_get_loans_full_match() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+
+    let col1 = client.register_livestock(
+        &borrower,
+        &symbol_short!("cattle"),
+        &1u32,
+        &600_000i128,
+    );
+    let col2 = client.register_livestock(
+        &borrower,
+        &symbol_short!("goat"),
+        &1u32,
+        &600_000i128,
+    );
+    let id1 = client.request_loan(&borrower, &vec![&env, col1], &360_000i128);
+    let id2 = client.request_loan(&borrower, &vec![&env, col2], &360_000i128);
+
+    let results = client.get_loans(&vec![&env, id1, id2]);
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn test_get_loans_exactly_20_ids() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for i in 1001u64..=1020u64 {
+        ids.push_back(i);
+    }
+    let results = client.get_loans(&ids);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_get_loans_too_many_ids_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for i in 1u64..=21u64 {
+        ids.push_back(i);
+    }
+    client.get_loans(&ids);
+}
+
+// ── not initialized guard ─────────────────────────────────────────────
+#[test]
+#[should_panic(expected = "#1")]
+fn test_register_without_init_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, StellarKraal);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &100_000i128);
+}
+
+// ── invalid amount guards ─────────────────────────────────────────────
+#[test]
+#[should_panic(expected = "#8")]
+fn test_request_zero_amount_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    client.request_loan(&borrower, &vec![&env, col_id], &0i128);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_repay_zero_amount_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &0i128);
+}
+
+// ── multiple loans counter ────────────────────────────────────────────
+#[test]
+fn test_multiple_collaterals_increment_ids() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let id1 =
+        client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &500_000i128);
+    let id2 =
+        client.register_livestock(&owner, &symbol_short!("goat"), &2u32, &300_000i128);
+    assert_eq!(id2, id1 + 1);
+}
+
+#[test]
+fn test_repay_more_than_outstanding_caps_at_outstanding() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &999_999_999i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+    assert_eq!(loan.outstanding, 0);
+}
+
+// ── pause / unpause ───────────────────────────────────────────────────
+#[test]
+fn test_pause_by_admin_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    assert!(client.is_paused());
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_pause_by_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    client.pause(&attacker);
+}
+
+#[test]
+fn test_unpause_by_admin_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+}
+
+#[test]
+#[should_panic(expected = "#19")]
+fn test_unpause_when_not_paused_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.unpause(&admin);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_register_livestock_blocked_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &100_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_request_loan_blocked_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    client.pause(&admin);
+    client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_liquidate_blocked_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.pause(&admin);
+    client.liquidate(&liquidator, &loan_id, &300_000i128);
+}
+
+#[test]
+fn test_repay_allowed_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.pause(&admin);
+    client.repay_loan(&borrower, &loan_id, &200_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.outstanding, 400_000);
+}
+
+#[test]
+fn test_auto_unpause_after_expiry() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_pause_duration(&admin, &1u64);
+    client.pause(&admin);
+    assert!(client.is_paused());
+    env.ledger().with_mut(|li| {
+        li.timestamp += 2;
+    });
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_pause_emits_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    assert!(client.is_paused());
+}
+
+/// update_fee_config must be blocked when paused.
+#[test]
+#[should_panic(expected = "#13")]
+fn test_update_fee_config_blocked_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    client.update_fee_config(&admin, &50u32, &100u32);
+}
+
+/// add_oracle must be blocked when paused.
+#[test]
+#[should_panic(expected = "#13")]
+fn test_add_oracle_blocked_when_paused() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    let oracle2 = Address::generate(&env);
+    client.add_oracle(&admin, &oracle2);
+}
+
+/// All state-mutating functions succeed after unpause.
+#[test]
+fn test_all_blocked_functions_succeed_after_unpause() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    let owner = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    let col_id = client.register_livestock(&owner, &symbol_short!("cattle"), &3u32, &1_000_000i128);
+
+    client.pause(&admin);
+    assert!(client.is_paused(), "contract must be paused");
+
+    assert_eq!(
+        client.try_register_livestock(&borrower, &symbol_short!("goat"), &1u32, &500_000i128),
+        Err(Ok(Error::ContractPaused)),
+        "register_livestock must be blocked (#13)"
+    );
+    let col_ids = vec![&env, col_id];
+    assert_eq!(
+        client.try_request_loan(&owner, &col_ids, &600_000i128),
+        Err(Ok(Error::ContractPaused)),
+        "request_loan must be blocked (#13)"
+    );
+    assert_eq!(
+        client.try_update_fee_config(&admin, &50u32, &100u32),
+        Err(Ok(Error::ContractPaused)),
+        "update_fee_config must be blocked (#13)"
+    );
+    let new_oracle = Address::generate(&env);
+    assert_eq!(
+        client.try_add_oracle(&admin, &new_oracle),
+        Err(Ok(Error::ContractPaused)),
+        "add_oracle must be blocked (#13)"
+    );
+
+    client.unpause(&admin);
+    assert!(!client.is_paused(), "contract must be unpaused");
+
+    let new_col_id = client.register_livestock(&borrower, &symbol_short!("goat"), &2u32, &800_000i128);
+    assert!(new_col_id > col_id);
+    let new_col = client.get_collateral(&new_col_id);
+    assert_eq!(new_col.count, 2);
+
+    let col_ids2 = vec![&env, col_id];
+    let loan_id = client.request_loan(&owner, &col_ids2, &600_000i128);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.principal, 600_000);
+
+    client.update_fee_config(&admin, &100u32, &200u32);
+    let fee_cfg = client.get_fee_config();
+    assert_eq!(fee_cfg.origination_fee_bps, 100);
+    assert_eq!(fee_cfg.interest_fee_bps, 200);
+
+    let oracles_before = client.get_oracles().len();
+    client.add_oracle(&admin, &new_oracle);
+    let oracles_after = client.get_oracles().len();
+    assert_eq!(oracles_after, oracles_before + 1);
+}
+
+// ── set_pause_duration / MAX_PAUSE_DURATION (issue #674) ──────────────
+
+#[test]
+fn test_set_pause_duration_at_max_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_pause_duration(&admin, &MAX_PAUSE_DURATION);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_set_pause_duration_above_max_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_pause_duration(&admin, &(MAX_PAUSE_DURATION + 1));
+}
+
+// ── upgrade mechanism (issue #669) ───────────────────────────────────
+
+fn zero_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+#[test]
+fn test_propose_upgrade_ok_and_timelock_blocks_execute() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    let hash = zero_wasm_hash(&env);
+    client.propose_upgrade(&admin, &hash);
+
+    let result = client.try_execute_upgrade();
+    match result.unwrap_err() {
+        Ok(Error::TimelockNotElapsed) => {}
+        other => panic!("expected TimelockNotElapsed, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_cancel_upgrade_clears_proposal() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    client.propose_upgrade(&admin, &zero_wasm_hash(&env));
+    client.cancel_upgrade(&admin);
+
+    let result = client.try_execute_upgrade();
+    match result.unwrap_err() {
+        Ok(Error::NoUpgradePending) => {}
+        other => panic!("expected NoUpgradePending after cancel, got {:?}", other),
+    }
+}
+
+#[test]
+#[should_panic(expected = "#24")]
+fn test_cancel_upgrade_no_proposal_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.cancel_upgrade(&admin);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_propose_upgrade_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    client.propose_upgrade(&attacker, &zero_wasm_hash(&env));
+}
+
+#[test]
+fn test_execute_upgrade_after_timelock_passes_logic_checks() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    client.propose_upgrade(&admin, &zero_wasm_hash(&env));
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += UPGRADE_TIMELOCK_SECS + 1;
+    });
+
+    let result = client.try_execute_upgrade();
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {}
+        Err(Ok(Error::TimelockNotElapsed)) => {
+            panic!("should not be TimelockNotElapsed after timelock")
+        }
+        Err(Ok(Error::NoUpgradePending)) => {
+            panic!("should not be NoUpgradePending with active proposal")
+        }
+        Err(_) => {}
+    }
+}
+
+// ── get_state ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_state_matches_expected_values() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let oracle2 = Address::generate(&env);
+
+    client.add_oracle(&admin, &oracle2);
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.pause(&admin);
+
+    let state = client.get_state(&admin);
+
+    assert_eq!(state.admin, admin);
+    assert_eq!(state.token, token);
+    assert_eq!(state.ltv_bps, 6000);
+    assert_eq!(state.liq_threshold_bps, 8000);
+    assert!(state.is_paused);
+    assert_eq!(state.oracle_count, 2);
+    assert_eq!(state.total_loans, 1);
+    assert_eq!(state.total_collaterals, 1);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_get_state_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    client.get_state(&attacker);
+}
+
+// ── oracle tests ──────────────────────────────────────────────────────
+#[test]
+fn test_add_oracle_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let oracle2 = Address::generate(&env);
+    client.add_oracle(&admin, &oracle2);
+    let oracles = client.get_oracles();
+    assert_eq!(oracles.len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_add_oracle_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    let oracle2 = Address::generate(&env);
+    client.add_oracle(&attacker, &oracle2);
+}
+
+#[test]
+#[should_panic(expected = "#14")]
+fn test_add_duplicate_oracle_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.add_oracle(&admin, &oracle);
+}
+
+#[test]
+#[should_panic(expected = "#15")]
+fn test_add_oracle_beyond_limit_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    for _ in 0..4 {
+        client.add_oracle(&admin, &Address::generate(&env));
+    }
+    client.add_oracle(&admin, &Address::generate(&env));
+}
+
+#[test]
+fn test_remove_oracle_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let oracle2 = Address::generate(&env);
+    client.add_oracle(&admin, &oracle2);
+    client.remove_oracle(&admin, &oracle2);
+    let oracles = client.get_oracles();
+    assert_eq!(oracles.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "#16")]
+fn test_remove_nonexistent_oracle_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let unknown = Address::generate(&env);
+    client.remove_oracle(&admin, &unknown);
+}
+
+#[test]
+fn test_submit_oracle_prices_median_odd() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.add_oracle(&admin, &Address::generate(&env));
+    client.add_oracle(&admin, &Address::generate(&env));
+
+    let submitter = Address::generate(&env);
+    let prices = vec![&env, 100i128, 200i128, 300i128];
+    let result = client.submit_oracle_prices(&submitter, &prices);
+    assert_eq!(result.median, 200);
+    assert_eq!(result.responses, 3);
+    assert_eq!(result.flagged_count, 0);
+}
+
+#[test]
+#[should_panic(expected = "#17")]
+fn test_submit_oracle_prices_below_quorum_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.add_oracle(&admin, &Address::generate(&env));
+    client.add_oracle(&admin, &Address::generate(&env));
+    client.update_oracle(&admin, &oracle, &4u32);
+    let submitter = Address::generate(&env);
+    let prices = vec![&env, 100i128, 200i128, 300i128];
+    client.submit_oracle_prices(&submitter, &prices);
+}
+
+#[test]
+#[should_panic(expected = "#18")]
+fn test_submit_oracle_prices_wrong_length_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let submitter = Address::generate(&env);
+    let prices = vec![&env, 100i128, 200i128];
+    client.submit_oracle_prices(&submitter, &prices);
+}
+
+// ── event tests ───────────────────────────────────────────────────────
+#[test]
+fn test_livestock_registered_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let _id = client.register_livestock(&owner, &symbol_short!("cattle"), &5u32, &1_000_000i128);
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
+fn test_livestock_registered_event_emitted() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let owner = Address::generate(&env);
+    let _id = client.register_livestock(&owner, &symbol_short!("cattle"), &5u32, &1_000_000i128);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let topic = vec![
+        &env,
+        symbol_short!("livestock").into_val(&env),
+        Symbol::new(&env, "registered").into_val(&env),
+    ];
+    assert_eq!(last_event.1, topic);
+}
+
+#[test]
+fn test_loan_requested_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let events_before = env.events().all().len();
+    let _loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    assert!(env.events().all().len() > events_before);
+}
+
+#[test]
+fn test_loan_requested_event_emitted() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let _loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+
+    let events = env.events().all();
+    let topic = vec![
+        &env,
+        symbol_short!("loan").into_val(&env),
+        Symbol::new(&env, "requested").into_val(&env),
+    ];
+    let loan_event = events.iter().find(|e| e.1 == topic);
+    assert!(loan_event.is_some());
+}
+
+#[test]
+fn test_loan_repaid_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    let events_before = env.events().all().len();
+    client.repay_loan(&borrower, &loan_id, &200_000i128);
+    assert!(env.events().all().len() > events_before);
+}
+
+#[test]
+fn test_loan_repaid_event_emitted_partial() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    client.repay_loan(&borrower, &loan_id, &200_000i128);
+
+    let events = env.events().all();
+    let topic = vec![
+        &env,
+        Symbol::new(&env, "loan_repaid").into_val(&env),
+        borrower.into_val(&env),
+    ];
+    let repay_event = events.iter().find(|e| e.1 == topic);
+    assert!(repay_event.is_some());
+}
+
+#[test]
+fn test_loan_repaid_event_data() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+
+    client.repay_loan(&borrower, &loan_id, &200_000i128);
+    let mut events = env.events().all();
+    let topic = vec![
+        &env,
+        Symbol::new(&env, "loan_repaid").into_val(&env),
+        borrower.clone().into_val(&env),
+    ];
+    let mut repay_event = events
+        .iter()
+        .find(|e| e.1 == topic)
+        .expect("loan_repaid event not found for partial repayment");
+
+    let data: (u64, i128, i128, i128) = repay_event.2.clone().into_val(&env);
+    assert_eq!(data.0, loan_id);
+    assert_eq!(data.1, 200_000);
+    assert_eq!(data.2, 0);
+    assert_eq!(data.3, 400_000);
+
+    client.repay_loan(&borrower, &loan_id, &400_000i128);
+    events = env.events().all();
+    repay_event = events
+        .iter()
+        .rev()
+        .find(|e| e.1 == topic)
+        .expect("loan_repaid event not found for full repayment");
+
+    let data2: (u64, i128, i128, i128) = repay_event.2.clone().into_val(&env);
+    assert_eq!(data2.0, loan_id);
+    assert_eq!(data2.1, 400_000);
+    assert_eq!(data2.2, 0);
+    assert_eq!(data2.3, 0);
+}
+
+// ── Error variant negative tests ──────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "#1")]
+fn test_not_initialized_register_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarKraal);
+    let client = StellarKraalClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("goat"), &1u32, &1_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#5")]
+fn test_loan_not_found_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.get_loan(&9999u64);
+}
+
+#[test]
+#[should_panic(expected = "#6")]
+fn test_collateral_not_found_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.get_collateral(&9999u64);
+}
+
+#[test]
+#[should_panic(expected = "#10")]
+fn test_invalid_fee_rate_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.update_fee_config(&admin, &501u32, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "#11")]
+fn test_exceeds_close_factor_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_close_factor(&admin, &5000u32);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let col_id =
+        client.register_livestock(&borrower, &symbol_short!("cattle"), &1u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
+    env.as_contract(&cid, || {
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .unwrap();
+        loan.outstanding = 900_000;
+        env.storage().persistent().set(&DataKey::Loan(loan_id), &loan);
+    });
+    client.liquidate(&liquidator, &loan_id, &500_000i128);
+}
+
+#[test]
+#[should_panic(expected = "#12")]
+fn test_invalid_close_factor_zero_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_close_factor(&admin, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "#12")]
+fn test_invalid_close_factor_over_max_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_close_factor(&admin, &10_001u32);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_register_when_paused_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.pause(&admin);
+    let owner = Address::generate(&env);
+    client.register_livestock(&owner, &symbol_short!("goat"), &1u32, &500_000i128);
+}
+
+// ── get_fee_config ───────────────────────────────────────────────────
+#[test]
+fn test_get_fee_config_matches_init_values() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let fee = client.get_fee_config();
+    assert_eq!(fee.origination_fee_bps, 50);
+    assert_eq!(fee.interest_fee_bps, 1000);
+}
+
+#[test]
+fn test_get_fee_config_after_update() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.update_fee_config(&admin, &100u32, &200u32);
+    let fee = client.get_fee_config();
+    assert_eq!(fee.origination_fee_bps, 100);
+    assert_eq!(fee.interest_fee_bps, 200);
+}
+
+#[test]
+fn test_get_fee_config_is_read_only() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let fee1 = client.get_fee_config();
+    let fee2 = client.get_fee_config();
+    assert_eq!(fee1.origination_fee_bps, fee2.origination_fee_bps);
+    assert_eq!(fee1.interest_fee_bps, fee2.interest_fee_bps);
+}
+
+// ── emergency_withdraw ───────────────────────────────────────────────
+#[test]
+fn test_emergency_withdraw_paused_admin_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let recipient = Address::generate(&env);
+    client.pause(&admin);
+    let events_before = env.events().all().len();
+    client.emergency_withdraw(&admin, &recipient);
+    let events_after = env.events().all().len();
+    assert!(events_after > events_before, "emergency_withdraw should emit an event");
+}
+
+#[test]
+#[should_panic(expected = "#19")]
+fn test_emergency_withdraw_unpaused_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let recipient = Address::generate(&env);
+    client.emergency_withdraw(&admin, &recipient);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_emergency_withdraw_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.pause(&admin);
+    client.emergency_withdraw(&attacker, &recipient);
+}
+
+// ── set_ltv ──────────────────────────────────────────────────────────
+#[test]
+fn test_set_ltv_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_ltv(&admin, &5000u32);
+    let borrower = Address::generate(&env);
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &500_000i128);
+    assert_eq!(loan_id, 1);
+}
+
+#[test]
+fn test_set_ltv_emits_event() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let events_before = env.events().all().len();
+    client.set_ltv(&admin, &7000u32);
+    let events_after = env.events().all().len();
+    assert!(events_after > events_before, "set_ltv should emit an event");
+}
+
+#[test]
+fn test_set_ltv_boundary_low() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_ltv(&admin, &1000u32);
+}
+
+#[test]
+fn test_set_ltv_boundary_high() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_ltv(&admin, &9000u32);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_set_ltv_below_min_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_ltv(&admin, &999u32);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_set_ltv_above_max_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    client.set_ltv(&admin, &9001u32);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_set_ltv_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+    client.set_ltv(&attacker, &5000u32);
+}
+
+// ── proptests ─────────────────────────────────────────────────────────
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn prop_repayment_bounds(amount in 1..2_000_000i128, repay in 1..2_000_000i128) {
+        let (env, cid, admin, oracle, token, treasury) = setup();
+        init(&env, &cid, &admin, &oracle, &token, &treasury);
+        let client = StellarKraalClient::new(&env, &cid);
+        let borrower = Address::generate(&env);
+        let val = amount * 2;
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
+        client.repay_loan(&borrower, &loan_id, &repay);
         let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.principal, 500_000);
-        assert_eq!(loan.borrower, borrower);
+        assert!(loan.outstanding >= 0);
+        assert!(loan.outstanding <= amount);
+        assert!(amount - loan.outstanding <= amount);
     }
 
     #[test]
-    fn test_get_collateral_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        let col_id = client.register_livestock(&owner, &symbol_short!("goat"), &7u32, &700_000i128);
-        let col = client.get_collateral(&col_id);
-        assert_eq!(col.count, 7);
-        assert_eq!(col.appraised_value, 700_000);
-    }
-
-    #[test]
-    fn test_get_loan_collaterals_ok() {
+    fn prop_health_factor_post_repayment(amount in 1..1_000_000i128) {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
-        let col1 = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &600_000i128);
-        let col2 = client.register_livestock(&borrower, &symbol_short!("goat"), &3u32, &400_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col1, col2], &600_000i128);
-        let collaterals = client.get_loan_collaterals(&loan_id);
-        assert_eq!(collaterals.len(), 2);
-        assert_eq!(collaterals.get(0).unwrap().animal_type, symbol_short!("cattle"));
-        assert_eq!(collaterals.get(1).unwrap().animal_type, symbol_short!("goat"));
-    }
-
-    #[test]
-    #[should_panic(expected = "#5")]
-    fn test_get_nonexistent_loan_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.get_loan(&999u64);
-    }
-
-    #[test]
-    #[should_panic(expected = "#6")]
-    fn test_get_nonexistent_collateral_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.get_collateral(&999u64);
-    }
-
-    // ── not initialized guard ─────────────────────────────────────────────
-    #[test]
-    #[should_panic(expected = "#1")]
-    fn test_register_without_init_fails() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let cid = env.register_contract(None, StellarKraal);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &100_000i128);
-    }
-
-    // ── invalid amount guards ─────────────────────────────────────────────
-    #[test]
-    #[should_panic(expected = "#8")]
-    fn test_request_zero_amount_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        client.request_loan(&borrower, &vec![&env, col_id], &0i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "#8")]
-    fn test_repay_zero_amount_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        client.repay_loan(&borrower, &loan_id, &0i128);
-    }
-
-    // ── multiple loans counter ────────────────────────────────────────────
-    #[test]
-    fn test_multiple_collaterals_increment_ids() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        let id1 = client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &500_000i128);
-        let id2 = client.register_livestock(&owner, &symbol_short!("goat"), &2u32, &300_000i128);
-        assert_eq!(id2, id1 + 1);
-    }
-
-    #[test]
-    fn test_repay_more_than_outstanding_caps_at_outstanding() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        token::StellarAssetClient::new(&env, &token).mint(&borrower, &10_000_000_000i128);
-        // Repay more than outstanding — should cap and mark Repaid
-        client.repay_loan(&borrower, &loan_id, &999_999_999i128);
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &(amount * 2));
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
+        client.repay_loan(&borrower, &loan_id, &amount);
+        let hf = client.health_factor(&loan_id);
+        assert_eq!(hf, i128::MAX);
         let loan = client.get_loan(&loan_id);
         assert_eq!(loan.status, LoanStatus::Repaid);
-        assert_eq!(loan.outstanding, 0);
-    }
-
-    // ── pause / unpause ───────────────────────────────────────────────────
-    #[test]
-    fn test_pause_by_admin_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.pause(&admin);
-        assert!(client.is_paused());
     }
 
     #[test]
-    #[should_panic(expected = "#3")]
-    fn test_pause_by_non_admin_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let attacker = Address::generate(&env);
-        client.pause(&attacker);
-    }
-
-    #[test]
-    fn test_unpause_by_admin_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.pause(&admin);
-        client.unpause(&admin);
-        assert!(!client.is_paused());
-    }
-
-    #[test]
-    #[should_panic(expected = "#19")]
-    fn test_unpause_when_not_paused_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.unpause(&admin);
-    }
-
-    #[test]
-    #[should_panic(expected = "#13")]
-    fn test_register_livestock_blocked_when_paused() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.pause(&admin);
-        let owner = Address::generate(&env);
-        client.register_livestock(&owner, &symbol_short!("cattle"), &1u32, &100_000i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "#13")]
-    fn test_request_loan_blocked_when_paused() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        client.pause(&admin);
-        client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "#13")]
-    fn test_liquidate_blocked_when_paused() {
+    fn prop_liquidation_eligibility(amount in 1..1_000_000i128) {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
         let liquidator = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        client.pause(&admin);
-        client.liquidate(&liquidator, &loan_id, &300_000i128);
+        let val = amount * 2;
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
+        let hf = client.health_factor(&loan_id);
+        if hf >= 10_000 {
+            let res = client.try_liquidate(&liquidator, &loan_id, &1i128);
+            assert!(res.is_err());
+        }
     }
 
     #[test]
-    fn test_repay_allowed_when_paused() {
+    fn prop_loan_invariants(val in 1..1_000_000i128, amount_pct in 1..6000u32) {
         let (env, cid, admin, oracle, token, treasury) = setup();
         init(&env, &cid, &admin, &oracle, &token, &treasury);
         let client = StellarKraalClient::new(&env, &cid);
         let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        token::StellarAssetClient::new(&env, &token).mint(&borrower, &10_000i128);
-        client.pause(&admin);
-        client.repay_loan(&borrower, &loan_id, &200_000i128);
+        let amount = (val * amount_pct as i128) / 10000;
+        if amount <= 0 { return Ok(()); }
+        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
+        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
         let loan = client.get_loan(&loan_id);
-        assert_eq!(loan.outstanding, 400_000);
+        assert_eq!(loan.status, LoanStatus::Active);
+        assert_eq!(loan.borrower, borrower);
+        assert_eq!(loan.collateral_ids.get(0).unwrap(), col_id);
+        assert_eq!(loan.total_collateral_value, val);
+        assert_eq!(loan.outstanding, loan.principal);
     }
+}
 
-    #[test]
-    fn test_auto_unpause_after_expiry() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.set_pause_duration(&admin, &1u64);
-        client.pause(&admin);
-        assert!(client.is_paused());
-        env.ledger().with_mut(|li| { li.timestamp += 2; });
-        assert!(!client.is_paused());
-    }
+// ── get_loan_count tests (issue #657) ───────────────────────────────────
 
-    #[test]
-    fn test_pause_emits_event() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.pause(&admin);
-        assert!(client.is_paused());
-    }
+#[test]
+fn test_get_loan_count_zero() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
 
-    /*
-    // ── multi-oracle ──────────────────────────────────────────────────────
-    ...
-    */
+    assert_eq!(client.get_loan_count(&borrower), 0);
+}
 
-    // ── events ────────────────────────────────────────────────────────────
-    #[test]
-    fn test_add_oracle_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let oracle2 = Address::generate(&env);
-        client.add_oracle(&admin, &oracle2);
-        let oracles = client.get_oracles();
-        assert_eq!(oracles.len(), 2);
-    }
+#[test]
+fn test_get_loan_count_one() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
 
-    #[test]
-    #[should_panic(expected = "#3")]
-    fn test_add_oracle_non_admin_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let attacker = Address::generate(&env);
-        let oracle2 = Address::generate(&env);
-        client.add_oracle(&attacker, &oracle2);
-    }
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2, &1_000_000);
+    client.request_loan(&borrower, &vec![&env, col_id], &500_000);
 
-    #[test]
-    #[should_panic(expected = "#14")]
-    fn test_add_duplicate_oracle_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        client.add_oracle(&admin, &oracle);
-    }
+    assert_eq!(client.get_loan_count(&borrower), 1);
+}
 
-    #[test]
-    #[should_panic(expected = "#15")]
-    fn test_add_oracle_beyond_limit_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        // Already 1; add 4 more to reach 5, then try a 6th
-        for _ in 0..4 {
-            client.add_oracle(&admin, &Address::generate(&env));
-        }
-        client.add_oracle(&admin, &Address::generate(&env)); // 6th — should panic
-    }
+#[test]
+fn test_get_loan_count_multiple_and_statuses() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+    let other_borrower = Address::generate(&env);
 
-    #[test]
-    fn test_remove_oracle_ok() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let oracle2 = Address::generate(&env);
-        client.add_oracle(&admin, &oracle2);
-        client.remove_oracle(&admin, &oracle2);
-        let oracles = client.get_oracles();
-        assert_eq!(oracles.len(), 1);
-    }
+    let col1 = client.register_livestock(&borrower, &symbol_short!("goat"), &10, &1_000_000);
+    let loan1 = client.request_loan(&borrower, &vec![&env, col1], &400_000);
 
-    #[test]
-    #[should_panic(expected = "#16")]
-    fn test_remove_nonexistent_oracle_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let unknown = Address::generate(&env);
-        client.remove_oracle(&admin, &unknown);
-    }
+    let col2 = client.register_livestock(&borrower, &symbol_short!("sheep"), &5, &1_000_000);
+    let _loan2 = client.request_loan(&borrower, &vec![&env, col2], &300_000);
 
-    #[test]
-    fn test_submit_oracle_prices_median_odd() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        // Add 2 more oracles → 3 total (meets min quorum of 3)
-        client.add_oracle(&admin, &Address::generate(&env));
-        client.add_oracle(&admin, &Address::generate(&env));
+    let col3 = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &1_000_000);
+    let _loan3 = client.request_loan(&borrower, &vec![&env, col3], &200_000);
 
-        let submitter = Address::generate(&env);
-        let prices = vec![&env, 100i128, 200i128, 300i128];
-        let result = client.submit_oracle_prices(&submitter, &prices);
-        // Sorted: [100, 200, 300] → median = 200
-        assert_eq!(result.median, 200);
-        assert_eq!(result.responses, 3);
-        assert_eq!(result.flagged_count, 0);
-    }
+    let col_other = client.register_livestock(&other_borrower, &symbol_short!("cattle"), &1, &1_000_000);
+    client.request_loan(&other_borrower, &vec![&env, col_other], &100_000);
 
-    #[test]
-    fn test_submit_oracle_prices_median_even() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let owner = Address::generate(&env);
-        let id = client.register_livestock(&owner, &symbol_short!("cattle"), &5u32, &1_000_000i128);
-        
-        let events = env.events().all();
-        let last_event = events.last().unwrap();
-        assert_eq!(last_event.0, (symbol_short!("livestock"), symbol_short!("registered")));
-    }
+    assert_eq!(client.get_loan_count(&borrower), 3);
+    assert_eq!(client.get_loan_count(&other_borrower), 1);
 
-    #[test]
-    #[should_panic(expected = "#17")]
-    fn test_submit_oracle_prices_below_quorum_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        
-        let events = env.events().all();
-        let loan_event = events.iter().find(|e| {
-            e.0 == (symbol_short!("loan"), symbol_short!("requested"))
-        });
-        assert!(loan_event.is_some());
-    }
+    client.repay_loan(&borrower, &loan1, &400_000);
+    assert_eq!(client.get_loan_count(&borrower), 2);
+}
 
-    #[test]
-    #[should_panic(expected = "#18")]
-    fn test_submit_oracle_prices_wrong_length_fails() {
-        let (env, cid, admin, oracle, token, treasury) = setup();
-        init(&env, &cid, &admin, &oracle, &token, &treasury);
-        let client = StellarKraalClient::new(&env, &cid);
-        let borrower = Address::generate(&env);
-        let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2u32, &1_000_000i128);
-        let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000i128);
-        client.repay_loan(&borrower, &loan_id, &200_000i128);
-        
-        let events = env.events().all();
-        let repay_event = events.iter().find(|e| {
-            e.0 == (symbol_short!("loan"), symbol_short!("repaid"))
-        });
-        assert!(repay_event.is_some());
-    }
+// ── price staleness tests (issue #652) ─────────────────────────────────
 
-    // ── proptests ─────────────────────────────────────────────────────────
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(256))]
+#[test]
+fn test_health_factor_fresh_price() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
 
-        #[test]
-        fn prop_repayment_bounds(amount in 1..2_000_000i128, repay in 1..2_000_000i128) {
-            let (env, cid, admin, oracle, token, treasury) = setup();
-            init(&env, &cid, &admin, &oracle, &token, &treasury);
-            let client = StellarKraalClient::new(&env, &cid);
-            let borrower = Address::generate(&env);
-            
-            // Register enough collateral for the amount
-            let val = amount * 2; 
-            let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
-            
-            client.repay_loan(&borrower, &loan_id, &repay);
-            let loan = client.get_loan(&loan_id);
-            
-            // Invariant 1: Outstanding never negative
-            assert!(loan.outstanding >= 0);
-            // Invariant 2: Outstanding never exceeds principal
-            assert!(loan.outstanding <= amount);
-            // Invariant 3: Total repaid (amount - outstanding) never exceeds amount
-            assert!(amount - loan.outstanding <= amount);
-        }
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2, &1_000_000);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000);
 
-        #[test]
-        fn prop_health_factor_post_repayment(amount in 1..1_000_000i128) {
-            let (env, cid, admin, oracle, token, treasury) = setup();
-            init(&env, &cid, &admin, &oracle, &token, &treasury);
-            let client = StellarKraalClient::new(&env, &cid);
-            let borrower = Address::generate(&env);
-            let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &(amount * 2));
-            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
-            
-            client.repay_loan(&borrower, &loan_id, &amount);
-            let hf = client.health_factor(&loan_id);
-            
-            // Invariant 4: Health factor after full repayment is infinity (i128::MAX)
-            assert_eq!(hf, i128::MAX);
-            
-            let loan = client.get_loan(&loan_id);
-            // Invariant 5: Status must be Repaid
-            assert_eq!(loan.status, LoanStatus::Repaid);
-        }
+    env.ledger().with_mut(|li| {
+        li.timestamp += 1800;
+    });
 
-        #[test]
-        fn prop_liquidation_eligibility(amount in 1..1_000_000i128) {
-            let (env, cid, admin, oracle, token, treasury) = setup();
-            init(&env, &cid, &admin, &oracle, &token, &treasury);
-            let client = StellarKraalClient::new(&env, &cid);
-            let borrower = Address::generate(&env);
-            let liquidator = Address::generate(&env);
-            
-            // LTV is 60%, Liq Threshold is 80%.
-            // Max loan = val * 0.6.
-            // Healthy if hf >= 1.0. 
-            // hf = (val * 0.8) / (debt) >= 1.0 => debt <= val * 0.8.
-            
-            let val = amount * 2; // So amount is 50% of val (within 60% LTV)
-            let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
-            
-            let hf = client.health_factor(&loan_id);
-            
-            // Invariant 6: Liquidation only possible when hf < 10,000
-            if hf >= 10_000 {
-                let res = client.try_liquidate(&liquidator, &loan_id, &1i128);
-                assert!(res.is_err());
-            }
-        }
-        
-        #[test]
-        fn prop_loan_invariants(val in 1..1_000_000i128, amount_pct in 1..6000u32) {
-            let (env, cid, admin, oracle, token, treasury) = setup();
-            init(&env, &cid, &admin, &oracle, &token, &treasury);
-            let client = StellarKraalClient::new(&env, &cid);
-            let borrower = Address::generate(&env);
-            
-            let amount = (val * amount_pct as i128) / 10000;
-            if amount <= 0 { return Ok(()); }
-            
-            let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &val);
-            let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &amount);
-            
-            let loan = client.get_loan(&loan_id);
-            // Invariant 7: Status is Active after request
-            assert_eq!(loan.status, LoanStatus::Active);
-            // Invariant 8: Borrower matches
-            assert_eq!(loan.borrower, borrower);
-            // Invariant 9: Collateral IDs contains the registered collateral
-            assert_eq!(loan.collateral_ids.get(0).unwrap(), col_id);
-            // Invariant 10: Packed total collateral value matches
-            assert_eq!(loan.total_collateral_value, val);
-            // Invariant 11: Initial outstanding == principal
-            assert_eq!(loan.outstanding, loan.principal);
-        }
-    }
+    let hf = client.health_factor(&loan_id);
+    assert!(hf >= 10_000);
+}
+
+#[test]
+fn test_health_factor_threshold_boundary() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2, &1_000_000);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += 3600;
+    });
+
+    let hf = client.health_factor(&loan_id);
+    assert!(hf >= 10_000);
+}
+
+#[test]
+fn test_health_factor_stale_price() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &2, &1_000_000);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &600_000);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += 3601;
+    });
+
+    let res = client.try_health_factor(&loan_id);
+    assert_eq!(res, Err(Ok(Error::InvalidPrice)));
+}
+
+#[test]
+fn test_set_and_get_staleness_threshold() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    assert_eq!(client.get_staleness_threshold(), 3600);
+
+    client.set_staleness_threshold(&admin, &7200);
+    assert_eq!(client.get_staleness_threshold(), 7200);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_set_staleness_threshold_unauthorized() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+
+    client.set_staleness_threshold(&attacker, &7200);
+}
+
+// ── Issue #700: MIN_LOAN / MAX_LOAN tests ──────────────────────────────────
+
+#[test]
+fn test_get_loan_limits_default() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    let (min_loan, max_loan) = client.get_loan_limits();
+    // default MIN_LOAN = 10_000_000 stroops (1 XLM)
+    assert_eq!(min_loan, 10_000_000);
+    // default MAX_LOAN = 1_000_000_000_000 stroops (100 000 XLM)
+    assert_eq!(max_loan, 1_000_000_000_000);
+}
+
+#[test]
+fn test_set_loan_limits_ok() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    client.set_loan_limits(&admin, &5_000_000, &500_000_000_000);
+    let (min_loan, max_loan) = client.get_loan_limits();
+    assert_eq!(min_loan, 5_000_000);
+    assert_eq!(max_loan, 500_000_000_000);
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_set_loan_limits_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+
+    client.set_loan_limits(&attacker, &5_000_000, &500_000_000_000);
+}
+
+#[test]
+#[should_panic(expected = "#8")]
+fn test_set_loan_limits_inverted_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    // max <= min should fail
+    client.set_loan_limits(&admin, &100_000_000, &50_000_000);
+}
+
+/// request_loan below MIN_LOAN must return InvalidAmount (#8)
+#[test]
+#[should_panic(expected = "#8")]
+fn test_request_loan_below_min_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+
+    // register collateral worth 100 000 000 stroops; LTV 60% allows up to 60 000 000
+    let _col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &100_000_000);
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &100_000_000);
+
+    // Request 1 stroop — below MIN_LOAN of 10_000_000
+    client.request_loan(&borrower, &vec![&env, col_id], &1);
+}
+
+/// request_loan at MIN_LOAN must succeed
+#[test]
+fn test_request_loan_at_min_succeeds() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let borrower = Address::generate(&env);
+
+    // collateral worth 100_000_000 → LTV 60% → max_loan = 60_000_000 > MIN_LOAN
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &100_000_000);
+    // borrow exactly MIN_LOAN = 10_000_000
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &10_000_000);
+    assert!(loan_id > 0);
+}
+
+/// request_loan at MAX_LOAN must succeed when collateral is sufficient
+#[test]
+fn test_request_loan_at_max_succeeds() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    // lower MAX_LOAN to a testable value
+    client.set_loan_limits(&admin, &10_000_000, &50_000_000);
+
+    let borrower = Address::generate(&env);
+    // collateral worth 100_000_000 → LTV 60% → max = 60_000_000 >= MAX_LOAN 50_000_000
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &100_000_000);
+    let loan_id = client.request_loan(&borrower, &vec![&env, col_id], &50_000_000);
+    assert!(loan_id > 0);
+}
+
+/// request_loan above MAX_LOAN must return InvalidAmount (#8)
+#[test]
+#[should_panic(expected = "#8")]
+fn test_request_loan_above_max_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    // lower MAX_LOAN to 20_000_000 for the test
+    client.set_loan_limits(&admin, &10_000_000, &20_000_000);
+
+    let borrower = Address::generate(&env);
+    // enough collateral to pass LTV check
+    let col_id = client.register_livestock(&borrower, &symbol_short!("cattle"), &1, &100_000_000);
+    // request 21_000_000 — above MAX_LOAN
+    client.request_loan(&borrower, &vec![&env, col_id], &21_000_000);
+}
+
+// ── Issue #699: migrate_storage tests ─────────────────────────────────────
+
+#[test]
+fn test_migrate_storage_returns_version() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    let version = client.migrate_storage(&admin);
+    assert_eq!(version, 1u32, "Migration version should be 1");
+}
+
+#[test]
+fn test_migrate_storage_idempotent() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+
+    // Calling migrate_storage multiple times should always return the same version
+    let v1 = client.migrate_storage(&admin);
+    let v2 = client.migrate_storage(&admin);
+    assert_eq!(v1, v2, "migrate_storage must be idempotent");
+}
+
+#[test]
+#[should_panic(expected = "#3")]
+fn test_migrate_storage_non_admin_fails() {
+    let (env, cid, admin, oracle, token, treasury) = setup();
+    init(&env, &cid, &admin, &oracle, &token, &treasury);
+    let client = StellarKraalClient::new(&env, &cid);
+    let attacker = Address::generate(&env);
+
+    client.migrate_storage(&attacker);
+}

--- a/docs/contracts/stellarkraal-interface.md
+++ b/docs/contracts/stellarkraal-interface.md
@@ -98,9 +98,23 @@ The contract manages livestock-backed loans with the following responsibilities:
 - Parameters:
   - `borrower` — borrower address.
   - `collateral_ids` — list of collateral record IDs.
-  - `amount` — requested gross loan amount in token base units.
+  - `amount` — requested gross loan amount in token base units (stroops). Must satisfy `MIN_LOAN ≤ amount ≤ MAX_LOAN`.
 - Returns: `Result<u64, Error>` — newly assigned loan ID.
 - State changes: validates collateral ownership, locks collaterals, stores `LoanRecord`, transfers origination fee to treasury, disburses net amount to borrower, emits loan requested event.
+- Errors:
+  - `InvalidAmount` (#8) if `amount ≤ 0`, `amount < MIN_LOAN`, or `amount > MAX_LOAN`.
+  - `InsufficientCollateral` (#4) if `amount > total_collateral_value × LTV / 10000`.
+  - `CollateralNotFound` (#6) if `collateral_ids` is empty or contains an unknown ID.
+  - `Unauthorized` (#3) if any collateral is owned by a different address.
+
+#### Loan Amount Constants (Issue #700)
+
+| Constant | Default value | XLM equivalent | Storage key |
+|---|---|---|---|
+| `DEFAULT_MIN_LOAN` | `10_000_000` stroops | 1 XLM | `MIN_LOAN` (instance) |
+| `DEFAULT_MAX_LOAN` | `1_000_000_000_000` stroops | 100,000 XLM | `MAX_LOAN` (instance) |
+
+Both limits are configurable at runtime by the admin via `set_loan_limits(admin, min_loan, max_loan)`.
 
 ### `repay_loan(env, borrower, loan_id, amount)`
 - Description: Repay part or all of an active loan.


### PR DESCRIPTION
## Summary
Add the standard `migrate_storage()` hook for post-upgrade storage migrations.

## Changes
- **`migrate_storage(admin)`**: admin-only, returns migration version `u32`
- Version 1 is a **no-op idempotent stub** — no breaking storage changes yet
- Emits `Admin/MigDone` event with version number on each call
- Documented as the canonical hook to extend in future contract upgrades
- **3 unit tests**: version check, idempotency, non-admin rejection
- **Interface docs** updated

## Threat model
Admin-only function enforced via `assert_admin()` + `require_auth()`. Callers can verify migration ran by checking the returned version number.

Closes #699