### PR TITLE
feat(design-tokens): define spacing scale and extend Tailwind config

### DIFF
--- a/frontend/scripts/contrast-audit.js
+++ b/frontend/scripts/contrast-audit.js
@@ -89,6 +89,24 @@ function analyze() {
     process.exit(1);
   }
 
+  // ── Spacing token check (#778) ────────────────────────────────────────────
+  // Verify that the required spacing scale is defined in tailwind.config.js.
+  const configPath = path.resolve(__dirname, '..', 'tailwind.config.js');
+  const cfg = require(configPath);
+  const spacingConfig = (cfg.theme && cfg.theme.extend && cfg.theme.extend.spacing) || {};
+  const requiredSpacingTokens = [
+    'space-1', 'space-2', 'space-3', 'space-4',
+    'space-6', 'space-8', 'space-12', 'space-16',
+  ];
+  const missingSpacing = requiredSpacingTokens.filter((t) => !(t in spacingConfig));
+  if (missingSpacing.length > 0) {
+    console.error('Spacing token check FAILED — missing tokens in tailwind.config.js:');
+    console.error(missingSpacing);
+    process.exit(2);
+  }
+  console.log(`Spacing token check passed: ${requiredSpacingTokens.length} tokens found.`);
+  // ─────────────────────────────────────────────────────────────────────────
+
   const files = walkDir(src);
   const findings = [];
 

--- a/frontend/src/__tests__/spacing-tokens.test.ts
+++ b/frontend/src/__tests__/spacing-tokens.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests for the spacing scale defined in design-tokens.ts (#778).
+ */
+
+import { spacing } from '@/lib/design-tokens';
+
+describe('spacing design tokens', () => {
+  const expectedTokens: Array<[keyof typeof spacing, string]> = [
+    ['space1',  'space-1'],
+    ['space2',  'space-2'],
+    ['space3',  'space-3'],
+    ['space4',  'space-4'],
+    ['space6',  'space-6'],
+    ['space8',  'space-8'],
+    ['space12', 'space-12'],
+    ['space16', 'space-16'],
+  ];
+
+  it('exports the correct number of spacing tokens', () => {
+    expect(Object.keys(spacing)).toHaveLength(8);
+  });
+
+  it.each(expectedTokens)(
+    'spacing.%s equals "%s"',
+    (key, expectedValue) => {
+      expect(spacing[key]).toBe(expectedValue);
+    },
+  );
+
+  it('all token values follow the space-N naming convention', () => {
+    Object.values(spacing).forEach((value) => {
+      expect(value).toMatch(/^space-\d+$/);
+    });
+  });
+});

--- a/frontend/src/lib/design-tokens.ts
+++ b/frontend/src/lib/design-tokens.ts
@@ -72,6 +72,39 @@ export const colors = {
   }
 } as const;
 
+// ── Spacing scale (#778) ─────────────────────────────────────────────────────
+// Base-4 scale. Values map to Tailwind spacing keys defined in tailwind.config.js.
+// Use these tokens instead of arbitrary px values to keep spacing consistent.
+//
+//   Token name    px     Tailwind class (example)
+//   space-1       4 px   p-space-1 / gap-space-1 / mt-space-1
+//   space-2       8 px   p-space-2 / gap-space-2
+//   space-3      12 px   …
+//   space-4      16 px
+//   space-6      24 px
+//   space-8      32 px
+//   space-12     48 px
+//   space-16     64 px
+
+export const spacing = {
+  /** 4 px — tight internal padding, icon gaps */
+  space1:  'space-1',
+  /** 8 px — small gaps, badge padding */
+  space2:  'space-2',
+  /** 12 px — inline element padding */
+  space3:  'space-3',
+  /** 16 px — default component padding */
+  space4:  'space-4',
+  /** 24 px — section padding, card inner spacing */
+  space6:  'space-6',
+  /** 32 px — between related sections */
+  space8:  'space-8',
+  /** 48 px — between major page sections */
+  space12: 'space-12',
+  /** 64 px — hero / page-level vertical rhythm */
+  space16: 'space-16',
+} as const;
+
 // ── Typography tokens (#298) ─────────────────────────────────────────────────
 
 export const typography = {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -14,6 +14,22 @@ module.exports = {
       animation: {
         fadeIn: 'fadeIn 0.6s ease-out both',
       },
+      // ── Spacing scale (#778) ─────────────────────────────────────────────────
+      // Base-4 scale. Use these token names instead of arbitrary px values.
+      // Mirrors the `spacing` export in frontend/src/lib/design-tokens.ts.
+      spacing: {
+        // Keep Tailwind's default scale by spreading a proxy — custom values
+        // are merged on top via `extend`, so all existing Tailwind spacing
+        // utilities (p-4, m-2, gap-8 …) remain available unchanged.
+        'space-1':  '0.25rem',  //  4 px
+        'space-2':  '0.5rem',   //  8 px
+        'space-3':  '0.75rem',  // 12 px
+        'space-4':  '1rem',     // 16 px
+        'space-6':  '1.5rem',   // 24 px
+        'space-8':  '2rem',     // 32 px
+        'space-12': '3rem',     // 48 px
+        'space-16': '4rem',     // 64 px
+      },
       // ── Typography scale (#298) ──────────────────────────────────────────────
       fontSize: {
         // Static (non-fluid) sizes — used directly via Tailwind utilities


### PR DESCRIPTION
## Summary

Defines a consistent base-4 spacing scale as design tokens, extends the Tailwind config with the corresponding custom spacing keys, and updates the contrast audit script to enforce the scale's presence.

## Changes

### `frontend/src/lib/design-tokens.ts`
- Exports new `spacing` object with 8 tokens: `space1`–`space16` (4 px → 64 px, base-4 scale)
- Each token maps to a Tailwind utility key (e.g. `p-space-4`, `gap-space-6`)

### `frontend/tailwind.config.js`
- Extends `theme.extend.spacing` with `space-1` through `space-16` using `rem` values
- All existing Tailwind spacing utilities are unaffected

### `frontend/scripts/contrast-audit.js`
- Adds a spacing token presence check — exits with code 2 if any of the 8 tokens are missing from `tailwind.config.js`

### `frontend/src/__tests__/spacing-tokens.test.ts`
- Unit tests verifying all 8 tokens exist with correct values and naming convention

## Acceptance Criteria

- [x] Spacing scale defined in design-tokens.ts (4, 8, 12, 16, 24, 32, 48, 64 px)
- [x] Tailwind config extended with custom spacing values
- [x] Contrast audit script updated to check spacing tokens
- [x] Unit tests added

closes #778