### PR TITLE
Assigned issues: profile endpoint, scroll-to-top, repayment calculator, offline forms

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2069,6 +2069,82 @@
           }
         }
       }
+    },
+    "/profile": {
+      "get": {
+        "tags": [
+          "profile"
+        ],
+        "summary": "Get the authenticated user's profile",
+        "description": "Returns the caller's own profile, including wallet address, display name, join date, and loan/collateral counts. First login auto-creates the underlying profile record.",
+        "operationId": "getProfile",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "User profile summary.",
+                  "properties": {
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "Stellar G... public key",
+                      "example": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "User-chosen display name",
+                      "example": "Alice"
+                    },
+                    "joinedAt": {
+                      "type": "string",
+                      "description": "ISO timestamp the profile was first created",
+                      "example": "2026-01-15T10:00:00.000Z"
+                    },
+                    "loanCount": {
+                      "type": "integer",
+                      "description": "Total number of loans belonging to this user",
+                      "example": 3
+                    },
+                    "collateralCount": {
+                      "type": "integer",
+                      "description": "Total number of collateral records owned by this user",
+                      "example": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "No profile record exists for this user yet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1736,6 +1736,92 @@ app.put(
 // ── User Profile ──────────────────────────────────────────────────────────────
 
 /**
+ * @openapi
+ * /profile:
+ *   get:
+ *     tags:
+ *       - profile
+ *     summary: Get the authenticated user's profile
+ *     description: Returns the caller's own profile, including wallet address, display name, join date, and loan/collateral counts. First login auto-creates the underlying profile record.
+ *     operationId: getProfile
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Profile found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: User profile summary.
+ *               properties:
+ *                 walletAddress:
+ *                   type: string
+ *                   description: Stellar G... public key
+ *                   example: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN
+ *                 displayName:
+ *                   type: string
+ *                   description: User-chosen display name
+ *                   example: Alice
+ *                 joinedAt:
+ *                   type: string
+ *                   description: ISO timestamp the profile was first created
+ *                   example: 2026-01-15T10:00:00.000Z
+ *                 loanCount:
+ *                   type: integer
+ *                   description: Total number of loans belonging to this user
+ *                   example: 3
+ *                 collateralCount:
+ *                   type: integer
+ *                   description: Total number of collateral records owned by this user
+ *                   example: 2
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '404':
+ *         description: No profile record exists for this user yet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ */
+app.get(
+  '/api/v1/profile',
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = (req as any).user as { publicKey?: string } | undefined;
+    if (!user?.publicKey) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const profile = getProfile(user.publicKey);
+    if (!profile) {
+      return res
+        .status(404)
+        .json({ error: 'Not found', message: 'No profile exists for this user yet' });
+    }
+
+    const { total: loanCount } = listLoans({ borrowerAddress: user.publicKey, page: 1, limit: 1 });
+    const { total: collateralCount } = listCollateral({
+      ownerId: user.publicKey,
+      page: 1,
+      limit: 1,
+    });
+
+    res.json({
+      walletAddress: profile.walletAddress,
+      displayName: profile.displayName,
+      joinedAt: profile.createdAt,
+      loanCount,
+      collateralCount,
+    });
+  })
+);
+
+/**
  * PATCH /api/v1/profile
  *
  * Update the authenticated user's profile.

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -16,6 +16,7 @@ import { Request, Response, NextFunction, Router } from 'express';
 import { createHmac, createHash, randomBytes } from 'crypto';
 import { Keypair } from '@stellar/stellar-sdk';
 import { config } from '../config';
+import { getProfile, updateProfile } from '../db/store';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -222,6 +223,11 @@ authRouter.post('/login', (req: Request, res: Response) => {
     return res.status(401).json({ error: 'Invalid wallet address or signature' });
   }
 
+  // First login auto-creates the user's profile record.
+  if (!getProfile(walletAddress)) {
+    updateProfile(walletAddress, {});
+  }
+
   const { accessToken, rawRefresh, expiresIn } = issueTokens(walletAddress);
   setRefreshCookie(res, rawRefresh);
   res.json({ accessToken, expiresIn });
@@ -289,6 +295,7 @@ const PROTECTED_GET_PATTERNS = [
   /^\/api\/loans\/[^/]+$/,
   /^\/api\/collateral$/,
   /^\/api\/v1\/loans\/summary$/,
+  /^\/api\/v1\/profile$/,
 ];
 
 /**

--- a/backend/src/routes/profile.get.integration.test.ts
+++ b/backend/src/routes/profile.get.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for GET /api/v1/profile.
+ * Closes #845
+ */
+import { createHmac } from "crypto";
+import request from "supertest";
+import { Keypair } from "@stellar/stellar-sdk";
+import app from "../index";
+import { insertLoan, insertCollateral } from "../db/store";
+
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createRequestLogger: jest.fn(() => ({
+    info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  })),
+}));
+
+// Avoid jest.requireActual("@stellar/stellar-sdk") — a transitive @noble/hashes
+// ESM build breaks under ts-jest's CJS transform. Define a self-contained mock
+// with a crypto-based Keypair stand-in instead.
+jest.mock("@stellar/stellar-sdk", () => {
+  const { createHmac: hmac } = require("crypto") as typeof import("crypto");
+  const registry = new Map<string, Buffer>();
+  let counter = 0;
+  class KP {
+    constructor(private pub: string, private seed: Buffer) {}
+    static random() {
+      counter += 1;
+      const seed = Buffer.from(`seed-${counter}-${Math.random()}`);
+      const pub = `GPROFILETEST${String(counter).padStart(4, "0")}${"A".repeat(43)}`.slice(0, 56);
+      registry.set(pub, seed);
+      return new KP(pub, seed);
+    }
+    static fromPublicKey(pub: string) {
+      const seed = registry.get(pub) ?? Buffer.alloc(32, pub);
+      return new KP(pub, seed);
+    }
+    publicKey() { return this.pub; }
+    sign(data: Buffer) { return hmac("sha512", this.seed).update(data).digest(); }
+    verify(data: Buffer, sig: Buffer) { return hmac("sha512", this.seed).update(data).digest().equals(sig); }
+  }
+  const rpcModule = {
+    Server: jest.fn().mockImplementation(() => ({
+      getAccount: jest.fn().mockResolvedValue({ id: "GABC", sequence: "1" }),
+      prepareTransaction: jest.fn().mockResolvedValue({ toXDR: () => "prepared_xdr" }),
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: { value: 42 } } }),
+      getHealth: jest.fn().mockResolvedValue({ status: "healthy" }),
+    })),
+  };
+  return {
+    Keypair: KP,
+    StrKey: { isValidEd25519PublicKey: () => true },
+    Networks: { TESTNET: "Test SDF Network ; September 2015", PUBLIC: "Public Global Stellar Network ; September 2015" },
+    BASE_FEE: "100",
+    Contract: jest.fn(() => ({ call: jest.fn().mockReturnValue({}) })),
+    TransactionBuilder: jest.fn(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({ toXDR: () => "mock_xdr" }),
+    })),
+    Address: jest.fn(() => ({ toScVal: jest.fn().mockReturnValue({}) })),
+    nativeToScVal: jest.fn().mockReturnValue({}),
+    SorobanRpc: rpcModule,
+    rpc: rpcModule,
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function getChallenge(): Promise<string> {
+  const res = await request(app).get("/api/auth/challenge");
+  expect(res.status).toBe(200);
+  return res.body.challenge as string;
+}
+
+async function login(kp: any): Promise<{ accessToken: string; expiresIn: number }> {
+  const challenge = await getChallenge();
+  const res = await request(app).post("/api/auth/login").send({
+    walletAddress: kp.publicKey(),
+    signedChallenge: { nonce: challenge, signature: kp.sign(Buffer.from(challenge, "hex")).toString("hex") },
+  });
+  expect(res.status).toBe(200);
+  return res.body;
+}
+
+const JWT_SECRET = "change-me-in-production-min-32-chars!!";
+function b64url(buf: Buffer | string): string {
+  const s = typeof buf === "string" ? Buffer.from(buf) : buf;
+  return s.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+function makeToken(payload: object, secret = JWT_SECRET): string {
+  const h = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const b = b64url(JSON.stringify(payload));
+  return `${h}.${b}.${b64url(createHmac("sha256", secret).update(`${h}.${b}`).digest())}`;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/profile", () => {
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/api/v1/profile");
+    expect(res.status).toBe(401);
+  });
+
+  it("auto-creates a profile on first login and returns it for a new user", async () => {
+    const kp = (Keypair as any).random();
+    const { accessToken } = await login(kp);
+
+    const res = await request(app)
+      .get("/api/v1/profile")
+      .set("Authorization", `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.walletAddress).toBe(kp.publicKey());
+    expect(typeof res.body.joinedAt).toBe("string");
+    expect(res.body.loanCount).toBe(0);
+    expect(res.body.collateralCount).toBe(0);
+  });
+
+  it("reflects loan and collateral counts for an existing user", async () => {
+    const kp = (Keypair as any).random();
+    const { accessToken } = await login(kp);
+    const wallet = kp.publicKey();
+
+    insertCollateral({
+      id: `col_${wallet}`,
+      owner: wallet,
+      animal_type: "cattle",
+      count: 5,
+      appraised_value: 1_000_000,
+    });
+    insertLoan({
+      id: `loan_${wallet}`,
+      borrower: wallet,
+      collateral_id: `col_${wallet}`,
+      amount: 500_000,
+    });
+
+    const res = await request(app)
+      .get("/api/v1/profile")
+      .set("Authorization", `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.loanCount).toBe(1);
+    expect(res.body.collateralCount).toBe(1);
+  });
+
+  it("returns 404 for an authenticated wallet that has never logged in (no profile record)", async () => {
+    const kp = (Keypair as any).random();
+    // Forge a valid token without ever calling POST /api/auth/login, so no
+    // profile auto-creation has happened for this wallet.
+    const token = makeToken({
+      sub: kp.publicKey(),
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 900,
+    });
+
+    const res = await request(app)
+      .get("/api/v1/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/frontend/src/__tests__/LoanDetailPage.test.tsx
+++ b/frontend/src/__tests__/LoanDetailPage.test.tsx
@@ -1,24 +1,27 @@
-import React from "react";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import LoanDetailPage from "@/app/loans/[id]/page";
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import LoanDetailPage from '@/app/loans/[id]/page';
 
-jest.mock("next/navigation", () => ({
-  useParams: () => ({ id: "loan-001" }),
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'loan-001' }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
 }));
 
-jest.mock("next/link", () => {
+jest.mock('next/link', () => {
   const Link = ({ href, children }: { href: string; children: React.ReactNode }) => (
     <a href={href}>{children}</a>
   );
-  Link.displayName = "Link";
+  Link.displayName = 'Link';
   return Link;
 });
 
-jest.mock("@/components/DetailSkeleton", () => ({
+jest.mock('@/components/DetailSkeleton', () => ({
+  __esModule: true,
   default: () => <div data-testid="detail-skeleton" />,
 }));
 
-jest.mock("@/components/ErrorState", () => ({
+jest.mock('@/components/ErrorState', () => ({
+  __esModule: true,
   default: ({ message, onRetry }: { message: string; onRetry: () => void }) => (
     <div role="alert">
       <p>{message}</p>
@@ -29,12 +32,12 @@ jest.mock("@/components/ErrorState", () => ({
 
 const mockLoan = {
   loan: {
-    id: "loan-001",
-    borrower: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-    collateral_id: "col-001",
+    id: 'loan-001',
+    borrower: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    collateral_id: 'col-001',
     amount: 15_000_000,
-    status: "active",
-    createdAt: "2026-01-01T00:00:00.000Z",
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
   },
   collateral: null,
   onChainStatus: null,
@@ -44,8 +47,8 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe("LoanDetailPage", () => {
-  it("renders loan details when data is available", async () => {
+describe('LoanDetailPage', () => {
+  it('renders loan details when data is available', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       status: 200,
       ok: true,
@@ -62,7 +65,7 @@ describe("LoanDetailPage", () => {
     expect(screen.getByText(/col-001/)).toBeInTheDocument();
   });
 
-  it("renders 404 error when loan is not found", async () => {
+  it('renders 404 error when loan is not found', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       status: 404,
       ok: false,
@@ -77,8 +80,8 @@ describe("LoanDetailPage", () => {
     expect(screen.getByText(/loan-001/)).toBeInTheDocument();
   });
 
-  it("renders network error state with retry", async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+  it('renders network error state with retry', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
 
     render(<LoanDetailPage />);
 
@@ -86,11 +89,11 @@ describe("LoanDetailPage", () => {
       expect(screen.getByText(/Could not load loan/i)).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 
-  describe("copy loan ID (#864)", () => {
-    it("renders a copy button next to the loan ID", async () => {
+  describe('copy loan ID (#864)', () => {
+    it('renders a copy button next to the loan ID', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         status: 200,
         ok: true,
@@ -103,13 +106,13 @@ describe("LoanDetailPage", () => {
         expect(screen.getByText(/loan-001/i)).toBeInTheDocument();
       });
 
-      const copyBtn = screen.getByRole("button", { name: /copy loan id/i });
+      const copyBtn = screen.getByRole('button', { name: /copy loan id/i });
       expect(copyBtn).toBeInTheDocument();
     });
 
-    it("copies the loan ID to clipboard and shows Copied feedback", async () => {
+    it('copies the loan ID to clipboard and shows Copied feedback', async () => {
       const clipboardMock = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, "clipboard", {
+      Object.defineProperty(navigator, 'clipboard', {
         value: { writeText: clipboardMock },
         writable: true,
         configurable: true,
@@ -127,11 +130,51 @@ describe("LoanDetailPage", () => {
         expect(screen.getByText(/loan-001/i)).toBeInTheDocument();
       });
 
-      const copyBtn = screen.getByRole("button", { name: /copy loan id/i });
+      const copyBtn = screen.getByRole('button', { name: /copy loan id/i });
       fireEvent.click(copyBtn);
 
-      expect(clipboardMock).toHaveBeenCalledWith("loan-001");
-      expect(screen.getByRole("button", { name: /loan id copied/i })).toBeInTheDocument();
+      expect(clipboardMock).toHaveBeenCalledWith('loan-001');
+      expect(screen.getByRole('button', { name: /loan id copied/i })).toBeInTheDocument();
     });
+  });
+
+  describe('repayment calculator (#536)', () => {
+    it('shows the repayment calculator for an active loan', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => mockLoan,
+      } as Response);
+
+      render(<LoanDetailPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/loan-001/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/repayment calculator/i)).toBeInTheDocument();
+      // Loan is already known from the page context — no separate loan ID input.
+      expect(screen.queryByPlaceholderText('Enter loan ID')).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Enter repayment amount')).toBeInTheDocument();
+    });
+
+    it.each(['repaid', 'liquidated'])(
+      'hides the repayment calculator for a %s loan',
+      async (status) => {
+        global.fetch = jest.fn().mockResolvedValue({
+          status: 200,
+          ok: true,
+          json: async () => ({ ...mockLoan, loan: { ...mockLoan.loan, status } }),
+        } as Response);
+
+        render(<LoanDetailPage />);
+
+        await waitFor(() => {
+          expect(screen.getByText(new RegExp(status, 'i'))).toBeInTheDocument();
+        });
+
+        expect(screen.queryByText(/repayment calculator/i)).not.toBeInTheDocument();
+      }
+    );
   });
 });

--- a/frontend/src/__tests__/LoanRepaymentCalculator.test.tsx
+++ b/frontend/src/__tests__/LoanRepaymentCalculator.test.tsx
@@ -1,19 +1,13 @@
-import React from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
-import LoanRepaymentCalculator from "../components/LoanRepaymentCalculator";
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import LoanRepaymentCalculator from '../components/LoanRepaymentCalculator';
 
-jest.mock("../components/HealthGauge", () => ({
+jest.mock('../components/HealthGauge', () => ({
   __esModule: true,
   default: ({ value }: { value: number }) => <div>Health: {value}</div>,
 }));
 
-describe("LoanRepaymentCalculator", () => {
+describe('LoanRepaymentCalculator', () => {
   const fetchMock = jest.fn();
 
   beforeEach(() => {
@@ -46,15 +40,15 @@ describe("LoanRepaymentCalculator", () => {
     jest.useRealTimers();
   });
 
-  it("debounces preview API and allows proceed-to-repay", async () => {
+  it('debounces preview API and allows proceed-to-repay', async () => {
     const onProceed = jest.fn();
     render(<LoanRepaymentCalculator onProceed={onProceed} />);
 
-    fireEvent.change(screen.getByPlaceholderText("Enter loan ID"), {
-      target: { value: "1" },
+    fireEvent.change(screen.getByPlaceholderText('Enter loan ID'), {
+      target: { value: '1' },
     });
-    fireEvent.change(screen.getByPlaceholderText("Enter repayment amount"), {
-      target: { value: "100" },
+    fireEvent.change(screen.getByPlaceholderText('Enter repayment amount'), {
+      target: { value: '100' },
     });
 
     await act(async () => {
@@ -68,10 +62,113 @@ describe("LoanRepaymentCalculator", () => {
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(screen.getByText("Proceed to Repay")).toBeTruthy();
+      expect(screen.getByText('Proceed to Repay')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("Proceed to Repay"));
-    expect(onProceed).toHaveBeenCalledWith("1", "100");
+    fireEvent.click(screen.getByText('Proceed to Repay'));
+    expect(onProceed).toHaveBeenCalledWith('1', '100');
+  });
+
+  describe('edge cases (#536)', () => {
+    it('does not call the preview API and shows no preview for a zero amount', async () => {
+      render(<LoanRepaymentCalculator onProceed={jest.fn()} />);
+
+      fireEvent.change(screen.getByPlaceholderText('Enter loan ID'), {
+        target: { value: '1' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Enter repayment amount'), {
+        target: { value: '0' },
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      // Only the initial loan-list fetch fired; no preview request for a zero amount.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('Proceed to Repay')).not.toBeInTheDocument();
+    });
+
+    it('shows a fully-repaid message instead of a health gauge for a full repayment', async () => {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: 1 }] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          loan_id: 1,
+          repayment_amount: 1000,
+          breakdown: {
+            principal: 1000,
+            interest: 50,
+            fees: 5,
+            remaining_balance: 0,
+          },
+          projected_health_factor_bps: null,
+          fully_repaid: true,
+        }),
+      });
+
+      render(<LoanRepaymentCalculator onProceed={jest.fn()} />);
+
+      fireEvent.change(screen.getByPlaceholderText('Enter loan ID'), {
+        target: { value: '1' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Enter repayment amount'), {
+        target: { value: '1000' },
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/fully repaid \(health factor becomes infinite\)/i)
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/^Health:/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('embedded with a fixed loanId (#536)', () => {
+    it('locks the loan ID and skips the loan-list fetch', async () => {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          loan_id: 7,
+          repayment_amount: 250,
+          breakdown: { principal: 250, interest: 10, fees: 1, remaining_balance: 750 },
+          projected_health_factor_bps: 15000,
+          fully_repaid: false,
+        }),
+      });
+
+      render(<LoanRepaymentCalculator loanId={7} onProceed={jest.fn()} />);
+
+      expect(screen.queryByPlaceholderText('Enter loan ID')).not.toBeInTheDocument();
+
+      fireEvent.change(screen.getByPlaceholderText('Enter repayment amount'), {
+        target: { value: '250' },
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining('/api/loan/repayment-preview'),
+          expect.objectContaining({
+            body: JSON.stringify({ loan_id: 7, amount: 250 }),
+          })
+        );
+      });
+      // Only the preview request fired — no separate loan-list fetch for a fixed loan.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/__tests__/OfflineBanner.test.tsx
+++ b/frontend/src/__tests__/OfflineBanner.test.tsx
@@ -1,43 +1,83 @@
-import React from "react";
-import { act, render, screen } from "@testing-library/react";
-import OfflineBanner from "../components/OfflineBanner";
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import OfflineBanner from '../components/OfflineBanner';
+import { ToastProvider, ToastContainer } from '../components/toast';
 
-describe("OfflineBanner", () => {
+function renderWithToast(ui: React.ReactElement) {
+  return render(
+    <ToastProvider>
+      {ui}
+      <ToastContainer />
+    </ToastProvider>
+  );
+}
+
+describe('OfflineBanner', () => {
   afterEach(() => {
     // Restore navigator.onLine to true
-    Object.defineProperty(navigator, "onLine", { value: true, configurable: true });
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
 
-  it("renders banner when navigator.onLine is false", () => {
-    Object.defineProperty(navigator, "onLine", { value: false, configurable: true });
-    render(<OfflineBanner />);
-    expect(screen.getByRole("alert")).toBeTruthy();
+  it('renders banner when navigator.onLine is false', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    renderWithToast(<OfflineBanner />);
+    expect(screen.getByRole('alert')).toBeTruthy();
     expect(screen.getByText(/You are offline/)).toBeTruthy();
   });
 
-  it("does not render banner when navigator.onLine is true", () => {
-    Object.defineProperty(navigator, "onLine", { value: true, configurable: true });
-    render(<OfflineBanner />);
-    expect(screen.queryByRole("alert")).toBeNull();
+  it('does not render banner when navigator.onLine is true', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    renderWithToast(<OfflineBanner />);
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
-  it("banner disappears when online event fires", () => {
-    Object.defineProperty(navigator, "onLine", { value: false, configurable: true });
-    render(<OfflineBanner />);
-    expect(screen.getByRole("alert")).toBeTruthy();
+  it('banner disappears when online event fires', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    renderWithToast(<OfflineBanner />);
+    expect(screen.getByText(/You are offline/)).toBeTruthy();
 
     act(() => {
-      Object.defineProperty(navigator, "onLine", { value: true, configurable: true });
-      window.dispatchEvent(new Event("online"));
+      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+      window.dispatchEvent(new Event('online'));
     });
 
-    expect(screen.queryByRole("alert")).toBeNull();
+    // The banner itself is gone — a separate "Reconnected" toast (also role="alert")
+    // may now be visible, so assert on the banner's own text rather than the role.
+    expect(screen.queryByText(/You are offline/)).toBeNull();
   });
 
-  it("has aria-live assertive region", () => {
-    Object.defineProperty(navigator, "onLine", { value: false, configurable: true });
-    render(<OfflineBanner />);
-    const banner = screen.getByRole("alert");
-    expect(banner.getAttribute("aria-live")).toBe("assertive");
+  it('has aria-live assertive region', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    renderWithToast(<OfflineBanner />);
+    const banner = screen.getByRole('alert');
+    expect(banner.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  describe('reconnection (#535)', () => {
+    it("shows a 'Reconnected' toast when coming back online", () => {
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      renderWithToast(<OfflineBanner />);
+
+      act(() => {
+        Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+        window.dispatchEvent(new Event('online'));
+      });
+
+      expect(screen.getByText('Reconnected')).toBeInTheDocument();
+    });
+
+    it("does not show a 'Reconnected' toast on initial mount while online", () => {
+      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+      renderWithToast(<OfflineBanner />);
+
+      expect(screen.queryByText('Reconnected')).not.toBeInTheDocument();
+    });
+
+    it("does not show a 'Reconnected' toast while still offline", () => {
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      renderWithToast(<OfflineBanner />);
+
+      expect(screen.queryByText('Reconnected')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/ScrollToTopButton.test.tsx
+++ b/frontend/src/__tests__/ScrollToTopButton.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ScrollToTopButton tests — #563
+ *
+ * Verifies:
+ *   - Hidden at the top of the page
+ *   - Appears after scrolling past 300px
+ *   - Has aria-label="Scroll to top"
+ *   - Clicking scrolls smoothly to the top
+ *   - Respects prefers-reduced-motion (instant scroll instead of smooth)
+ */
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ScrollToTopButton from '../components/ScrollToTopButton';
+
+function setScrollY(value: number) {
+  Object.defineProperty(window, 'scrollY', { value, writable: true, configurable: true });
+}
+
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = jest.fn().mockReturnValue({
+    matches,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+}
+
+describe('ScrollToTopButton (#563)', () => {
+  const originalScrollTo = window.scrollTo;
+
+  beforeEach(() => {
+    setScrollY(0);
+    mockMatchMedia(false);
+    window.scrollTo = jest.fn();
+  });
+
+  afterEach(() => {
+    window.scrollTo = originalScrollTo;
+  });
+
+  it('is hidden at the top of the page', () => {
+    render(<ScrollToTopButton />);
+    expect(screen.queryByRole('button', { name: /scroll to top/i })).not.toBeInTheDocument();
+  });
+
+  it('appears after scrolling past 300px', () => {
+    render(<ScrollToTopButton />);
+
+    setScrollY(301);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(screen.getByRole('button', { name: /scroll to top/i })).toBeInTheDocument();
+  });
+
+  it('hides again once scrolled back near the top', () => {
+    render(<ScrollToTopButton />);
+
+    setScrollY(500);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(screen.getByRole('button', { name: /scroll to top/i })).toBeInTheDocument();
+
+    setScrollY(0);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(screen.queryByRole('button', { name: /scroll to top/i })).not.toBeInTheDocument();
+  });
+
+  it('scrolls smoothly to the top when clicked', () => {
+    render(<ScrollToTopButton />);
+    setScrollY(400);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /scroll to top/i }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('scrolls instantly when prefers-reduced-motion is set', () => {
+    mockMatchMedia(true);
+    render(<ScrollToTopButton />);
+    setScrollY(400);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /scroll to top/i }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+  });
+});

--- a/frontend/src/app/collateral/CollateralListClient.tsx
+++ b/frontend/src/app/collateral/CollateralListClient.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import SearchFilterBar from '@/components/SearchFilterBar';
 import HighlightText from '@/components/HighlightText';
 import PageTransition from '@/components/PageTransition';
+import ScrollToTopButton from '@/components/ScrollToTopButton';
 import { useScrollPosition } from '@/hooks/useScrollPosition';
 import MoneyAmount from '@/components/MoneyAmount';
 
@@ -137,6 +138,7 @@ export default function CollateralListClient() {
           <CollateralListContent />
         </Suspense>
       </main>
+      <ScrollToTopButton />
     </PageTransition>
   );
 }

--- a/frontend/src/app/loans/LoansListClient.tsx
+++ b/frontend/src/app/loans/LoansListClient.tsx
@@ -1,12 +1,13 @@
-"use client";
-import { Suspense, useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { motion, useReducedMotion } from "framer-motion";
-import SearchFilterBar from "@/components/SearchFilterBar";
-import PageTransition from "@/components/PageTransition";
-import Card from "@/components/Card";
-import { badgeVariants } from "@/lib/animations";
-import { useScrollPosition } from "@/hooks/useScrollPosition";
+'use client';
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { motion, useReducedMotion } from 'framer-motion';
+import SearchFilterBar from '@/components/SearchFilterBar';
+import PageTransition from '@/components/PageTransition';
+import Card from '@/components/Card';
+import ScrollToTopButton from '@/components/ScrollToTopButton';
+import { badgeVariants } from '@/lib/animations';
+import { useScrollPosition } from '@/hooks/useScrollPosition';
 
 interface Loan {
   id: string;
@@ -23,14 +24,14 @@ const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 /** Maps loan status to design-token badge classes (WCAG AA compliant). */
 function statusBadgeClasses(status: string): string {
   switch (status) {
-    case "active":
-      return "bg-success-light text-success-dark";
-    case "repaid":
-      return "bg-gold-100 text-gold-700 dark:bg-gold-900/40 dark:text-gold-300";
-    case "liquidated":
-      return "bg-error-light text-error-dark";
+    case 'active':
+      return 'bg-success-light text-success-dark';
+    case 'repaid':
+      return 'bg-gold-100 text-gold-700 dark:bg-gold-900/40 dark:text-gold-300';
+    case 'liquidated':
+      return 'bg-error-light text-error-dark';
     default:
-      return "bg-brown-100 text-brown-600 dark:bg-brown-700 dark:text-brown-300";
+      return 'bg-brown-100 text-brown-600 dark:bg-brown-700 dark:text-brown-300';
   }
 }
 
@@ -147,6 +148,7 @@ export default function LoansListClient() {
           <LoanListContent />
         </Suspense>
       </main>
+      <ScrollToTopButton />
     </PageTransition>
   );
 }

--- a/frontend/src/app/loans/[id]/page.tsx
+++ b/frontend/src/app/loans/[id]/page.tsx
@@ -1,9 +1,10 @@
-"use client";
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import ErrorState from "@/components/ErrorState";
-import DetailSkeleton from "@/components/DetailSkeleton";
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import ErrorState from '@/components/ErrorState';
+import DetailSkeleton from '@/components/DetailSkeleton';
+import LoanRepaymentCalculator from '@/components/LoanRepaymentCalculator';
 
 interface LoanRecord {
   id: string;
@@ -14,12 +15,13 @@ interface LoanRecord {
   createdAt: string;
 }
 
-type ErrorType = "404" | "network" | null;
+type ErrorType = '404' | 'network' | null;
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export default function LoanDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
   const [loan, setLoan] = useState<LoanRecord | null>(null);
   const [error, setError] = useState<ErrorType>(null);
   const [loading, setLoading] = useState(true);
@@ -31,10 +33,10 @@ export default function LoanDetailPage() {
       setError(null);
       const res = await fetch(`${API}/api/loans/${id}`);
       if (res.status === 404) {
-        setError("404");
+        setError('404');
         setLoan(null);
       } else if (!res.ok) {
-        setError("network");
+        setError('network');
         setLoan(null);
       } else {
         const data = await res.json();
@@ -42,7 +44,7 @@ export default function LoanDetailPage() {
         setError(null);
       }
     } catch {
-      setError("network");
+      setError('network');
       setLoan(null);
     } finally {
       setLoading(false);
@@ -57,17 +59,24 @@ export default function LoanDetailPage() {
     return <DetailSkeleton />;
   }
 
-  if (error === "404") {
+  if (error === '404') {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
         <Link href="/loans" className="text-brown/60 hover:text-brown text-sm mb-6 inline-block">
           ← Back to Loans
         </Link>
         <div className="rounded-2xl border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20 p-6 text-center">
-          <p className="text-5xl mb-4" aria-hidden="true">📄</p>
+          <p className="text-5xl mb-4" aria-hidden="true">
+            📄
+          </p>
           <h1 className="text-2xl font-bold text-brown mb-2">Loan Not Found</h1>
-          <p className="text-brown/60 mb-6">No loan record exists for ID <code className="bg-brown/10 px-1 rounded">{id}</code>.</p>
-          <Link href="/loans" className="inline-block bg-brown text-cream px-5 py-2 rounded-xl font-semibold hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-brown focus:ring-offset-2">
+          <p className="text-brown/60 mb-6">
+            No loan record exists for ID <code className="bg-brown/10 px-1 rounded">{id}</code>.
+          </p>
+          <Link
+            href="/loans"
+            className="inline-block bg-brown text-cream px-5 py-2 rounded-xl font-semibold hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-brown focus:ring-offset-2"
+          >
             ← Back to Loans
           </Link>
         </div>
@@ -75,7 +84,7 @@ export default function LoanDetailPage() {
     );
   }
 
-  if (error === "network") {
+  if (error === 'network') {
     return (
       <main className="max-w-2xl mx-auto px-4 py-10">
         <ErrorState message="Could not load loan – check your connection" onRetry={fetchLoan} />
@@ -114,24 +123,46 @@ export default function LoanDetailPage() {
           <span className="text-brown/50 text-sm">Loan ID</span>
           <button
             onClick={copyId}
-            aria-label={copied ? "Loan ID copied" : "Copy loan ID"}
-            title={copied ? "Copied!" : "Copy ID"}
+            aria-label={copied ? 'Loan ID copied' : 'Copy loan ID'}
+            title={copied ? 'Copied!' : 'Copy ID'}
             className="shrink-0 text-brown/50 hover:text-brown transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brown rounded"
           >
             {copied ? (
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+                />
               </svg>
             )}
           </button>
         </div>
         <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
           <dt className="text-brown/50">Borrower</dt>
-          <dd className="font-medium text-brown truncate" title={loan.borrower}>{loan.borrower.slice(0, 8)}…{loan.borrower.slice(-4)}</dd>
+          <dd className="font-medium text-brown truncate" title={loan.borrower}>
+            {loan.borrower.slice(0, 8)}…{loan.borrower.slice(-4)}
+          </dd>
           <dt className="text-brown/50">Collateral ID</dt>
           <dd className="font-medium text-brown">{loan.collateral_id}</dd>
           <dt className="text-brown/50">Amount</dt>
@@ -139,9 +170,15 @@ export default function LoanDetailPage() {
           <dt className="text-brown/50">Status</dt>
           <dd className="font-medium text-brown capitalize">{loan.status}</dd>
           <dt className="text-brown/50">Created</dt>
-          <dd className="font-medium text-brown">{new Date(loan.createdAt).toLocaleDateString()}</dd>
+          <dd className="font-medium text-brown">
+            {new Date(loan.createdAt).toLocaleDateString()}
+          </dd>
         </dl>
       </div>
+
+      {loan.status === 'active' && (
+        <LoanRepaymentCalculator loanId={loan.id} onProceed={() => router.push('/dashboard')} />
+      )}
     </main>
   );
 }

--- a/frontend/src/components/CollateralRegistrationForm.tsx
+++ b/frontend/src/components/CollateralRegistrationForm.tsx
@@ -8,6 +8,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { submitVariants } from '@/lib/animations';
 import { Input, Select, Button, ErrorSummary, toSummaryErrors } from '@/components/ui';
 import { useToast } from '@/components/toast';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 
 interface Props {
   walletAddress: string;
@@ -59,6 +60,7 @@ const FIELD_IDS: Record<keyof FormErrors, string> = {
 export default function CollateralRegistrationForm({ walletAddress, onSuccess }: Props) {
   const reduced = useReducedMotion();
   const toast = useToast();
+  const { isOnline } = useNetworkStatus();
   const [formData, setFormData] = useState<FormData>({
     animalType: 'cattle',
     quantity: '',
@@ -76,7 +78,6 @@ export default function CollateralRegistrationForm({ walletAddress, onSuccess }:
   const [showRestorePrompt, setShowRestorePrompt] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
 
   // Image upload state
@@ -463,13 +464,17 @@ export default function CollateralRegistrationForm({ walletAddress, onSuccess }:
           variants={reduced ? undefined : submitVariants}
           animate={loading ? 'loading' : 'idle'}
           className="w-full bg-brown text-cream py-2.5 rounded-xl font-semibold hover:bg-brown/80 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-          disabled={loading}
+          disabled={loading || !isOnline}
+          aria-disabled={loading || !isOnline}
+          title={!isOnline ? "You're offline" : undefined}
         >
           {loading ? (
             <>
               <Spinner />
               Processing…
             </>
+          ) : !isOnline ? (
+            "You're offline"
           ) : (
             'Register Collateral'
           )}

--- a/frontend/src/components/LiquidatorWhitelist.tsx
+++ b/frontend/src/components/LiquidatorWhitelist.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useId } from 'react';
 import Card from '@/components/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/FormField';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -57,6 +58,7 @@ export default function LiquidatorWhitelist({
   const [submitting, setSubmitting] = useState(false);
   const [removingAddress, setRemovingAddress] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const { isOnline } = useNetworkStatus();
 
   const inputId = useId();
   const listId = useId();
@@ -72,9 +74,7 @@ export default function LiquidatorWhitelist({
         return;
       }
       if (!isValidStellarAddress(trimmed)) {
-        setFieldError(
-          'Enter a valid Stellar address (56 characters, starting with G or C).',
-        );
+        setFieldError('Enter a valid Stellar address (56 characters, starting with G or C).');
         return;
       }
       const duplicate = liquidators.some((l) => l.address === trimmed);
@@ -95,7 +95,7 @@ export default function LiquidatorWhitelist({
         setSubmitting(false);
       }
     },
-    [newAddress, liquidators, onAdd],
+    [newAddress, liquidators, onAdd]
   );
 
   const handleRemove = useCallback(
@@ -104,16 +104,14 @@ export default function LiquidatorWhitelist({
       setRemovingAddress(address);
       try {
         await onRemove(address);
-        setSuccessMessage(
-          `${address.slice(0, 8)}…${address.slice(-4)} removed from whitelist.`,
-        );
+        setSuccessMessage(`${address.slice(0, 8)}…${address.slice(-4)} removed from whitelist.`);
       } catch {
         /* errors surface via the parent's error prop */
       } finally {
         setRemovingAddress(null);
       }
     },
-    [onRemove],
+    [onRemove]
   );
 
   const isOpenMode = liquidators.length === 0;
@@ -138,7 +136,9 @@ export default function LiquidatorWhitelist({
               ].join(' ')}
               aria-live="polite"
             >
-              {isOpenMode ? 'Open liquidation (no restrictions)' : `${liquidators.length} approved liquidator${liquidators.length !== 1 ? 's' : ''}`}
+              {isOpenMode
+                ? 'Open liquidation (no restrictions)'
+                : `${liquidators.length} approved liquidator${liquidators.length !== 1 ? 's' : ''}`}
             </span>
           </div>
         }
@@ -172,12 +172,7 @@ export default function LiquidatorWhitelist({
         )}
 
         {/* Add liquidator form */}
-        <form
-          onSubmit={handleAdd}
-          aria-label="Add liquidator"
-          className="mb-8"
-          noValidate
-        >
+        <form onSubmit={handleAdd} aria-label="Add liquidator" className="mb-8" noValidate>
           <div className="flex gap-3 items-start flex-wrap sm:flex-nowrap">
             <div className="flex-1 min-w-0">
               <Input
@@ -203,10 +198,11 @@ export default function LiquidatorWhitelist({
                 type="submit"
                 variant="primary"
                 loading={submitting}
-                disabled={loading}
+                disabled={loading || !isOnline}
+                title={!isOnline ? "You're offline" : undefined}
                 aria-label="Add address to whitelist"
               >
-                {submitting ? 'Adding…' : 'Add'}
+                {!isOnline ? "You're offline" : submitting ? 'Adding…' : 'Add'}
               </Button>
             </div>
           </div>

--- a/frontend/src/components/LoanForm.tsx
+++ b/frontend/src/components/LoanForm.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/components/toast';
 import { Input, Select, ErrorSummary, toSummaryErrors } from '@/components/ui';
 import { useFetchWithRateLimit } from '@/hooks/useFetchWithRateLimit';
 import { useNetworkMismatch } from '@/hooks/useNetworkMismatch';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 
 interface Props {
   walletAddress: string;
@@ -73,6 +74,7 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
   const toast = useToast();
   const { retryCountdown, isRateLimited, fetchWithLimit } = useFetchWithRateLimit();
   const networkMismatch = useNetworkMismatch(walletAddress);
+  const { isOnline } = useNetworkStatus();
 
   const collateralErrors = {
     count: validateCount(count),
@@ -207,8 +209,9 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
           />
           <button
             type="submit"
-            disabled={loading || isRateLimited || networkMismatch}
-            aria-disabled={loading || isRateLimited || networkMismatch}
+            disabled={loading || isRateLimited || networkMismatch || !isOnline}
+            aria-disabled={loading || isRateLimited || networkMismatch || !isOnline}
+            title={!isOnline ? "You're offline" : undefined}
             className={`w-full ${colors.primary.bg} ${colors.primary.text} py-2.5 rounded-xl font-semibold ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center justify-center gap-2`}
           >
             {loading ? (
@@ -218,6 +221,8 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
               </>
             ) : isRateLimited ? (
               `Retry in ${retryCountdown}s`
+            ) : !isOnline ? (
+              "You're offline"
             ) : (
               'Register & Continue'
             )}
@@ -258,8 +263,9 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
           />
           <button
             type="submit"
-            disabled={loading || isRateLimited || networkMismatch}
-            aria-disabled={loading || isRateLimited || networkMismatch}
+            disabled={loading || isRateLimited || networkMismatch || !isOnline}
+            aria-disabled={loading || isRateLimited || networkMismatch || !isOnline}
+            title={!isOnline ? "You're offline" : undefined}
             className={`w-full ${colors.secondary.bg} ${colors.secondary.text} py-2.5 rounded-xl font-semibold ${colors.secondary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center justify-center gap-2`}
           >
             {loading ? (
@@ -269,6 +275,8 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
               </>
             ) : isRateLimited ? (
               `Retry in ${retryCountdown}s`
+            ) : !isOnline ? (
+              "You're offline"
             ) : (
               'Request Loan'
             )}

--- a/frontend/src/components/LoanRepaymentCalculator.tsx
+++ b/frontend/src/components/LoanRepaymentCalculator.tsx
@@ -5,8 +5,14 @@ import { EmptyLoansIllustration } from '@/components/illustrations';
 import { formatXlmFromStroops } from '@/lib/formatMoney';
 
 interface Props {
-  onProceed: (loanId: string, amount: string) => void;
+  onProceed?: (loanId: string, amount: string) => void;
   onApplyForLoan?: () => void;
+  /**
+   * When provided, locks the calculator to this loan and hides the loan ID
+   * input/picker — used when embedding the calculator on a page that already
+   * has a specific loan in context (e.g. the loan detail page).
+   */
+  loanId?: number | string;
 }
 
 interface RepaymentPreview {
@@ -24,8 +30,13 @@ interface RepaymentPreview {
 
 const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: Props) {
-  const [loanId, setLoanId] = useState('');
+export default function LoanRepaymentCalculator({
+  onProceed,
+  onApplyForLoan,
+  loanId: fixedLoanId,
+}: Props) {
+  const isFixedLoan = fixedLoanId !== undefined && fixedLoanId !== null;
+  const [loanId, setLoanId] = useState(isFixedLoan ? String(fixedLoanId) : '');
   const [amount, setAmount] = useState('');
   const [loanOptions, setLoanOptions] = useState<number[]>([]);
   const [loansLoaded, setLoansLoaded] = useState(false);
@@ -33,10 +44,14 @@ export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: P
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const parsedLoanId = useMemo(() => Number(loanId), [loanId]);
+  const parsedLoanId = useMemo(
+    () => (isFixedLoan ? Number(fixedLoanId) : Number(loanId)),
+    [isFixedLoan, fixedLoanId, loanId]
+  );
   const parsedAmount = useMemo(() => Number(amount), [amount]);
 
   useEffect(() => {
+    if (isFixedLoan) return undefined;
     let mounted = true;
     async function loadLoans() {
       try {
@@ -60,7 +75,7 @@ export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: P
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [isFixedLoan]);
 
   useEffect(() => {
     if (
@@ -111,7 +126,7 @@ export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: P
         Preview principal, interest, fees, and health impact before repaying.
       </p>
 
-      {loansLoaded && loanOptions.length === 0 && (
+      {!isFixedLoan && loansLoaded && loanOptions.length === 0 && (
         <EmptyState
           illustration={<EmptyLoansIllustration />}
           message="You have no active loans"
@@ -121,25 +136,30 @@ export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: P
       )}
 
       <div className="space-y-3">
-        <div>
-          <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
-            Loan ID
-          </label>
-          <input
-            className="w-full rounded-lg px-3 py-2 min-h-[44px] bg-transparent"
-            style={{ border: '1px solid var(--color-border)', color: 'var(--color-text)' }}
-            placeholder="Enter loan ID"
-            value={loanId}
-            onChange={(e) => setLoanId(e.target.value)}
-            list="loan-options"
-            type="number"
-          />
-          <datalist id="loan-options">
-            {loanOptions.map((id) => (
-              <option key={id} value={id} />
-            ))}
-          </datalist>
-        </div>
+        {!isFixedLoan && (
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: 'var(--color-text)' }}
+            >
+              Loan ID
+            </label>
+            <input
+              className="w-full rounded-lg px-3 py-2 min-h-[44px] bg-transparent"
+              style={{ border: '1px solid var(--color-border)', color: 'var(--color-text)' }}
+              placeholder="Enter loan ID"
+              value={loanId}
+              onChange={(e) => setLoanId(e.target.value)}
+              list="loan-options"
+              type="number"
+            />
+            <datalist id="loan-options">
+              {loanOptions.map((id) => (
+                <option key={id} value={id} />
+              ))}
+            </datalist>
+          </div>
+        )}
 
         <div>
           <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
@@ -213,7 +233,7 @@ export default function LoanRepaymentCalculator({ onProceed, onApplyForLoan }: P
           <button
             type="button"
             className="mt-4 w-full bg-brown text-cream py-2.5 rounded-xl font-semibold hover:bg-brown/80 transition min-h-[44px] dark:bg-gold dark:text-brown"
-            onClick={() => onProceed(String(preview.loan_id), String(preview.repayment_amount))}
+            onClick={() => onProceed?.(String(preview.loan_id), String(preview.repayment_amount))}
           >
             Proceed to Repay
           </button>

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,8 +1,22 @@
-"use client";
-import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+'use client';
+import { useEffect, useRef } from 'react';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useToast } from '@/components/toast';
 
 export default function OfflineBanner() {
   const { isOnline } = useNetworkStatus();
+  const toast = useToast();
+  const wasOffline = useRef(false);
+
+  useEffect(() => {
+    if (!isOnline) {
+      wasOffline.current = true;
+    } else if (wasOffline.current) {
+      // Only announce reconnection — never fires on initial mount while online.
+      wasOffline.current = false;
+      toast.success('Reconnected');
+    }
+  }, [isOnline, toast]);
 
   if (isOnline) return null;
 

--- a/frontend/src/components/ScrollToTopButton.tsx
+++ b/frontend/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,55 @@
+'use client';
+/**
+ * ScrollToTopButton — #563
+ *
+ * Floating button shown on long list pages (Loans, Collateral) once the user
+ * has scrolled past SCROLL_THRESHOLD. Scrolls smoothly back to the top of the
+ * page, or instantly when the user has `prefers-reduced-motion` enabled.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+const SCROLL_THRESHOLD = 300;
+
+export default function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > SCROLL_THRESHOLD);
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-brown text-cream shadow-lg transition hover:bg-brown/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brown focus-visible:ring-offset-2 dark:bg-gold dark:text-brown"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+      </svg>
+    </button>
+  );
+}

--- a/frontend/tests/e2e/offline-form-submission.spec.ts
+++ b/frontend/tests/e2e/offline-form-submission.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E: Offline banner behaviour (#535)
+ *
+ * Acceptance criteria:
+ *  ✅  Form submit buttons are disabled when the browser goes offline
+ *  ✅  OfflineBanner is visible at the top of the page when offline
+ *  ✅  Banner disappears automatically when connectivity is restored
+ *  ✅  Submit button re-enables once back online
+ *
+ * Simulates offline mode via Playwright's `context.setOffline(true)`, which
+ * flips `navigator.onLine` to `false` and fires the `offline`/`online`
+ * window events the app listens to (see useNetworkStatus).
+ */
+
+const WALLET_ADDRESS = "GTESTWALLETADDRESS1234567890ABCDEFGH1234567890";
+
+test.describe("offline form submission behaviour (E2E) — #535", () => {
+  test("disables the collateral registration submit button while offline and re-enables it when back online", async ({
+    page,
+    context,
+  }) => {
+    await page.addInitScript(
+      ({ walletAddress }) => {
+        window.__STELLARKRAAL_E2E__ = {
+          async isConnected() {
+            return { isConnected: true };
+          },
+          async isAllowed() {
+            return { isAllowed: true };
+          },
+          async setAllowed() {
+            return { isAllowed: true };
+          },
+          async getAddress() {
+            return { address: walletAddress };
+          },
+          async signTransaction(xdr: string) {
+            return { signedTxXdr: `${xdr}-signed` };
+          },
+          async submitSignedXdr() {
+            return "mock-tx-hash";
+          },
+        };
+      },
+      { walletAddress: WALLET_ADDRESS }
+    );
+
+    await page.route("**/api/loans", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+    );
+    await page.route("**/api/transactions**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      })
+    );
+    await page.route("**/api/health/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ health_factor: 1.5 }),
+      })
+    );
+
+    await page.goto("/borrow");
+    await page.getByRole("button", { name: /connect freighter wallet/i }).click();
+    await expect(page.getByText(WALLET_ADDRESS.slice(0, 8))).toBeVisible();
+
+    const submitButton = page.getByRole("button", { name: /register collateral/i });
+    await expect(submitButton).toBeVisible();
+    await expect(submitButton).toBeEnabled();
+
+    // No offline banner while online.
+    await expect(page.getByRole("alert").filter({ hasText: /you are offline/i })).toHaveCount(0);
+
+    // ── Go offline ────────────────────────────────────────────────────────────
+    await context.setOffline(true);
+
+    await expect(page.getByRole("alert").filter({ hasText: /you are offline/i })).toBeVisible();
+    await expect(submitButton).toBeDisabled();
+
+    // ── Back online ───────────────────────────────────────────────────────────
+    await context.setOffline(false);
+
+    await expect(page.getByRole("alert").filter({ hasText: /you are offline/i })).toHaveCount(0);
+    await expect(submitButton).toBeEnabled();
+  });
+});


### PR DESCRIPTION

## Summary
closes #845 
closes #563 
closes #536 
closes #535


Implements the 4 issues assigned to me:

- **#845** — `GET /api/v1/profile`: returns the caller's own profile (walletAddress, displayName, joinedAt, loanCount, collateralCount). Auth required, 404 if no profile record exists yet, first login now auto-creates one. OpenAPI spec regenerated.
- **#563** — Floating scroll-to-top button on the Loans and Collateral list pages: appears past 300px, hidden at top, `aria-label="Scroll to top"`, respects `prefers-reduced-motion`.
- **#536** — `LoanRepaymentCalculator` is now embedded on the loan detail page for Active loans only (hidden for Repaid/Liquidated), locked to the loan already in context, with real-time preview as the amount changes.
- **#535** — Form submit buttons (collateral registration, loan request, liquidator whitelist) disable while offline; `OfflineBanner` now also fires a "Reconnected" toast when connectivity returns. New Playwright e2e spec drives a real offline/online transition.

## Notes on pre-existing issues found along the way

While implementing these, I ran into a few bugs unrelated to the 4 issues above, from the most recent merged commit (livestock image upload, #1033):

- `CollateralRegistrationForm.tsx` had a **duplicate `useState` declaration** for `imagePreview`, which broke compilation of the file entirely (`SyntaxError: Identifier 'imagePreview' has already been declared`). I removed the duplicate since it blocked testing my own change in this file — this is a one-line, unambiguous fix.
- The same component's validation currently treats the (supposedly *optional*) animal photo as **required** — `validateField('image', ...)` returns `'Image is required'` when empty, so registration without a photo now fails validation. I did **not** fix this (out of scope for my 4 issues) but flagging it since it contradicts the PR title and will block real users. Worth a follow-up.
- The whole frontend currently fails `tsc --noEmit` due to unrelated JSX syntax errors in `DashboardClient.tsx` and `StepCollateral.tsx` (also pre-existing on `main`, unrelated to my changes). Not touched here.
- Several existing frontend tests are broken independent of my changes: `jest.mock("@stellar/stellar-sdk", ...)` failures in backend tests using `jest.requireActual`, jsdom missing `window.matchMedia`/`URL.revokeObjectURL`, and a React-19 timing issue in one clipboard-copy test. I fixed only what I needed to (missing `__esModule: true` on two mocks in `LoanDetailPage.test.tsx`, which was silently breaking every test in that file) to get my own new tests running; the rest are noted but left alone.

## Testing

- Backend: new Jest integration tests for `GET /api/v1/profile` (auth required, first-login auto-create, loan/collateral counts, 404 case) — all passing. `tsc --noEmit` clean.
- Frontend: new/updated Jest tests for `ScrollToTopButton`, `LoanRepaymentCalculator` (embed + edge cases), `LoanDetailPage` (calculator visibility), `OfflineBanner` (reconnect toast) — all passing except one pre-existing, unrelated flaky test (`LoanDetailPage` clipboard-copy timing) confirmed broken on `main` before this branch touched anything.
- New Playwright e2e spec for the offline form-disable behavior (not executed in this sandbox — no browsers installed here — but follows the existing e2e suite's conventions and should run via `npm run test:e2e`).