### PR TITLE
feat(forms): add inline FieldTooltip to complex form fields (#1095)

### DIFF
--- a/frontend/src/__tests__/FieldTooltip.test.tsx
+++ b/frontend/src/__tests__/FieldTooltip.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for FieldTooltip component — #1095
+ *
+ * Verifies:
+ * - Tooltip hidden by default
+ * - Shows on hover (mouseenter/mouseleave)
+ * - Shows on keyboard focus/blur
+ * - Toggle on click
+ * - Closes on Escape
+ * - role='tooltip' and aria-describedby applied correctly
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FieldTooltip from "../components/FieldTooltip";
+
+const TOOLTIP_CONTENT = "LTV is how much you borrow vs your collateral value.";
+
+describe("FieldTooltip (#1095)", () => {
+  it("does not show tooltip content by default", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("renders the info icon button with default aria-label", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button", { name: /more information/i });
+    expect(btn).toBeDefined();
+  });
+
+  it("accepts a custom aria-label", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} label="What is LTV?" />);
+    const btn = screen.getByRole("button", { name: /what is ltv/i });
+    expect(btn).toBeDefined();
+  });
+
+  it("shows tooltip on mouseenter", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    fireEvent.mouseEnter(btn);
+    expect(screen.getByRole("tooltip")).toBeDefined();
+    expect(screen.getByText(TOOLTIP_CONTENT)).toBeDefined();
+  });
+
+  it("hides tooltip on mouseleave", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    fireEvent.mouseEnter(btn);
+    expect(screen.getByRole("tooltip")).toBeDefined();
+    fireEvent.mouseLeave(btn);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows tooltip on focus", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    expect(screen.getByRole("tooltip")).toBeDefined();
+  });
+
+  it("hides tooltip on blur", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    fireEvent.blur(btn);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("toggles tooltip on click", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    // First click: opens
+    fireEvent.click(btn);
+    expect(screen.getByRole("tooltip")).toBeDefined();
+    // Second click: closes
+    fireEvent.click(btn);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("closes tooltip on Escape keydown", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    expect(screen.getByRole("tooltip")).toBeDefined();
+    fireEvent.keyDown(btn, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("sets aria-describedby on button when tooltip is visible", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-describedby")).toBeNull();
+
+    fireEvent.mouseEnter(btn);
+    const describedBy = btn.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.id).toBe(describedBy);
+  });
+
+  it("sets aria-expanded=false by default and true when open", () => {
+    render(<FieldTooltip content={TOOLTIP_CONTENT} />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.mouseEnter(btn);
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/frontend/src/components/FieldTooltip.tsx
+++ b/frontend/src/components/FieldTooltip.tsx
@@ -1,0 +1,102 @@
+"use client";
+import { useState, useId } from "react";
+
+export interface FieldTooltipProps {
+  /** The tooltip text shown on hover/focus. Written at Grade 8 reading level. */
+  content: string;
+  /** Optional aria-label for the trigger button (defaults to "More information"). */
+  label?: string;
+}
+
+/**
+ * FieldTooltip — #1095
+ *
+ * An info-icon button that shows a tooltip for complex form field terms
+ * (LTV, health factor, origination fee, collateral value, etc.).
+ *
+ * Accessibility:
+ *  - Trigger button is keyboard-focusable
+ *  - Tooltip has role="tooltip" and is referenced by aria-describedby on the trigger
+ *  - Opens on hover (mouseenter/mouseleave) and keyboard focus (focus/blur)
+ *  - Toggle-able via Enter or Space
+ *  - Closes on Escape
+ */
+export default function FieldTooltip({ content, label = "More information" }: FieldTooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
+
+  function show() {
+    setVisible(true);
+  }
+
+  function hide() {
+    setVisible(false);
+  }
+
+  function toggle() {
+    setVisible((v) => !v);
+  }
+
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        aria-label={label}
+        aria-describedby={visible ? tooltipId : undefined}
+        aria-expanded={visible}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            hide();
+          }
+        }}
+        className="inline-flex items-center justify-center text-brown/50 hover:text-brown
+          transition focus:outline-none focus-visible:ring-2 focus-visible:ring-gold/60
+          focus-visible:ring-offset-1 rounded-full"
+      >
+        {/* Info circle icon */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </button>
+
+      {visible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2
+            w-56 sm:w-64 rounded-lg bg-brown-dark p-3 text-sm shadow-lg
+            text-white pointer-events-none"
+          style={{ backgroundColor: "#3D2810" }}
+        >
+          {content}
+          {/* Caret */}
+          <span
+            aria-hidden="true"
+            className="absolute left-1/2 -bottom-2 -translate-x-1/2
+              border-solid border-t-8 border-x-8 border-b-0
+              border-x-transparent"
+            style={{ borderTopColor: "#3D2810" }}
+          />
+        </div>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/LoanForm.tsx
+++ b/frontend/src/components/LoanForm.tsx
@@ -6,6 +6,7 @@ import { colors } from '@/lib/design-tokens';
 import Spinner from '@/components/Spinner';
 import { useToast } from '@/components/toast';
 import { Input, Select, ErrorSummary, toSummaryErrors } from '@/components/ui';
+import FieldTooltip from '@/components/FieldTooltip';
 import { useFetchWithRateLimit } from '@/hooks/useFetchWithRateLimit';
 import { useNetworkMismatch } from '@/hooks/useNetworkMismatch';
 
@@ -195,16 +196,27 @@ export default function LoanForm({ walletAddress, initialCollateralId }: Props) 
             error={submitted ? (collateralErrors.count ?? undefined) : undefined}
             disabled={loading}
           />
-          <Input
-            id={COLLATERAL_FIELD_IDS.appraisedValue}
-            label="Appraised Value (stroops)"
-            type="number"
-            placeholder="Total appraised value"
-            value={appraisedValue}
-            onChange={(e) => setAppraisedValue(e.target.value)}
-            error={submitted ? (collateralErrors.appraisedValue ?? undefined) : undefined}
-            disabled={loading}
-          />
+          {/* Appraised Value with tooltip — #1095 */}
+          <div>
+            <div className="flex items-center gap-1 mb-1">
+              <label htmlFor={COLLATERAL_FIELD_IDS.appraisedValue} className="text-sm font-medium text-brown-700">
+                Appraised Value (stroops)
+              </label>
+              <FieldTooltip
+                content="Collateral value is the total worth of your animals as determined by the appraiser. Your maximum loan is 70% of this amount."
+                label="What is Appraised Value?"
+              />
+            </div>
+            <Input
+              id={COLLATERAL_FIELD_IDS.appraisedValue}
+              type="number"
+              placeholder="Total appraised value"
+              value={appraisedValue}
+              onChange={(e) => setAppraisedValue(e.target.value)}
+              error={submitted ? (collateralErrors.appraisedValue ?? undefined) : undefined}
+              disabled={loading}
+            />
+          </div>
           <button
             type="submit"
             disabled={loading || isRateLimited || networkMismatch}

--- a/frontend/src/components/wizard/steps/StepAmount.tsx
+++ b/frontend/src/components/wizard/steps/StepAmount.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useWizard } from '@/context/LoanWizardContext';
 import { GlossaryTerm } from '@/components/GlossaryTerm';
+import FieldTooltip from '@/components/FieldTooltip';
 import { Input, Button } from '@/components/ui';
 import { formatXlmFromStroops } from '@/lib/formatMoney';
 
@@ -73,8 +74,13 @@ export default function StepAmount() {
         {loanAmount && maxLoan > 0 && (
           <div className="mt-2">
             <div className="flex justify-between text-xs text-brown-400 mb-1">
-              <span>
-                <GlossaryTerm termKey="ltv">LTV</GlossaryTerm>: {ltv}%
+              <span className="flex items-center gap-1">
+                <GlossaryTerm termKey="ltv">LTV</GlossaryTerm>
+                <FieldTooltip
+                  content="Loan-to-Value (LTV) is how much you borrow compared to your collateral's value. A lower LTV means less risk and more room before liquidation."
+                  label="What is LTV?"
+                />
+                : {ltv}%
               </span>
               <span>Max: 70%</span>
             </div>
@@ -118,8 +124,12 @@ export default function StepAmount() {
       {/* Health factor preview */}
       {healthFactor && (
         <div className="bg-white border border-brown/20 rounded-xl px-4 py-3 flex justify-between items-center">
-          <span className="text-sm text-brown/70">
+          <span className="text-sm text-brown/70 flex items-center gap-1">
             <GlossaryTerm termKey="healthFactor">Est. Health Factor</GlossaryTerm>
+            <FieldTooltip
+              content="Health Factor measures how safe your loan is. Above 1.5 is safe (green), 1.0–1.5 needs watching (yellow), below 1.0 risks liquidation (red)."
+              label="What is Health Factor?"
+            />
           </span>
           <span className={`font-bold text-lg ${healthColor}`}>{healthFactor}</span>
         </div>

--- a/frontend/src/components/wizard/steps/StepReview.tsx
+++ b/frontend/src/components/wizard/steps/StepReview.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useWizard } from '@/context/LoanWizardContext';
 import { GlossaryTerm } from '@/components/GlossaryTerm';
+import FieldTooltip from '@/components/FieldTooltip';
 import { Button } from '@/components/ui';
 import { useCurrencyConversion } from '@/hooks/useCurrencyConversion';
 
@@ -107,11 +108,33 @@ export default function StepReview() {
       value: `${ANIMAL_EMOJI[animalType]} ${animalType.charAt(0).toUpperCase() + animalType.slice(1)}`,
     },
     { label: 'Animal Count', value: count },
-    { label: 'Appraised Value', value: `${parseInt(appraisedValue || '0').toLocaleString()} stroops` },
+    {
+      label: (
+        <span className="flex items-center gap-1">
+          Appraised Value
+          <FieldTooltip
+            content="Collateral value is the total worth of your animals as determined by the appraiser. Your maximum loan is 70% of this amount."
+            label="What is Collateral Value?"
+          />
+        </span>
+      ),
+      value: `${parseInt(appraisedValue || '0').toLocaleString()} stroops`,
+    },
     { label: <GlossaryTerm termKey="loanAmount">Loan Amount</GlossaryTerm>, value: `${principal.toLocaleString()} stroops` },
     { label: 'Loan Term', value: `${loanTermDays} days` },
     { label: <GlossaryTerm termKey="feeRate">Fee Rate</GlossaryTerm>, value: rate },
-    { label: 'Fee Amount', value: `${fee.toLocaleString()} stroops` },
+    {
+      label: (
+        <span className="flex items-center gap-1">
+          <GlossaryTerm termKey="feeRate">Fee Amount</GlossaryTerm>
+          <FieldTooltip
+            content="Origination fee is a one-time charge added to your loan when it's issued. It covers the cost of processing your loan application."
+            label="What is Origination Fee?"
+          />
+        </span>
+      ),
+      value: `${fee.toLocaleString()} stroops`,
+    },
     {
       label: (
         <span className="flex items-center">


### PR DESCRIPTION
- Create FieldTooltip component: info-icon button with role=tooltip, aria-describedby, keyboard accessible (hover/focus/click/Escape)
- Tooltip content written at Grade 8 reading level
- Integrate into StepAmount: LTV (loan-to-value) and Health Factor fields
- Integrate into StepReview: Collateral Value and Origination Fee rows
- Integrate into LoanForm: Appraised Value field in collateral registration
- Add FieldTooltip.test.tsx covering all accessibility and interaction cases

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**

closes #1095

