### PR TITLE
feat(print): enhance loan summary print stylesheet (#1096)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -520,6 +520,96 @@ body {
     page-break-inside: avoid;
   }
 
+  /* ── Loan summary specific print layout — #1096 ── */
+
+  /* Loan summary section wrapper — targets LoanSummaryCards and LoanDetail */
+  .loan-summary-print,
+  [data-print-section="loan-summary"] {
+    display: block !important;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Loan summary table: clear layout for principal, status, dates, health factor */
+  .loan-summary-print table,
+  [data-print-section="loan-summary"] table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+  }
+
+  .loan-summary-print th,
+  .loan-summary-print td,
+  [data-print-section="loan-summary"] th,
+  [data-print-section="loan-summary"] td {
+    border: 1px solid #999;
+    padding: 0.5rem 0.625rem;
+    text-align: left;
+  }
+
+  .loan-summary-print th,
+  [data-print-section="loan-summary"] th {
+    background: #f5f5f5 !important;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #333 !important;
+  }
+
+  /* Key fields row highlight */
+  .loan-summary-print tr.loan-summary-highlight td,
+  [data-print-section="loan-summary"] tr.loan-summary-highlight td {
+    background: #fefaf3 !important;
+    font-weight: 600;
+  }
+
+  /* Health factor — keep colour cues in greyscale print */
+  .loan-summary-print .health-factor-safe,
+  [data-print-section="loan-summary"] .health-factor-safe {
+    font-weight: 700;
+  }
+
+  /* Loan amount — large, prominent */
+  .loan-summary-print .loan-amount-print,
+  [data-print-section="loan-summary"] .loan-amount-print {
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+
+  /* Status badge — readable text only */
+  .loan-summary-print .status-badge,
+  [data-print-section="loan-summary"] .status-badge {
+    border: 1px solid #999 !important;
+    background: none !important;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  /* Hide action buttons and health gauge animation inside loan summary */
+  .loan-summary-print button,
+  .loan-summary-print [role="progressbar"],
+  .loan-summary-print canvas,
+  [data-print-section="loan-summary"] button,
+  [data-print-section="loan-summary"] [role="progressbar"],
+  [data-print-section="loan-summary"] canvas {
+    display: none !important;
+  }
+
+  /* Collateral detail card inside loan summary */
+  .loan-summary-print .collateral-print-row,
+  [data-print-section="loan-summary"] .collateral-print-row {
+    border-top: 1px solid #ccc;
+    padding-top: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  /* ── End loan summary print styles — #1096 ── */
+
   /* Tables inside loan summaries */
   table {
     width: 100%;

--- a/frontend/src/components/LoanSummaryCards.tsx
+++ b/frontend/src/components/LoanSummaryCards.tsx
@@ -63,7 +63,7 @@ const METRICS: {
  */
 export default function LoanSummaryCards({ summary }: LoanSummaryCardsProps) {
   return (
-    <section aria-label="Loan summary">
+    <section aria-label="Loan summary" data-print-section="loan-summary" className="loan-summary-print">
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {METRICS.map(({ key, label, formatter, ariaLabel }) => (
           <Card key={key}>


### PR DESCRIPTION
- Add .loan-summary-print and [data-print-section=loan-summary] selectors to globals.css @media print block
- Table layout with bordered cells for loan amount, status, health factor
- Status badge styled for greyscale print
- Loan amount printed large and bold
- Collateral detail row separator for print
- Hide buttons, progress bars, and canvas elements inside loan summary
- Add data-print-section='loan-summary' attribute to LoanSummaryCards so the enhanced print CSS targets it correctly
- Nav, buttons, and banners remain hidden in all print views

## Summary

Please describe the change and why it is needed.

## Related Issue

Fixes #

## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**



closes #1096