### PR TITLE
feat(HealthGauge): add skeleton placeholder for loading state

### DIFF
--- a/frontend/src/__tests__/HealthGauge.test.tsx
+++ b/frontend/src/__tests__/HealthGauge.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import HealthGauge from '../components/HealthGauge';
+import HealthGauge, { SkeletonHealthGauge } from '../components/HealthGauge';
 
 jest.mock('../lib/design-tokens', () => ({
   healthColor: (bps: number) => (bps >= 15_000 ? '#16A34A' : bps >= 10_000 ? '#D97706' : '#DC2626'),
@@ -72,12 +72,12 @@ describe('HealthGauge', () => {
     const { container } = render(<HealthGauge value={12_000} />);
     const paths = container.querySelectorAll('path');
     const progressArc = Array.from(paths).find(
-      (p) => p.className.includes('motion-reduce'),
+      (p) => p.getAttribute('class')?.includes('motion-reduce'),
     );
     expect(progressArc).toBeTruthy();
 
     const needle = container.querySelector('line');
-    expect(needle!.className.baseVal).toContain('motion-reduce');
+    expect(needle!.getAttribute('class')).toContain('motion-reduce');
   });
 
   it('chart points animate on appearance when mounted', () => {
@@ -90,14 +90,13 @@ describe('HealthGauge', () => {
         ]}
       />,
     );
-    // After mount, points should have motion-safe animation class
+    // Circles are rendered inside the history SVG
     const circles = container.querySelectorAll('circle[role="button"]');
-    // Circles are rendered; mounted state may vary in test env but they exist
     expect(circles.length).toBe(2);
   });
 
   it('allows keyboard navigation between chart points and shows tooltip', () => {
-    render(
+    const { container } = render(
       <HealthGauge
         value={10000}
         history={[
@@ -107,7 +106,7 @@ describe('HealthGauge', () => {
       />,
     );
 
-    const points = screen.getAllByRole('button');
+    const points = Array.from(container.querySelectorAll<HTMLElement>('circle[role="button"]'));
     expect(points).toHaveLength(2);
 
     act(() => {
@@ -130,5 +129,53 @@ describe('HealthGauge', () => {
       fireEvent.keyDown(points[1], { key: 'Escape', code: 'Escape' });
     });
     expect(screen.queryByText('Health:')).toBeNull();
+  });
+});
+
+describe('HealthGauge skeleton', () => {
+  it('renders skeleton when loading prop is true', () => {
+    const { getByTestId } = render(<HealthGauge value={0} loading={true} />);
+    expect(getByTestId('health-gauge-skeleton')).toBeTruthy();
+  });
+
+  it('does not render live gauge content when loading is true', () => {
+    render(<HealthGauge value={15_000} loading={true} />);
+    // The real gauge shows "Safe" and a numeric ratio; neither should appear
+    expect(screen.queryByText('Safe')).toBeNull();
+    expect(screen.queryByText('1.50x')).toBeNull();
+  });
+
+  it('renders live gauge when loading is false', () => {
+    render(<HealthGauge value={15_000} loading={false} />);
+    expect(screen.getByText('Safe')).toBeTruthy();
+  });
+
+  it('renders live gauge when loading prop is omitted', () => {
+    render(<HealthGauge value={15_000} />);
+    expect(screen.getByText('Safe')).toBeTruthy();
+  });
+
+  it('skeleton has aria-busy and aria-label for screen readers', () => {
+    render(<SkeletonHealthGauge />);
+    const el = screen.getByLabelText('Loading health gauge');
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('skeleton renders an SVG arc with the same viewBox as the live gauge', () => {
+    const { container } = render(<SkeletonHealthGauge />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute('viewBox')).toBe('20 20 160 90');
+  });
+
+  it('skeleton dimensions do not cause layout shift when replaced by live gauge', () => {
+    const { container: skeletonContainer } = render(<SkeletonHealthGauge />);
+    const { container: gaugeContainer } = render(<HealthGauge value={12_000} />);
+    const skeletonSvg = skeletonContainer.querySelector('svg');
+    const gaugeSvg = gaugeContainer.querySelector('svg');
+    // Both use the same viewBox and className, so no layout shift
+    expect(skeletonSvg!.getAttribute('viewBox')).toBe(gaugeSvg!.getAttribute('viewBox'));
+    expect(skeletonSvg!.getAttribute('class')).toBe(gaugeSvg!.getAttribute('class'));
   });
 });

--- a/frontend/src/components/HealthGauge.tsx
+++ b/frontend/src/components/HealthGauge.tsx
@@ -16,6 +16,7 @@ interface TooltipState {
 interface Props {
   value: number;          // current bps value (single-point mode)
   history?: DataPoint[];  // optional time-series for chart mode
+  loading?: boolean;      // when true, renders skeleton placeholder
 }
 
 function formatDate(iso: string) {
@@ -234,7 +235,64 @@ const ZONES = [
   { start: 0.75, end: 1, color: '#16A34A', label: 'Safe' },
 ];
 
-export default function HealthGauge({ value }: Props) {
+/**
+ * SkeletonHealthGauge — arc-shaped skeleton placeholder.
+ * Matches the live gauge dimensions exactly (viewBox "20 20 160 90").
+ */
+export function SkeletonHealthGauge() {
+  return (
+    <div
+      className="flex flex-col items-center w-full"
+      aria-busy="true"
+      aria-label="Loading health gauge"
+      data-testid="health-gauge-skeleton"
+    >
+      <svg viewBox="20 20 160 90" className="w-full max-w-xs" aria-hidden="true">
+        {/* Background track skeleton */}
+        <path
+          d={arcPath(180, 0)}
+          fill="none"
+          strokeWidth={STROKE}
+          strokeLinecap="round"
+          className="skeleton-shimmer"
+          style={{ stroke: 'var(--color-skeleton-base)' }}
+        />
+        {/* Needle placeholder */}
+        <line
+          x1={CX}
+          y1={CY}
+          x2={CX}
+          y2={CY - (R - STROKE / 2)}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          style={{ stroke: 'var(--color-skeleton-base)' }}
+        />
+        <circle cx={CX} cy={CY} r={5} style={{ fill: 'var(--color-skeleton-base)' }} />
+        {/* Value text placeholder */}
+        <rect
+          x={CX - 18}
+          y={CY + 9}
+          width={36}
+          height={12}
+          rx={4}
+          className="skeleton-shimmer"
+          style={{ fill: 'var(--color-skeleton-base)' }}
+        />
+      </svg>
+      {/* Label placeholder */}
+      <div
+        className="skeleton-shimmer mt-1 rounded"
+        style={{ width: '3.5rem', height: '1rem', background: 'var(--color-skeleton-base)' }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+export default function HealthGauge({ value, history, loading }: Props) {
+  if (loading) {
+    return <SkeletonHealthGauge />;
+  }
   const frac = Math.min(value / 20_000, 1); // cap at 200% (2.0x)
   const displayValue = (value / 10_000).toFixed(2);
   const color = healthColor(value);
@@ -339,6 +397,9 @@ export default function HealthGauge({ value }: Props) {
       <span className="text-sm font-semibold mt-1" style={{ color }}>
         {label}
       </span>
+
+      {/* Optional history chart */}
+      {history && history.length > 0 && <HistoryChart history={history} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a skeleton loading placeholder to the `HealthGauge` component that matches the arc gauge shape, preventing blank areas while data loads.

## Changes

- **`HealthGauge.tsx`**: Added `loading` prop; when `true` renders `SkeletonHealthGauge` instead of the live gauge. Exported `SkeletonHealthGauge` for standalone use.
- **`SkeletonHealthGauge`**: SVG arc skeleton matching the live gauge `viewBox` (`20 20 160 90`) exactly — no layout shift on transition. Uses `skeleton-shimmer` CSS class with `--color-skeleton-base`/`--color-skeleton-shine` CSS vars (light + dark mode).
- Restored `HistoryChart` rendering when `history` prop is provided.
- **`HealthGauge.test.tsx`**: Added 6 skeleton tests covering: renders on `loading=true`, no live content when loading, `aria-busy`/`aria-label`, same viewBox as live gauge, no layout shift.

## Acceptance Criteria

- [x] Skeleton renders an arc shape with pulse animation
- [x] Skeleton dimensions match the live gauge exactly
- [x] Skeleton replaced by real gauge without layout shift
- [x] Skeleton works in both light and dark mode
- [x] Unit test verifies skeleton renders when `loading` prop is true
- [x] All existing CI checks pass

closes #813