### PR TITLE
Fix dark mode persistence tests, mobile navbar a11y, wizard autosave + error boundaries (#522, #523, #524, #528)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/dom": "^10.4.1",
         "focus-trap-react": "^12.0.3",
         "framer-motion": "^12.42.2",
+        "lucide-react": "0.469.0",
         "next": "14.2.35",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -8643,6 +8644,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/src/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/__tests__/ErrorBoundary.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ErrorBoundary from "../components/ErrorBoundary";
 
 // Suppress expected console.error noise from React's error boundary
@@ -50,5 +51,47 @@ describe("ErrorBoundary", () => {
     );
     // componentDidCatch calls console.error in dev (NODE_ENV=test counts as non-production)
     expect(spy).toHaveBeenCalled();
+  });
+
+  // #522: retry support used to wrap individual LoanWizard steps
+  describe("onRetry", () => {
+    it("shows a retry button instead of Reload when onRetry is provided", () => {
+      const onRetry = jest.fn();
+      render(
+        <ErrorBoundary onRetry={onRetry} retryLabel="← Back to previous step">
+          <Bomb shouldThrow={true} />
+        </ErrorBoundary>,
+      );
+      expect(screen.getByRole("button", { name: /back to previous step/i })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: /^reload$/i })).toBeNull();
+    });
+
+    it("calls onRetry and clears the error so children render again", async () => {
+      const user = userEvent.setup();
+      const onRetry = jest.fn();
+
+      function Wrapper() {
+        const [shouldThrow, setShouldThrow] = React.useState(true);
+        return (
+          <ErrorBoundary
+            onRetry={() => {
+              onRetry();
+              setShouldThrow(false);
+            }}
+            retryLabel="Try again"
+          >
+            <Bomb shouldThrow={shouldThrow} />
+          </ErrorBoundary>
+        );
+      }
+
+      render(<Wrapper />);
+      expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("OK")).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/__tests__/LoanWizard.test.tsx
+++ b/frontend/src/__tests__/LoanWizard.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LoanWizard from "../components/wizard/LoanWizard";
+
+// Suppress expected console.error noise from React's error boundary
+beforeEach(() => jest.spyOn(console, "error").mockImplementation(() => {}));
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+// Lightweight step stubs — LoanWizard's own orchestration (step switching,
+// per-step ErrorBoundary wrapping, retry) is what's under test here, not
+// the real steps' internals (covered by their own test files).
+jest.mock("../components/wizard/steps/StepCollateral", () => {
+  return function StepCollateral() {
+    return <div>Collateral step content</div>;
+  };
+});
+
+let stepAmountShouldThrow = false;
+jest.mock("../components/wizard/steps/StepAmount", () => {
+  return function StepAmount() {
+    if (stepAmountShouldThrow) throw new Error("boom in amount step");
+    return <div>Amount step content</div>;
+  };
+});
+
+jest.mock("../components/wizard/steps/StepReview", () => {
+  return function StepReview() {
+    return <div>Review step content</div>;
+  };
+});
+
+jest.mock("../components/wizard/steps/StepConfirm", () => {
+  return function StepConfirm() {
+    return <div>Confirm step content</div>;
+  };
+});
+
+describe("LoanWizard error boundaries (#522)", () => {
+  beforeEach(() => {
+    stepAmountShouldThrow = false;
+  });
+
+  it("renders the first step normally with no error UI", () => {
+    render(<LoanWizard walletAddress="GTEST" />);
+    expect(screen.getByText("Collateral step content")).toBeTruthy();
+    expect(screen.queryByText(/something went wrong/i)).toBeNull();
+  });
+
+  it("shows a scoped fallback when a step throws, without crashing the rest of the wizard", () => {
+    stepAmountShouldThrow = true;
+    // Force the wizard straight to step 2 via saved state so we don't need
+    // to drive StepCollateral's real validation to advance.
+    localStorage.setItem(
+      "loan_wizard_state",
+      JSON.stringify({
+        walletAddress: "GTEST",
+        data: {
+          animalType: "cattle",
+          count: "2",
+          appraisedValue: "1000",
+          collateralId: "1",
+          loanAmount: "",
+          loanTermDays: "30",
+          step: 2,
+          loading: false,
+          error: null,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    );
+
+    render(<LoanWizard walletAddress="GTEST" />);
+    expect(screen.getByText(/amount.*something went wrong/i)).toBeTruthy();
+    // The rest of the wizard chrome (progress header) still renders.
+    expect(screen.getByText(/loan request/i)).toBeTruthy();
+  });
+
+  it("retry from a crashed step navigates back to the previous step", async () => {
+    const user = userEvent.setup();
+    stepAmountShouldThrow = true;
+    localStorage.setItem(
+      "loan_wizard_state",
+      JSON.stringify({
+        walletAddress: "GTEST",
+        data: {
+          animalType: "cattle",
+          count: "2",
+          appraisedValue: "1000",
+          collateralId: "1",
+          loanAmount: "",
+          loanTermDays: "30",
+          step: 2,
+          loading: false,
+          error: null,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    );
+
+    render(<LoanWizard walletAddress="GTEST" />);
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /back to previous step/i }));
+
+    expect(screen.getByText("Collateral step content")).toBeTruthy();
+    expect(screen.queryByText(/something went wrong/i)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -134,4 +134,30 @@ describe('Navbar', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  // #524: drawer closes when the overlay behind it is tapped
+  it('mobile menu closes when the overlay is clicked', async () => {
+    render(<Navbar />);
+    await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(document.getElementById('mobile-menu')).toBeTruthy();
+
+    const overlay = document.querySelector('[aria-hidden="true"].fixed.inset-0');
+    expect(overlay).toBeTruthy();
+    await userEvent.click(overlay as Element);
+
+    expect(document.getElementById('mobile-menu')).toBeNull();
+  });
+
+  // #524: focus is trapped inside the open drawer for keyboard users
+  it('traps focus inside the open drawer', async () => {
+    render(<Navbar />);
+    await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    const drawer = document.getElementById('mobile-menu');
+    expect(drawer).toBeTruthy();
+    expect(drawer).toHaveAttribute('role', 'dialog');
+    expect(drawer).toHaveAttribute('aria-modal', 'true');
+
+    // Focus should be inside the drawer, not left on the page behind it
+    expect(drawer!.contains(document.activeElement)).toBe(true);
+  });
 });

--- a/frontend/src/__tests__/ThemeProvider.test.tsx
+++ b/frontend/src/__tests__/ThemeProvider.test.tsx
@@ -1,18 +1,33 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import ThemeProvider, { ThemeScript } from '../components/ThemeProvider';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ThemeProvider, { ThemeScript, useTheme } from '../components/ThemeProvider';
 
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-  }),
-});
+function mockMatchMedia(matchesDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: matchesDark,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }),
+  });
+}
+
+/** Runs the real ThemeScript source against the current jsdom document,
+ * the same way the browser would execute it before React hydrates. */
+function runThemeScript() {
+  const { container } = render(<ThemeScript />);
+  const script = container.querySelector('script')!.innerHTML;
+  eval(script);
+}
 
 describe('ThemeProvider (#572 – hydration)', () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+  });
