### PR TITLE
feat(frontend): add breadcrumb navigation to /dashboard sub-pages

### DIFF
--- a/frontend/src/__tests__/Breadcrumb.test.tsx
+++ b/frontend/src/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import Breadcrumb, { buildCrumbs } from '../components/Breadcrumb';
+
+expect.extend(toHaveNoViolations);
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mutable pathname so each test can set its own value.
+let mockPathname = '/dashboard';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+jest.mock('next/link', () => {
+  const Link = ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+// ---------------------------------------------------------------------------
+// buildCrumbs unit tests (pure function — no rendering needed)
+// ---------------------------------------------------------------------------
+
+describe('buildCrumbs', () => {
+  it('returns a single crumb for /dashboard', () => {
+    const crumbs = buildCrumbs('/dashboard');
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0]).toEqual({ label: 'Dashboard', href: '/dashboard' });
+  });
+
+  it('returns two crumbs for /dashboard/collateral', () => {
+    const crumbs = buildCrumbs('/dashboard/collateral');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: 'Dashboard', href: '/dashboard' });
+    expect(crumbs[1]).toEqual({ label: 'Collateral', href: '/dashboard/collateral' });
+  });
+
+  it('returns three crumbs for /dashboard/collateral/abc-123', () => {
+    const crumbs = buildCrumbs('/dashboard/collateral/abc-123');
+    expect(crumbs).toHaveLength(3);
+    expect(crumbs[0]).toEqual({ label: 'Dashboard', href: '/dashboard' });
+    expect(crumbs[1]).toEqual({ label: 'Collateral', href: '/dashboard/collateral' });
+    expect(crumbs[2]).toEqual({ label: 'abc-123', href: '/dashboard/collateral/abc-123' });
+  });
+
+  it('falls back to the raw segment for unknown segments', () => {
+    const crumbs = buildCrumbs('/dashboard/unknown-segment');
+    expect(crumbs[1].label).toBe('unknown-segment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Breadcrumb component rendering tests
+// ---------------------------------------------------------------------------
+
+describe('Breadcrumb', () => {
+  // -- Hidden on top-level pages --
+
+  it('renders nothing on /dashboard (top-level page)', () => {
+    mockPathname = '/dashboard';
+    const { container } = render(<Breadcrumb />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // -- /dashboard/collateral --
+
+  describe('on /dashboard/collateral', () => {
+    beforeEach(() => {
+      mockPathname = '/dashboard/collateral';
+      render(<Breadcrumb />);
+    });
+
+    it('renders a breadcrumb nav', () => {
+      expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toBeTruthy();
+    });
+
+    it('shows "Dashboard" as a link (not the current page)', () => {
+      const link = screen.getByRole('link', { name: 'Dashboard' });
+      expect(link).toBeTruthy();
+      expect(link).toHaveAttribute('href', '/dashboard');
+      expect(link).not.toHaveAttribute('aria-current');
+    });
+
+    it('shows "Collateral" as the current page (not a link)', () => {
+      // The last segment should NOT be an anchor
+      expect(screen.queryByRole('link', { name: 'Collateral' })).toBeNull();
+      const current = screen.getByText('Collateral');
+      expect(current).toHaveAttribute('aria-current', 'page');
+    });
+  });
+
+  // -- /dashboard/collateral/abc-123 --
+
+  describe('on /dashboard/collateral/abc-123', () => {
+    beforeEach(() => {
+      mockPathname = '/dashboard/collateral/abc-123';
+      render(<Breadcrumb />);
+    });
+
+    it('renders a breadcrumb nav', () => {
+      expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toBeTruthy();
+    });
+
+    it('shows "Dashboard" as a link to /dashboard', () => {
+      const link = screen.getByRole('link', { name: 'Dashboard' });
+      expect(link).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('shows "Collateral" as a link to /dashboard/collateral', () => {
+      const link = screen.getByRole('link', { name: 'Collateral' });
+      expect(link).toHaveAttribute('href', '/dashboard/collateral');
+    });
+
+    it('shows the dynamic ID segment as the current page (not a link)', () => {
+      expect(screen.queryByRole('link', { name: 'abc-123' })).toBeNull();
+      const current = screen.getByText('abc-123');
+      expect(current).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('does not mark ancestor links with aria-current', () => {
+      const dashLink = screen.getByRole('link', { name: 'Dashboard' });
+      const colLink = screen.getByRole('link', { name: 'Collateral' });
+      expect(dashLink).not.toHaveAttribute('aria-current');
+      expect(colLink).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  // -- Accessibility --
+
+  it('has no axe accessibility violations on /dashboard/collateral', async () => {
+    mockPathname = '/dashboard/collateral';
+    const { container } = render(<Breadcrumb />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe accessibility violations on /dashboard/collateral/abc-123', async () => {
+    mockPathname = '/dashboard/collateral/abc-123';
+    const { container } = render(<Breadcrumb />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,18 @@
+import Breadcrumb from '@/components/Breadcrumb';
+
+/**
+ * Shared layout for all /dashboard routes.
+ * The Breadcrumb component itself suppresses rendering on the top-level
+ * /dashboard page (≤1 path segment), so it only appears on nested pages
+ * like /dashboard/collateral and /dashboard/collateral/[id].
+ */
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <div className="mx-auto max-w-6xl px-4 pt-4">
+        <Breadcrumb />
+      </div>
+      {children}
+    </>
+  );
+}

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,74 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Human-readable label overrides for specific path segments.
+ * Dynamic segments (e.g. collateral IDs) fall back to the raw segment value.
+ */
+const SEGMENT_LABELS: Record<string, string> = {
+  dashboard: 'Dashboard',
+  collateral: 'Collateral',
+};
+
+interface Crumb {
+  label: string;
+  href: string;
+}
+
+/**
+ * Builds a crumb list from a pathname string.
+ * e.g. "/dashboard/collateral/abc-123" →
+ *   [{ label: 'Dashboard', href: '/dashboard' },
+ *    { label: 'Collateral', href: '/dashboard/collateral' },
+ *    { label: 'abc-123', href: '/dashboard/collateral/abc-123' }]
+ */
+export function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split('/').filter(Boolean);
+  return segments.map((segment, index) => {
+    const href = '/' + segments.slice(0, index + 1).join('/');
+    const label = SEGMENT_LABELS[segment] ?? segment;
+    return { label, href };
+  });
+}
+
+/**
+ * Renders a breadcrumb trail for the current route.
+ * Returns null when the path is not nested (≤1 segment deep),
+ * so it is invisible on top-level pages like /dashboard.
+ */
+export default function Breadcrumb() {
+  const pathname = usePathname();
+  const crumbs = buildCrumbs(pathname);
+
+  // Hide on top-level pages (e.g. /dashboard itself)
+  if (crumbs.length <= 1) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4">
+      <ol className="flex flex-wrap items-center gap-1 text-sm text-brown/70">
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1;
+          return (
+            <li key={crumb.href} className="flex items-center gap-1">
+              {index > 0 && (
+                <span aria-hidden="true" className="text-brown/40 select-none">
+                  /
+                </span>
+              )}
+              {isLast ? (
+                <span aria-current="page" className="font-medium text-brown">
+                  {crumb.label}
+                </span>
+              ) : (
+                <Link href={crumb.href} className="hover:text-brown hover:underline transition">
+                  {crumb.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
- Create Breadcrumb component (usePathname-based, exports buildCrumbs)
- Add dashboard layout.tsx to inject Breadcrumb on all /dashboard routes
- Hidden on top-level /dashboard page (≤1 path segment)
- Each ancestor segment is a link; current page has aria-current=page
- 15 unit tests: buildCrumbs logic, rendering, a11y (jest-axe)

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**


closes #543 
