### PR TITLE
feat(Pagination): page size selector with options 10/20/50

### DIFF
--- a/frontend/src/__tests__/Pagination.test.tsx
+++ b/frontend/src/__tests__/Pagination.test.tsx
@@ -86,8 +86,8 @@ describe('Pagination component', () => {
   it('calls onLimitChange when page size is changed', () => {
     const onLimitChange = jest.fn();
     render(<Pagination {...defaultProps} onLimitChange={onLimitChange} />);
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: '25' } });
-    expect(onLimitChange).toHaveBeenCalledWith(25);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '20' } });
+    expect(onLimitChange).toHaveBeenCalledWith(20);
   });
 
   it('has accessible nav landmark', () => {
@@ -105,10 +105,10 @@ describe('usePagination hook', () => {
   });
 
   it('reads page and limit from URL params', () => {
-    setParams({ page: '3', limit: '25' });
+    setParams({ page: '3', limit: '20' });
     const { result } = renderHook(() => usePagination(100));
     expect(result.current.page).toBe(3);
-    expect(result.current.limit).toBe(25);
+    expect(result.current.limit).toBe(20);
   });
 
   it('clamps page to totalPages when URL page exceeds total', () => {
@@ -158,10 +158,10 @@ describe('usePagination hook', () => {
     setParams({ page: '4' });
     const { result } = renderHook(() => usePagination(100));
     act(() => {
-      result.current.setLimit(25);
+      result.current.setLimit(20);
     });
     const url = mockPush.mock.calls[0][0] as string;
-    expect(url).toContain('limit=25');
+    expect(url).toContain('limit=20');
     expect(url).toContain('page=1');
   });
 

--- a/frontend/src/components/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Pagination from './Pagination';
+import { PAGE_SIZE_OPTIONS, PageSize } from '@/hooks/usePagination';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+/** Interactive story — the page size selector resets to page 1 on change. */
+export const Default: Story = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    const [limit, setLimit] = useState<PageSize>(10);
+    const totalPages = 5;
+
+    function handleLimitChange(next: PageSize) {
+      setLimit(next);
+      setPage(1); // reset to page 1
+    }
+
+    return (
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        limit={limit}
+        onPageChange={setPage}
+        onLimitChange={handleLimitChange}
+      />
+    );
+  },
+};
+
+/** Shows available page-size options: 10 / 20 / 50. */
+export const PageSizeOptions: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <p className="text-sm text-brown-600">
+        Available page sizes: {PAGE_SIZE_OPTIONS.join(', ')} — changing size resets to page 1.
+      </p>
+      {PAGE_SIZE_OPTIONS.map((size) => (
+        <Pagination
+          key={size}
+          page={1}
+          totalPages={10}
+          limit={size}
+          onPageChange={() => {}}
+          onLimitChange={() => {}}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/** First page — Previous button is disabled. */
+export const FirstPage: Story = {
+  args: {
+    page: 1,
+    totalPages: 5,
+    limit: 10,
+    onPageChange: () => {},
+    onLimitChange: () => {},
+  },
+};
+
+/** Last page — Next button is disabled. */
+export const LastPage: Story = {
+  args: {
+    page: 5,
+    totalPages: 5,
+    limit: 10,
+    onPageChange: () => {},
+    onLimitChange: () => {},
+  },
+};
+
+/** Middle page — both navigation buttons are active. */
+export const MiddlePage: Story = {
+  args: {
+    page: 3,
+    totalPages: 5,
+    limit: 20,
+    onPageChange: () => {},
+    onLimitChange: () => {},
+  },
+};

--- a/frontend/src/hooks/usePagination.ts
+++ b/frontend/src/hooks/usePagination.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 
-export const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+export const PAGE_SIZE_OPTIONS = [10, 20, 50] as const;
 export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
 
 export interface PaginationState {


### PR DESCRIPTION
## Summary

Updates the `Pagination` component's page size options to `[10, 20, 50]` as specified and adds a Storybook story demonstrating the selector.

## Changes

- **`usePagination.ts`**: Changed `PAGE_SIZE_OPTIONS` from `[10, 25, 50]` to `[10, 20, 50]`.
- **`Pagination.tsx`**: Already has a fully accessible `<select>` with:
  - `<label htmlFor="page-size" className="sr-only">` for screen reader support
  - Keyboard navigable
  - Changing page size resets to page 1 via URL params (`setLimit` calls `navigate({ limit, page: '1' })`)
  - Selected value persists in URL query params (`?limit=N&page=1`)
- **`Pagination.stories.tsx`**: New Storybook story with 5 stories (Default interactive, PageSizeOptions, FirstPage, LastPage, MiddlePage).
- **Tests**: Updated `Pagination.test.tsx` to use `20` instead of `25`.

## Acceptance Criteria

- [x] Page size selector shows options: 10, 20, 50
- [x] Changing page size resets to page 1
- [x] Selected page size persists in URL query params
- [x] Selector is accessible (labelled select element)
- [x] Storybook story demonstrates the selector
- [x] Unit/integration tests added or updated
- [x] Component is keyboard-navigable and screen-reader friendly

closes #814