+
   it('renders children without crashing', () => {
     render(
       <ThemeProvider>
@@ -28,5 +43,83 @@ describe('ThemeProvider (#572 – hydration)', () => {
     expect(script).not.toBeNull();
     expect(script!.innerHTML).toContain('classList');
     expect(script!.innerHTML).not.toContain('textContent');
+  });
+});
+
+// #528: dark mode toggle persistence
+describe('ThemeScript (#528 – read-from-storage & system-preference fallback)', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+    localStorage.clear();
+  });
+
+  it('applies dark class from a stored "dark" preference, regardless of system preference', () => {
+    localStorage.setItem('theme', 'dark');
+    mockMatchMedia(false); // system prefers light — stored value should win
+    runThemeScript();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('keeps light (no dark class) from a stored "light" preference, even if system prefers dark', () => {
+    localStorage.setItem('theme', 'light');
+    mockMatchMedia(true); // system prefers dark — stored value should still win
+    runThemeScript();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('falls back to system preference (dark) when nothing is stored', () => {
+    mockMatchMedia(true);
+    runThemeScript();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('falls back to system preference (light) when nothing is stored', () => {
+    mockMatchMedia(false);
+    runThemeScript();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});
+
+describe('ThemeProvider (#528 – reads the class already applied by ThemeScript)', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  function ThemeLabel() {
+    const { theme } = useTheme();
+    return <span>{theme}</span>;
+  }
+
+  it('picks up "dark" when ThemeScript has already applied the class before hydration', () => {
+    document.documentElement.classList.add('dark');
+    render(
+      <ThemeProvider>
+        <ThemeLabel />
+      </ThemeProvider>
+    );
+    expect(screen.getByText('dark')).toBeTruthy();
+  });
+
+  it('picks up "light" when no class was applied', () => {
+    render(
+      <ThemeProvider>
+        <ThemeLabel />
+      </ThemeProvider>
+    );
+    expect(screen.getByText('light')).toBeTruthy();
+  });
+
+  it('writes the toggled preference to localStorage under the "theme" key', () => {
+    function ToggleButton() {
+      const { toggle } = useTheme();
+      return <button onClick={toggle}>toggle</button>;
+    }
+    render(
+      <ThemeProvider>
+        <ToggleButton />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('toggle'));
+    expect(localStorage.getItem('theme')).toBe('dark');
   });
 });

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -5,6 +5,15 @@ interface Props {
   children: ReactNode;
   /** Shown above the generic message — e.g. "Dashboard" */
   section?: string;
+  /**
+   * When provided, the primary action becomes a retry button that calls
+   * this instead of reloading the whole page — e.g. navigate a multi-step
+   * flow back to its previous step (#522) — and the boundary clears its
+   * own error state so the retried content gets a fresh render.
+   */
+  onRetry?: () => void;
+  /** Label for the retry button. Defaults to "Try again". Ignored without onRetry. */
+  retryLabel?: string;
 }
 
 interface State {
@@ -24,11 +33,17 @@ export default class ErrorBoundary extends Component<Props, State> {
     }
   }
 
+  handleRetry = () => {
+    this.setState({ error: null });
+    this.props.onRetry?.();
+  };
+
   render() {
     const { error } = this.state;
     if (!error) return this.props.children;
 
     const section = this.props.section ? `${this.props.section} — ` : "";
+    const { onRetry, retryLabel } = this.props;
 
     return (
       <div className="flex flex-col items-center justify-center min-h-[200px] p-8 text-center">
@@ -40,12 +55,21 @@ export default class ErrorBoundary extends Component<Props, State> {
           An unexpected error occurred. Please reload or report the issue.
         </p>
         <div className="flex gap-3 flex-wrap justify-center">
-          <button
-            onClick={() => window.location.reload()}
-            className="bg-gold text-brown font-semibold px-4 py-2 rounded-lg hover:bg-gold/80 transition"
-          >
-            Reload
-          </button>
+          {onRetry ? (
+            <button
+              onClick={this.handleRetry}
+              className="bg-gold text-brown font-semibold px-4 py-2 rounded-lg hover:bg-gold/80 transition"
+            >
+              {retryLabel ?? "Try again"}
+            </button>
+          ) : (
+            <button
+              onClick={() => window.location.reload()}
+              className="bg-gold text-brown font-semibold px-4 py-2 rounded-lg hover:bg-gold/80 transition"
+            >
+              Reload
+            </button>
+          )}
           <a
             href="/help/faq"
             className="border border-brown/30 text-brown px-4 py-2 rounded-lg hover:bg-brown/5 transition text-sm"

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
+import FocusTrap from "focus-trap-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -183,60 +184,91 @@ export default function Navbar() {
         </div>
       </div>
 
-      {/* Mobile drawer */}
+      {/* Mobile drawer (#524) */}
       {open && (
-        <ul
-          id="mobile-menu"
-          className="md:hidden flex flex-col border-t py-2"
-          style={{ borderColor: "var(--color-nav-border)" }}
-          role="list"
-        >
-          {NAV_SECTIONS.map(({ href, label, icon }) => {
-            const active =
-              pathname === href || pathname.startsWith(href + "/");
-            const isDashboard = href === "/dashboard";
-            return (
-              <li key={href}>
-                {/*
-                 * Mobile active state (#781):
-                 * — left border pill (4 px) instead of bottom to suit the vertical layout
-                 * — same token colours as desktop
-                 */}
-                <Link
-                  href={href}
-                  aria-current={active ? "page" : undefined}
-                  onClick={() => setOpen(false)}
-                  className={[
-                    "relative flex items-center gap-2 px-4 min-h-[44px] transition font-medium",
-                    active ? "border-l-4 font-bold" : "hover:bg-[var(--color-border)]",
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
-                  style={
-                    active
-                      ? {
-                          color: "var(--token-primary)",
-                          borderLeftColor: "var(--token-primary)",
-                          backgroundColor:
-                            "color-mix(in srgb, var(--token-primary) 8%, transparent)",
+        <>
+          {/* Overlay — tapping it dismisses the drawer, same as the close button */}
+          <div
+            className="md:hidden fixed inset-0 z-40 bg-black/40"
+            aria-hidden="true"
+            onClick={() => setOpen(false)}
+          />
+          {/*
+           * Focus is trapped inside the open drawer (#524) so keyboard users
+           * can't tab into content hidden behind the overlay. Escape and an
+           * outside click both close it via onDeactivate.
+           */}
+          <FocusTrap
+            active={open}
+            focusTrapOptions={{
+              onDeactivate: () => setOpen(false),
+              clickOutsideDeactivates: true,
+              escapeDeactivates: true,
+              fallbackFocus: "#mobile-menu",
+            }}
+          >
+            <div
+              id="mobile-menu"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Mobile navigation menu"
+              tabIndex={-1}
+              className="md:hidden fixed inset-x-0 top-14 z-50 border-t shadow-lg"
+              style={{
+                borderColor: "var(--color-nav-border)",
+                backgroundColor: "var(--color-nav-bg)",
+              }}
+            >
+              <ul className="flex flex-col py-2" role="list">
+                {NAV_SECTIONS.map(({ href, label, icon }) => {
+                  const active =
+                    pathname === href || pathname.startsWith(href + "/");
+                  const isDashboard = href === "/dashboard";
+                  return (
+                    <li key={href}>
+                      {/*
+                       * Mobile active state (#781):
+                       * — left border pill (4 px) instead of bottom to suit the vertical layout
+                       * — same token colours as desktop
+                       */}
+                      <Link
+                        href={href}
+                        aria-current={active ? "page" : undefined}
+                        onClick={() => setOpen(false)}
+                        className={[
+                          "relative flex items-center gap-2 px-4 min-h-[44px] transition font-medium",
+                          active ? "border-l-4 font-bold" : "hover:bg-[var(--color-border)]",
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                        style={
+                          active
+                            ? {
+                                color: "var(--token-primary)",
+                                borderLeftColor: "var(--token-primary)",
+                                backgroundColor:
+                                  "color-mix(in srgb, var(--token-primary) 8%, transparent)",
+                              }
+                            : {
+                                color: "var(--token-text-muted)",
+                              }
                         }
-                      : {
-                          color: "var(--token-text-muted)",
-                        }
-                  }
-                >
-                  {/* lucide icon — decorative */}
-                  <Icon icon={icon} size="sm" className="text-current" />
-                  {label}
-                  {/* #803: notification badge on dashboard link in mobile menu */}
-                  {isDashboard && atRiskCount > 0 && (
-                    <NotificationBadge count={atRiskCount} />
-                  )}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+                      >
+                        {/* lucide icon — decorative */}
+                        <Icon icon={icon} size="sm" className="text-current" />
+                        {label}
+                        {/* #803: notification badge on dashboard link in mobile menu */}
+                        {isDashboard && atRiskCount > 0 && (
+                          <NotificationBadge count={atRiskCount} />
+                        )}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </FocusTrap>
+        </>
       )}
     </nav>
   );

--- a/frontend/src/components/wizard/LoanWizard.tsx
+++ b/frontend/src/components/wizard/LoanWizard.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { useState } from "react";
 import { LoanWizardProvider, useWizard } from "@/context/LoanWizardContext";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import StepCollateral from "./steps/StepCollateral";
 import StepAmount from "./steps/StepAmount";
 import StepReview from "./steps/StepReview";
@@ -17,7 +19,16 @@ interface Props {
 }
 
 function WizardInner({ walletAddress }: Props) {
-  const { step } = useWizard();
+  const { step, prevStep } = useWizard();
+  // Bumped on every retry so the ErrorBoundary's `key` changes and the
+  // crashed step remounts cleanly, even when there's no previous step to
+  // go back to (#522).
+  const [retryKey, setRetryKey] = useState(0);
+
+  function handleStepRetry() {
+    setRetryKey((k) => k + 1);
+    prevStep();
+  }
 
   return (
     <div className="bg-white rounded-2xl shadow-lg mt-6 overflow-hidden">
@@ -83,12 +94,51 @@ function WizardInner({ walletAddress }: Props) {
         </div>
       </div>
 
-      {/* Step Content */}
+      {/* Step Content — each step is wrapped in its own ErrorBoundary (#522)
+          so a crash in one step doesn't take down the whole wizard. Retry
+          navigates back to the previous step (or, on step 1 where there is
+          none, simply remounts the step for another attempt). */}
       <div className="p-6">
-        {step === 1 && <StepCollateral walletAddress={walletAddress} />}
-        {step === 2 && <StepAmount />}
-        {step === 3 && <StepReview />}
-        {step === 4 && <StepConfirm walletAddress={walletAddress} />}
+        {step === 1 && (
+          <ErrorBoundary
+            key={`collateral-${retryKey}`}
+            section="Collateral"
+            onRetry={handleStepRetry}
+            retryLabel="↻ Try again"
+          >
+            <StepCollateral walletAddress={walletAddress} />
+          </ErrorBoundary>
+        )}
+        {step === 2 && (
+          <ErrorBoundary
+            key={`amount-${retryKey}`}
+            section="Amount"
+            onRetry={handleStepRetry}
+            retryLabel="← Back to previous step"
+          >
+            <StepAmount />
+          </ErrorBoundary>
+        )}
+        {step === 3 && (
+          <ErrorBoundary
+            key={`review-${retryKey}`}
+            section="Review"
+            onRetry={handleStepRetry}
+            retryLabel="← Back to previous step"
+          >
+            <StepReview />
+          </ErrorBoundary>
+        )}
+        {step === 4 && (
+          <ErrorBoundary
+            key={`confirm-${retryKey}`}
+            section="Confirm"
+            onRetry={handleStepRetry}
+            retryLabel="← Back to previous step"
+          >
+            <StepConfirm walletAddress={walletAddress} />
+          </ErrorBoundary>
+        )}
       </div>
     </div>
   );
@@ -96,7 +146,7 @@ function WizardInner({ walletAddress }: Props) {
 
 export default function LoanWizard({ walletAddress }: Props) {
   return (
-    <LoanWizardProvider>
+    <LoanWizardProvider walletAddress={walletAddress}>
       <WizardInner walletAddress={walletAddress} />
     </LoanWizardProvider>
   );

--- a/frontend/src/components/wizard/steps/StepConfirm.tsx
+++ b/frontend/src/components/wizard/steps/StepConfirm.tsx
@@ -32,6 +32,7 @@ export default function StepConfirm({ walletAddress }: Props) {
     setField,
     prevStep,
     reset,
+    clearSavedProgress,
   } = useWizard();
 
   const [loanId, setLoanId] = useState<string | null>(null);
@@ -64,6 +65,10 @@ export default function StepConfirm({ walletAddress }: Props) {
       setLoanId(String(result));
       // New loan created — drop cached loan lists so they revalidate.
       invalidateLoans();
+      // Loan is submitted; stop offering to restore this now-completed
+      // draft on a future visit (#523). The in-memory values stay put so
+      // the success screen below can still show what was submitted.
+      clearSavedProgress();
       submitButton.setSuccess();
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Something went wrong.';

--- a/frontend/src/context/LoanWizardContext.tsx
+++ b/frontend/src/context/LoanWizardContext.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { createContext, useContext, useState, ReactNode, useEffect, useRef } from 'react';
+import { useFormAutoSave } from '@/hooks/useFormAutoSave';
 
 export type AnimalType = 'cattle' | 'goat' | 'sheep';
 
@@ -38,6 +39,12 @@ interface WizardCtx extends WizardState {
   prevStep: () => void;
   reset: () => void;
   canProceed: () => boolean;
+  /**
+   * Drops the persisted autosave without resetting in-memory state (#523).
+   * Used right after a successful loan submission, where the just-submitted
+   * values are still shown on screen but shouldn't be offered for restore.
+   */
+  clearSavedProgress: () => void;
 }
 
 function makeItem(overrides?: Partial<CollateralItem>): CollateralItem {
@@ -52,6 +59,7 @@ function makeItem(overrides?: Partial<CollateralItem>): CollateralItem {
 }
 
 const defaults: WizardState = {
+  collaterals: [],
   animalType: 'cattle',
   count: '',
   appraisedValue: '',
@@ -64,35 +72,52 @@ const defaults: WizardState = {
 };
 
 const STORAGE_KEY = 'loan_wizard_state';
+// Persisted wizard state older than this is treated as gone rather than
+// restored (#523) — a form left mid-fill for a day is more likely stale
+// than something the borrower still wants to resume.
+const SAVE_EXPIRY_MS = 24 * 60 * 60 * 1000;
 
 const LoanWizardContext = createContext<WizardCtx | null>(null);
 
-export function LoanWizardProvider({ children }: { children: ReactNode }) {
+export function LoanWizardProvider({
+  children,
+  walletAddress,
+}: {
+  children: ReactNode;
+  walletAddress?: string;
+}) {
   const [state, setState] = useState<WizardState>(defaults);
-  const [mounted, setMounted] = useState(false);
+  const restoredRef = useRef(false);
 
-  // Load from localStorage on mount
+  // Autosaves `state` to localStorage as the wizard is filled in, and gives
+  // us restore/clear helpers (#523). Scoping by walletAddress, when known,
+  // keeps one wallet from resuming another's in-progress loan request.
+  const { restoreSavedData, clearSavedData } = useFormAutoSave<WizardState>({
+    storageKey: STORAGE_KEY,
+    data: state,
+    walletAddress,
+    interval: 1000,
+    expiryMs: SAVE_EXPIRY_MS,
+  });
+
+  // Restore once on mount so the wizard reopens at the last completed step.
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        setState(JSON.parse(saved));
-      } catch {
-        // Ignore parse errors
-      }
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    const restored = restoreSavedData();
+    if (restored) {
+      setState(restored);
     }
-    setMounted(true);
+    // Intentionally run once — restoreSavedData reads storage synchronously
+    // and re-running it on every render would fight the autosave interval.
   }, []);
-
-  // Save to localStorage whenever state changes
-  useEffect(() => {
-    if (mounted) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    }
-  }, [state, mounted]);
 
   function setField<K extends keyof WizardState>(key: K, value: WizardState[K]) {
     setState((s) => ({ ...s, [key]: value }));
+  }
+
+  function setCollaterals(items: CollateralItem[]) {
+    setState((s) => ({ ...s, collaterals: items }));
   }
 
   function canProceed(): boolean {
@@ -122,12 +147,21 @@ export function LoanWizardProvider({ children }: { children: ReactNode }) {
 
   function reset() {
     setState(defaults);
-    localStorage.removeItem(STORAGE_KEY);
+    clearSavedData();
   }
 
   return (
     <LoanWizardContext.Provider
-      value={{ ...state, setField, nextStep, prevStep, reset, canProceed }}
+      value={{
+        ...state,
+        setField,
+        setCollaterals,
+        nextStep,
+        prevStep,
+        reset,
+        canProceed,
+        clearSavedProgress: clearSavedData,
+      }}
     >
       {children}
     </LoanWizardContext.Provider>

--- a/frontend/src/hooks/useFormAutoSave.ts
+++ b/frontend/src/hooks/useFormAutoSave.ts
@@ -6,6 +6,12 @@ interface AutoSaveOptions<T> {
   enabled?: boolean;
   interval?: number;
   walletAddress?: string;
+  /**
+   * Saved data older than this (ms) is treated as if it were never saved:
+   * it's discarded from localStorage and neither `hasSavedData` nor
+   * `restoreSavedData()` will surface it. Omit for no expiry.
+   */
+  expiryMs?: number;
 }
 
 interface SavedData<T> {
@@ -14,12 +20,20 @@ interface SavedData<T> {
   timestamp: string;
 }
 
+function isExpired<T>(parsed: SavedData<T>, expiryMs?: number): boolean {
+  if (expiryMs == null) return false;
+  const savedAt = new Date(parsed.timestamp).getTime();
+  if (Number.isNaN(savedAt)) return false;
+  return Date.now() - savedAt > expiryMs;
+}
+
 export function useFormAutoSave<T extends Record<string, any>>({
   storageKey,
   data,
   enabled = true,
   interval = 5000,
   walletAddress,
+  expiryMs,
 }: AutoSaveOptions<T>) {
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [hasSavedData, setHasSavedData] = useState(false);
@@ -30,14 +44,16 @@ export function useFormAutoSave<T extends Record<string, any>>({
     if (saved) {
       try {
         const parsed: SavedData<T> = JSON.parse(saved);
-        if (!walletAddress || parsed.walletAddress === walletAddress) {
+        if (isExpired(parsed, expiryMs)) {
+          localStorage.removeItem(storageKey);
+        } else if (!walletAddress || parsed.walletAddress === walletAddress) {
           setHasSavedData(true);
         }
       } catch (e) {
         // Invalid saved data
       }
     }
-  }, [storageKey, walletAddress]);
+  }, [storageKey, walletAddress, expiryMs]);
 
   // Auto-save
   useEffect(() => {
@@ -72,6 +88,11 @@ export function useFormAutoSave<T extends Record<string, any>>({
 
     try {
       const parsed: SavedData<T> = JSON.parse(saved);
+      if (isExpired(parsed, expiryMs)) {
+        localStorage.removeItem(storageKey);
+        setHasSavedData(false);
+        return null;
+      }
       if (walletAddress && parsed.walletAddress !== walletAddress) {
         return null;
       }

--- a/frontend/tests/e2e/navbar-mobile.spec.ts
+++ b/frontend/tests/e2e/navbar-mobile.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E: Navbar mobile responsiveness (#524)
+ *
+ * Acceptance criteria covered here:
+ *  - All nav links are reachable on screens narrower than 640 px
+ *  - Hamburger icon toggles a drawer containing the nav links
+ *  - Drawer closes when a link is clicked or the overlay is tapped
+ *  - Focus is trapped inside the open drawer
+ *
+ * The home page ("/") renders the global Navbar with no wallet/auth gate,
+ * so no mocking is required to exercise it.
+ */
+
+test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE-ish, well under 640px
+
+test.describe("Navbar — mobile (< 640px)", () => {
+  test("hamburger opens a drawer with all nav links, and clicking a link navigates and closes it", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const hamburger = page.getByRole("button", { name: /open menu/i });
+    await expect(hamburger).toBeVisible();
+
+    const drawer = page.locator("#mobile-menu");
+    await expect(drawer).toBeHidden();
+
+    await hamburger.click();
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByRole("link", { name: /dashboard/i })).toBeVisible();
+    await expect(drawer.getByRole("link", { name: /loans/i })).toBeVisible();
+    await expect(drawer.getByRole("link", { name: /collateral/i })).toBeVisible();
+    await expect(drawer.getByRole("link", { name: /settings/i })).toBeVisible();
+
+    await drawer.getByRole("link", { name: /loans/i }).click();
+    await expect(page).toHaveURL(/\/loans/);
+    await expect(drawer).toBeHidden();
+  });
+
+  test("drawer closes when the overlay behind it is tapped", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /open menu/i }).click();
+    const drawer = page.locator("#mobile-menu");
+    await expect(drawer).toBeVisible();
+
+    // Tap the overlay well below the drawer's own content, outside its links.
+    await page.mouse.click(10, page.viewportSize()!.height - 10);
+    await expect(drawer).toBeHidden();
+  });
+
+  test("focus is trapped inside the open drawer", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /open menu/i }).click();
+    const drawer = page.locator("#mobile-menu");
+    await expect(drawer).toBeVisible();
+
+    // Tabbing repeatedly should never move focus outside the drawer while it's open.
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press("Tab");
+      const focusIsInsideDrawer = await drawer.evaluate(
+        (el) => el.contains(document.activeElement)
+      );
+      expect(focusIsInsideDrawer).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the four issues assigned to me:

- Closes #528 — dark mode toggle persistence
- Closes #524 — Navbar fully responsive on mobile (< 640px)
- Closes #523 — persist LoanWizard form state across refreshes
- Closes #522 — error boundary around LoanWizard steps

### #528 — Dark mode toggle persistence
`ThemeScript`/`ThemeProvider` already implemented all the acceptance criteria (localStorage-before-hydration, `theme` key write, `prefers-color-scheme` fallback, no FOUC). This adds the missing unit test coverage: `ThemeScript` is executed for real against jsdom to verify stored-value vs. system-preference precedence in both directions, and `ThemeProvider` is asserted to pick up whatever class `ThemeScript` applied.

### #524 — Navbar responsive on mobile
The hamburger drawer opened/closed and closed on link click already, but had no backdrop and didn't constrain focus.
- Added a fixed backdrop behind the open drawer; tapping it closes the menu.
- Wrapped the drawer in `focus-trap-react` (already a dependency, previously unused) so Tab cycles inside it and Escape / an outside click dismiss it.
- Gave the drawer `role="dialog"` / `aria-modal="true"`.
- New unit tests for the overlay click and focus containment, plus a Playwright e2e spec covering open/close, link navigation, overlay-tap, and focus trapping at a sub-640px viewport.

### #523 — Persist LoanWizard state
`useFormAutoSave` existed but had no expiry and wasn't actually wired into `LoanWizardContext` (which rolled its own localStorage read/write instead).
- `useFormAutoSave` gains an optional `expiryMs`; saved data past that age is discarded rather than restored.
- `LoanWizardContext` now autosaves through the hook (scoped by wallet address when known) with a 24h expiry, and restores once on mount — including `step`, so the wizard reopens at the last completed step.
- Fixed two latent gaps in the same file surfaced along the way: `defaults` was missing the required `collaterals` field, and `setCollaterals` was declared on the context type but never implemented.
- `StepConfirm` now drops the saved draft immediately on a successful submission via a new `clearSavedProgress` (clears storage only, so the success screen can still show the just-submitted values).

### #522 — Error boundary around LoanWizard steps
Each step (`StepCollateral`, `StepAmount`, `StepReview`, `StepConfirm`) now renders inside its own `ErrorBoundary`, keyed per step + retry attempt so a retry remounts cleanly.
- `ErrorBoundary` gains an optional `onRetry`/`retryLabel`: when provided, the fallback's primary action calls it (and clears the boundary's own error) instead of reloading the page.
- `LoanWizard` wires `onRetry` to navigate back to the previous step (on step 1, where there's no previous step, it just re-attempts the step).

## Testing
- `npm test` — all newly added/modified tests pass; no regressions (verified 1:1 against `main`: same 34 pre-existing failing suites / 130 pre-existing failing tests on both, my branch only adds passing tests on top). Note: `StepCollateral.tsx`, `DashboardClient.tsx`, and a chunk of the wider suite were already broken/failing on `main` before this PR — untouched here, out of scope.
- `npx tsc --noEmit` — same pre-existing errors as `main` (`DashboardClient.tsx`, `StepCollateral.tsx`), nothing new introduced.
- `npx eslint` on touched files — no new issues beyond the repo's existing prettier quote-style debt (pre-existing repo-wide, confirmed against `main`).
- New e2e spec (`tests/e2e/navbar-mobile.spec.ts`) not run in this environment (no browser binaries installed); written to the same conventions as the existing specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
