### PR TITLE
feat(errors): custom 404/500/offline error page templates (#1097)

### DIFF
--- a/frontend/src/__tests__/ErrorPages.test.tsx
+++ b/frontend/src/__tests__/ErrorPages.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for error page templates — #1097
+ *
+ * Covers:
+ * - 404 page: search bar renders and navigates
+ * - app/error.tsx: shows error ID, try again, go home
+ * - OfflinePage: detects online state, auto-reload on reconnect
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: jest.fn(() => "/some/missing-page"),
+}));
+
+jest.mock("next/link", () => {
+  const MockLink = ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
+});
+
+// ── NotFoundSearch ────────────────────────────────────────────────────────────
+import NotFoundSearch from "../app/NotFoundSearch";
+
+describe("NotFoundSearch (#1097)", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("renders a search input and submit button", () => {
+    render(<NotFoundSearch />);
+    expect(screen.getByRole("searchbox")).toBeDefined();
+    expect(screen.getByRole("button", { name: /submit search/i })).toBeDefined();
+  });
+
+  it("has role='search' landmark", () => {
+    render(<NotFoundSearch />);
+    expect(screen.getByRole("search")).toBeDefined();
+  });
+
+  it("navigates to /help/faq with query on submit", async () => {
+    render(<NotFoundSearch />);
+    const input = screen.getByRole("searchbox");
+    await userEvent.type(input, "health factor");
+    await userEvent.click(screen.getByRole("button", { name: /submit search/i }));
+    expect(mockPush).toHaveBeenCalledWith(
+      "/help/faq?q=health%20factor"
+    );
+  });
+
+  it("does not navigate when query is empty", async () => {
+    render(<NotFoundSearch />);
+    await userEvent.click(screen.getByRole("button", { name: /submit search/i }));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+// ── not-found.tsx ─────────────────────────────────────────────────────────────
+import NotFound from "../app/not-found";
+
+describe("NotFound page with search bar (#1097)", () => {
+  it("renders a search bar", () => {
+    render(<NotFound />);
+    expect(screen.getByRole("searchbox")).toBeDefined();
+  });
+
+  it("renders Help & FAQ popular link", () => {
+    render(<NotFound />);
+    expect(screen.getByRole("link", { name: /help & faq/i })).toBeDefined();
+  });
+});
+
+// ── app/error.tsx ─────────────────────────────────────────────────────────────
+import RouteError from "../app/error";
+
+function makeError(message = "Unexpected failure", digest?: string) {
+  const err = new Error(message) as Error & { digest?: string };
+  if (digest) err.digest = digest;
+  return err;
+}
+
+describe("RouteError page (#1097)", () => {
+  const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  afterAll(() => consoleSpy.mockRestore());
+
+  it("renders the error heading", () => {
+    render(<RouteError error={makeError()} reset={jest.fn()} />);
+    expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeDefined();
+  });
+
+  it("renders 'Try again' button that calls reset", async () => {
+    const reset = jest.fn();
+    render(<RouteError error={makeError()} reset={reset} />);
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders 'Go home' link pointing to '/'", () => {
+    render(<RouteError error={makeError()} reset={jest.fn()} />);
+    const link = screen.getByRole("link", { name: /go home/i });
+    expect(link.getAttribute("href")).toBe("/");
+  });
+
+  it("shows support reference when digest is present", () => {
+    render(<RouteError error={makeError("Oops", "ABCDEFGH12345678")} reset={jest.fn()} />);
+    expect(screen.getByText(/support reference/i)).toBeDefined();
+    // The reference ID is derived from the last 8 chars of digest, uppercased with SK- prefix
+    expect(screen.getByText(/SK-/)).toBeDefined();
+  });
+});
+
+// ── offline page ──────────────────────────────────────────────────────────────
+import OfflinePage from "../app/offline/page";
+
+describe("OfflinePage (#1097)", () => {
+  const originalOnline = window.navigator.onLine;
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: originalOnline,
+    });
+  });
+
+  it("shows offline message when navigator.onLine is false", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: false,
+    });
+    render(<OfflinePage />);
+    expect(screen.getByRole("heading", { name: /you're offline/i })).toBeDefined();
+  });
+
+  it("shows auto-reconnect notice", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: false,
+    });
+    render(<OfflinePage />);
+    expect(
+      screen.getByText(/this page will reload automatically/i)
+    ).toBeDefined();
+  });
+
+  it("shows 'Back online!' heading when navigator.onLine is true", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: true,
+    });
+    render(<OfflinePage />);
+    expect(screen.getByRole("heading", { name: /back online/i })).toBeDefined();
+  });
+
+  it("shows 'back online' state after 'online' event fires", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: false,
+    });
+    render(<OfflinePage />);
+    expect(screen.getByRole("heading", { name: /you're offline/i })).toBeDefined();
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(screen.getByRole("heading", { name: /back online/i })).toBeDefined();
+  });
+
+  it("renders 'Try again' and 'Go home' buttons/links when offline", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      writable: true,
+      value: false,
+    });
+    render(<OfflinePage />);
+    expect(screen.getByRole("button", { name: /try again/i })).toBeDefined();
+    expect(screen.getByRole("link", { name: /go home/i })).toBeDefined();
+  });
+});

