### PR TITLE
docs: add rate limits guide and cross-links (closes #750)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ npm run test:frontend
 | Document | Description |
 |---|---|
 | [Loan State Machine](docs/protocol/loan-state-machine.md) | All loan states, valid transitions, triggering events, and on-chain event mapping |
+| [API Quickstart](docs/guides/api-quickstart.md) | Base URL, auth flow, and common `/api/v1` operations |
+| [Rate limits](docs/guides/rate-limits.md) | Global, auth, read, and write tiers; headers and retry behavior |
 | [Liquidation Mechanism](docs/protocol/liquidation.md) | Health factor formula, liquidation threshold, partial liquidation examples |
 | [Smart Contract Interface](docs/contracts/stellarkraal-interface.md) | Soroban contract public API, error codes, state changes, and CLI invocation guide |
 | [Contract API Docs](https://teslims2.github.io/StellarKraal-/contracts/) | Auto-generated `cargo doc` reference published to GitHub Pages |

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "StellarKraal API",
     "version": "1.0.0",
-    "description": "Livestock-backed micro-lending API on Stellar/Soroban. Write endpoints return an unsigned XDR transaction the client must sign with Freighter and submit to the Stellar network."
+    "description": "Livestock-backed micro-lending API on Stellar/Soroban. Write endpoints return an unsigned XDR transaction the client must sign with Freighter and submit to the Stellar network.\n\n**Rate limits:** Per-IP limits apply (global, auth, and write tiers). See the [rate limits guide](../docs/guides/rate-limits.md) for limits, headers, and retry behavior. See also the [API quickstart](../docs/guides/api-quickstart.md)."
   },
   "servers": [
     { "url": "/api/v1", "description": "Versioned API" },

--- a/docs/guides/api-quickstart.md
+++ b/docs/guides/api-quickstart.md
@@ -1,0 +1,38 @@
+# API Quickstart
+
+StellarKraal exposes a versioned REST API for livestock-backed lending on Stellar/Soroban.
+
+## Base URL
+
+- **Local:** `http://localhost:3001` (see `PORT` in `.env`)
+- **Versioned prefix:** `/api/v1` (recommended for new integrations)
+- **OpenAPI / Swagger UI:** `http://localhost:3001/api/docs` (served from `backend/openapi.json`)
+
+## Authentication
+
+Wallet-based JWT flow (challenge → sign → login). See [ADR-002: JWT-Based Authentication Strategy](../adr/ADR-002-jwt-auth.md).
+
+- `GET /api/auth/challenge` — obtain a one-time challenge
+- `POST /api/auth/login` — submit signature and receive JWT
+- `POST /api/auth/refresh` — rotate tokens
+
+Protected `POST`/`PUT`/`DELETE` routes require `Authorization: Bearer <token>` except `/api/auth/*`.
+
+## Typical flow
+
+1. Register collateral: `POST /api/v1/collateral/register` → unsigned XDR to sign with Freighter.
+2. Request a loan: `POST /api/v1/loan/request`.
+3. Monitor position: `GET /api/v1/loan/:id`, `GET /api/v1/health/:loanId`.
+4. Repay: `POST /api/v1/loan/repay`.
+
+Write endpoints return JSON with an `xdr` field for client-side signing and submission to the network.
+
+## Rate limits
+
+All clients are subject to per-IP rate limits (global, auth, and write tiers). See **[Rate limits](./rate-limits.md)** for limits, headers, and retry behavior.
+
+## Further reading
+
+- [Local development setup](../development/local-setup.md)
+- [Troubleshooting](../troubleshooting.md)
+- [Liquidation protocol](../protocol/liquidation.md)

--- a/docs/guides/rate-limits.md
+++ b/docs/guides/rate-limits.md
@@ -1,0 +1,128 @@
+# API rate limits
+
+StellarKraal’s backend uses [express-rate-limit](https://github.com/express-rate-limit/express-rate-limit) with multiple limiters. Limits are enforced **per client IP** (default `express-rate-limit` keying). Every HTTP request passes through the **global** limiter first; some routes apply an additional, stricter limiter.
+
+Implementation: `backend/src/middleware/rateLimit.ts`, mounted in `backend/src/index.ts` and `backend/src/routes/v1.ts`.
+
+## Overview
+
+| Tier | Limiter | Default max / window | Configurable via env |
+|------|---------|----------------------|----------------------|
+| Global | `globalLimiter` | 60 requests / 1 minute | `RATE_LIMIT_GLOBAL` |
+| Auth | `authLimiter` | 10 requests / 1 minute | No (fixed in code) |
+| Read | *(none — uses global only)* | Same as global | `RATE_LIMIT_GLOBAL` |
+| Write | `writeLimiter` | 10 requests / 1 minute | `RATE_LIMIT_WRITE` |
+
+**Window duration:** all limiters use a **60 second** sliding window (`windowMs = 60 * 1000`).
+
+**Stacking:** stricter limiters apply **in addition** to the global limiter. For example, each `POST /api/auth/login` consumes one slot on both the global counter and the auth counter.
+
+Defaults are defined in `backend/src/config.ts` and `env.example`:
+
+- `RATE_LIMIT_GLOBAL=60`
+- `RATE_LIMIT_WRITE=10`
+
+## Global tier
+
+- **Middleware:** `globalLimiter` in `backend/src/index.ts` (`app.use(globalLimiter)`).
+- **Limit:** `RATE_LIMIT_GLOBAL` (default **60** requests per minute).
+- **Endpoints:** all routes on the Express app, including `/metrics`, `/api/*`, `/api/v1/*`, and static API docs at `/api/docs`.
+
+## Auth tier
+
+- **Middleware:** `authLimiter` mounted as `app.use("/api/auth", authLimiter, authRouter)`.
+- **Limit:** **10** requests per minute (hard-coded; not overridden by environment variables).
+- **Endpoints:**
+  - `GET /api/auth/challenge`
+  - `POST /api/auth/login`
+  - `POST /api/auth/refresh`
+
+Auth routes are also counted against the **global** tier.
+
+## Read tier
+
+There is **no separate read limiter** in the codebase. `GET` and other non-write traffic is limited only by the **global** tier (`RATE_LIMIT_GLOBAL`, default 60/min).
+
+**`/api/v1` read routes** (global limit only):
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/health` |
+| `GET` | `/api/v1/loan/:id` |
+| `GET` | `/api/v1/health/:loanId` |
+| `GET` | `/api/v1/loans` |
+| `GET` | `/api/v1/admin/webhooks` |
+| `GET` | `/api/v1/admin/webhooks/logs` |
+| `GET` | `/api/v1/settings/:wallet` |
+
+Legacy unversioned read routes under `/api/*` in `backend/src/index.ts` (for example `GET /api/health`, `GET /api/loans`, `GET /api/transactions`) are subject to the same global limit.
+
+## Write tier
+
+- **Middleware:** `writeLimiter` on selected routes in `backend/src/routes/v1.ts`.
+- **Limit:** `RATE_LIMIT_WRITE` (default **10** requests per minute).
+- **Endpoints** (each route also counts toward the global limit):
+
+| Method | Path |
+|--------|------|
+| `POST` | `/api/v1/collateral/register` |
+| `POST` | `/api/v1/loan/request` |
+| `POST` | `/api/v1/loan/repay` |
+| `POST` | `/api/v1/loan/liquidate` |
+
+Other `POST`/`PUT`/`DELETE` handlers (including legacy `/api/*` writes and v1 routes such as `POST /api/v1/oracle/price-update` or `POST /api/v1/webhooks`) are **not** wrapped with `writeLimiter`; they are only subject to the **global** tier unless noted above.
+
+## Retry behavior
+
+When a limit is exceeded, the server responds with:
+
+- **HTTP status:** `429 Too Many Requests`
+- **Body (JSON):** `{ "error": "Too many requests", "retryAfter": 60 }`
+- **`Retry-After` header:** set by `express-rate-limit` (seconds until the client can retry; aligned with the one-minute window in tests)
+
+Clients should back off and retry after the time indicated by `Retry-After` (or the `retryAfter` field in the JSON body). Counters reset when the current window expires.
+
+## Rate-limit response headers
+
+All limiters set `standardHeaders: true` and `legacyHeaders: false`, so responses use the [RateLimit draft headers](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers):
+
+| Header | Meaning |
+|--------|---------|
+| `RateLimit-Limit` | Maximum requests allowed in the window for this limiter |
+| `RateLimit-Remaining` | Requests remaining in the current window |
+| `RateLimit-Reset` | Time when the window resets (Unix timestamp) |
+
+On `429` responses, **`Retry-After`** is also sent.
+
+When multiple limiters apply, the client may see headers from the limiter that handled the request; each limiter maintains its own counter.
+
+## Examples
+
+### Successful read within global limit
+
+```bash
+curl -s -D - -o /dev/null http://localhost:3001/api/v1/health
+```
+
+Expect `200` and headers such as `RateLimit-Limit: 60` (if `RATE_LIMIT_GLOBAL` is unset).
+
+### Exceeding the auth limit
+
+After more than **10** requests in one minute to `/api/auth/challenge` from the same IP:
+
+```bash
+curl -s http://localhost:3001/api/auth/challenge
+# ... repeat until 429
+```
+
+Expect `429`, `Retry-After`, and body `{"error":"Too many requests","retryAfter":60}`.
+
+### Write limit on loan request
+
+`POST /api/v1/loan/request` is limited to **10** writes per minute per IP (`RATE_LIMIT_WRITE`) in addition to the global cap. Integrations that burst contract-building calls should queue or backoff when `RateLimit-Remaining` approaches zero.
+
+## Related documentation
+
+- [API Quickstart](./api-quickstart.md)
+- Interactive OpenAPI UI: `/api/docs` when the backend is running
+- Environment variables: `env.example`, [Local development setup](../development/local-setup.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `docs/guides/rate-limits.md` describing the backend rate limiting tiers as implemented in `express-rate-limit` middleware, plus cross-links from the API quickstart, OpenAPI spec, and README.

## Implementation notes

- **Global:** `RATE_LIMIT_GLOBAL` (default 60/min), all routes.
- **Auth:** fixed 10/min on `/api/auth/*`, stacked with global.
- **Read:** no dedicated limiter; documented as global-only with v1 GET route list.
- **Write:** `RATE_LIMIT_WRITE` (default 10/min) on selected `/api/v1` POST routes, stacked with global.
- Added `docs/guides/api-quickstart.md` so the rate limits guide can be linked from the API quickstart (file did not exist in the repo).

## Tests executed

- `npx jest src/middleware/rateLimit.test.ts --forceExit` (12 passed)

## Documentation updated

- `docs/guides/rate-limits.md` (new)
- `docs/guides/api-quickstart.md` (new)
- `backend/openapi.json` (info description links)
- `README.md` (documentation table)

## Limitations

- Legacy `/api/*` routes outside `/api/v1` are noted briefly; OpenAPI documents v1 only.

Closes #750