--- a/frontend/src/__tests__/NotFound.test.tsx
+++ b/frontend/src/__tests__/NotFound.test.tsx
@@ -12,6 +12,7 @@ import { render, screen } from "@testing-library/react";
 // ── Mock next/navigation ──────────────────────────────────────────────────────
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(() => "/some/invalid/path"),
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
 }));
 
 // ── Mock next/link ────────────────────────────────────────────────────────────

--- a/frontend/src/app/NotFoundSearch.tsx
+++ b/frontend/src/app/NotFoundSearch.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * NotFoundSearch — #1097
+ *
+ * A client-side search bar rendered on the 404 page.
+ * Submitting the form navigates to /help/faq with the query pre-filled,
+ * which is the closest discovery surface in the app.
+ */
+export default function NotFoundSearch() {
+  const [query, setQuery] = useState("");
+  const router = useRouter();
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+    router.push(`/help/faq?q=${encodeURIComponent(q)}`);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      role="search"
+      aria-label="Search StellarKraal"
+      className="w-full max-w-md"
+    >
+      <label htmlFor="not-found-search" className="sr-only">
+        Search StellarKraal
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="not-found-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search for help, loans, collateral…"
+          autoComplete="off"
+          className="flex-1 rounded-xl border border-brown/30 px-4 py-3 text-brown placeholder-brown/40
+            bg-white focus:outline-none focus:ring-2 focus:ring-gold/40 focus:border-gold transition text-sm"
+        />
+        <button
+          type="submit"
+          aria-label="Submit search"
+          className="bg-brown text-cream font-semibold px-5 py-3 rounded-xl hover:bg-brown/80
+            transition focus:outline-none focus:ring-2 focus:ring-gold text-sm"
+        >
+          Search
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+interface Props {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Route-level error boundary — #1097
+ *
+ * Shown when a server component in a route segment throws.
+ * Unlike global-error.tsx (which wraps the root layout), this component
+ * has access to the full layout so Navbar and shell remain visible.
+ *
+ * Shows:
+ *   - Friendly copy
+ *   - Error ID (digest) for support reference in production
+ *   - "Try again" button that calls reset()
+ *   - "Go home" link
+ */
+export default function RouteError({ error, reset }: Props) {
+  const referenceId = error.digest
+    ? `SK-${error.digest.slice(-8).toUpperCase()}`
+    : undefined;
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      console.error("[RouteError]", error, { referenceId });
+    }
+  }, [error, referenceId]);
+
+  return (
+    <div className="min-h-[70vh] flex flex-col items-center justify-center px-4 text-center">
+      {/* Illustration */}
+      <div aria-hidden="true" className="mb-8">
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 120 120"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="60" cy="60" r="56" fill="#FEF2F2" stroke="#DC2626" strokeWidth="3" />
+          <text
+            x="50%"
+            y="54%"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            fontSize="52"
+          >
+            ⚠️
+          </text>
+        </svg>
+      </div>
+
+      <p className="text-sm font-semibold uppercase tracking-widest text-red-500 mb-3">
+        Error 500
+      </p>
+
+      <h1
+        id="route-error-title"
+        className="text-3xl font-bold text-brown mb-3"
+      >
+        Something went wrong
+      </h1>
+
+      <p
+        id="route-error-description"
+        className="text-brown/60 max-w-md mb-6"
+      >
+        An unexpected error occurred on this page. You can try again or return
+        home. If the problem continues, share the reference ID with support.
+      </p>
+
+      {/* Support reference ID — shown in production */}
+      {referenceId && (
+        <div
+          aria-label="Support reference"
+          className="mb-6 rounded-lg border border-brown/20 bg-brown/5 px-5 py-4 text-left w-full max-w-sm"
+        >
+          <p className="text-xs font-medium uppercase tracking-widest text-brown/50 mb-1">
+            Support reference
+          </p>
+          <p className="font-mono text-sm text-brown">{referenceId}</p>
+        </div>
+      )}
+
+      {/* Dev-only: show error message */}
+      {process.env.NODE_ENV !== "production" && (
+        <div
+          aria-label="Development error details"
+          className="mb-6 rounded-lg border border-red-200 bg-red-50 px-5 py-4 text-left w-full max-w-sm"
+        >
+          <p className="text-xs font-medium uppercase tracking-widest text-red-400 mb-1">
+            Error
+          </p>
+          <p className="font-mono text-sm text-red-700 break-words">{error.message}</p>
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <button
+          onClick={reset}
+          className="bg-brown text-cream font-semibold px-6 py-3 rounded-xl hover:bg-brown/80
+            transition focus:outline-none focus:ring-2 focus:ring-gold"
+          type="button"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl
+            hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import NotFoundPath from "./NotFoundPath";
+import NotFoundSearch from "./NotFoundSearch";
 
 export const metadata: Metadata = {
   title: "404 Not Found — StellarKraal",
@@ -11,6 +12,7 @@ const NAV_LINKS = [
   { href: "/dashboard", label: "Dashboard", icon: "⊞" },
   { href: "/borrow", label: "Borrow", icon: "💰" },
   { href: "/collateral", label: "Collateral", icon: "🐄" },
+  { href: "/help/faq", label: "Help & FAQ", icon: "❓" },
 ] as const;
 
 export default function NotFound() {
@@ -51,8 +53,11 @@ export default function NotFound() {
         track.
       </p>
 
+      {/* Search bar — #1097 */}
+      <NotFoundSearch />
+
       {/* Navigation suggestions */}
-      <nav aria-label="Suggested pages" className="flex flex-col sm:flex-row gap-3">
+      <nav aria-label="Suggested pages" className="flex flex-wrap justify-center gap-3 mt-8">
         <Link
           href="/"
           className="bg-brown text-cream font-semibold px-6 py-3 rounded-xl hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-gold"

--- a/frontend/src/app/offline/page.tsx
+++ b/frontend/src/app/offline/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * OfflinePage — #1097
+ *
+ * Shown by the service worker when the user tries to navigate while offline.
+ * This component:
+ *   - Detects navigator.onLine on mount
+ *   - Listens for the 'online' event and auto-reloads when connectivity returns
+ *   - Shows a countdown / "reconnecting…" indicator
+ */
+export default function OfflinePage() {
+  const [isOnline, setIsOnline] = useState<boolean>(
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  );
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    function handleOnline() {
+      setIsOnline(true);
+      // Brief delay so the "Back online!" message is visible before reloading
+      setTimeout(() => {
+        window.location.reload();
+      }, 800);
+    }
+
+    function handleOffline() {
+      setIsOnline(false);
+    }
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  function handleRetry() {
+    setChecking(true);
+    setTimeout(() => {
+      setChecking(false);
+      window.location.reload();
+    }, 400);
+  }
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4 text-center"
+      style={{ backgroundColor: "var(--color-bg)", color: "var(--color-text)" }}
+    >
+      {/* Illustration */}
+      <div aria-hidden="true" className="mb-8">
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 120 120"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="60" cy="60" r="56" fill="#FDF6EC" stroke="#D4A017" strokeWidth="3" />
+          <text
+            x="50%"
+            y="54%"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            fontSize="44"
+          >
+            📡
+          </text>
+        </svg>
+      </div>
+
+      {isOnline ? (
+        <>
+          <h1 className="text-3xl font-bold text-brown mb-3">Back online!</h1>
+          <p className="text-brown/60 max-w-sm mb-6">
+            Your connection is restored. Reloading the page…
+          </p>
+          <div className="flex items-center gap-2 text-brown/50 text-sm">
+            <svg
+              className="animate-spin h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Reloading…
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="text-sm font-semibold uppercase tracking-widest text-gold mb-3">
+            No connection
+          </p>
+          <h1 className="text-3xl font-bold text-brown mb-3">
+            You&apos;re offline
+          </h1>
+          <p className="text-brown/60 max-w-sm mb-8">
+            StellarKraal needs an internet connection to show your loans and
+            collateral. Check your Wi-Fi or mobile data, then try again.
+          </p>
+
+          <div className="space-y-3 w-full max-w-xs">
+            <button
+              onClick={handleRetry}
+              disabled={checking}
+              className="w-full bg-brown text-cream font-semibold px-6 py-3 rounded-xl
+                hover:bg-brown/80 transition focus:outline-none focus:ring-2 focus:ring-gold
+                disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              type="button"
+            >
+              {checking ? (
+                <>
+                  <svg
+                    className="animate-spin h-4 w-4"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Checking…
+                </>
+              ) : (
+                "Try again"
+              )}
+            </button>
+            <a
+              href="/"
+              className="block w-full border border-brown/30 text-brown font-semibold px-6 py-3 rounded-xl
+                hover:border-brown/60 transition focus:outline-none focus:ring-2 focus:ring-gold text-center"
+            >
+              Go home
+            </a>
+          </div>
+
+          {/* Auto-reconnect notice */}
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-xs text-brown/40 mt-8"
+          >
+            This page will reload automatically when your connection returns.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- 404 page: add NotFoundSearch client component with search bar and popular links (Dashboard, Borrow, Collateral, Help & FAQ)
- Create app/error.tsx: route-level error boundary with error ID for support reference and Try again / Go home actions
- Create app/offline/page.tsx: offline detection via navigator.onLine, auto-reloads on 'online' event, retry and go-home buttons
- All pages match brand design (brown, cream, gold tokens)
- Fix NotFound.test.tsx to mock useRouter for new NotFoundSearch
- Add ErrorPages.test.tsx covering all three pages

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**

closes #1097

