### PR TITLE
feat(wallet): add copy button with tooltip to WalletHeader

### DIFF
--- a/frontend/src/__tests__/WalletHeaderCopyButton.test.tsx
+++ b/frontend/src/__tests__/WalletHeaderCopyButton.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Tests for Issue 2 – WalletHeader always-visible copy button
+ *
+ * Verifies:
+ *  - Copy button is visible in the header bar when wallet is connected (no popover needed)
+ *  - Clicking copy button calls clipboard.writeText with full address
+ *  - Tooltip shows "Copied!" for 2 s after click
+ *  - Button has aria-label="Copy wallet address"
+ *  - Button is keyboard accessible (Enter key triggers click)
+ *  - Graceful fallback when Clipboard API throws
+ */
+import React from 'react';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import WalletHeader from '@/components/WalletHeader';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockConnect = jest.fn();
+const mockDisconnect = jest.fn();
+
+const TEST_ADDRESS = 'GABCDEFGHIJ1234567890ABCDEFGHIJ1234567890ABCDEFGHIJKLMNO';
+
+let walletState = {
+  address: null as string | null,
+  freighterInstalled: null as boolean | null,
+  connecting: false,
+  error: null,
+  connect: mockConnect,
+  disconnect: mockDisconnect,
+};
+
+jest.mock('@/hooks/useWallet', () => ({
+  useWallet: () => walletState,
+}));
+
+// Mock fetch for Horizon balance – return immediately
+const mockFetch = jest.fn().mockResolvedValue({
+  ok: true,
+  json: async () => ({
+    balances: [{ asset_type: 'native', balance: '100.0000000' }],
+  }),
+});
+global.fetch = mockFetch;
+
+// Mock clipboard
+const mockWriteText = jest.fn();
+
+function renderConnectedHeader() {
+  walletState = {
+    address: TEST_ADDRESS,
+    freighterInstalled: true,
+    connecting: false,
+    error: null,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+  };
+  return render(<WalletHeader />);
+}
+
+describe('WalletHeader – header copy button (Issue 2)', () => {
+  beforeEach(() => {
+    mockWriteText.mockReset();
+    mockFetch.mockClear();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      writable: true,
+    });
+    jest.clearAllMocks();
+    // Re-assign fetch after clearAllMocks
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        balances: [{ asset_type: 'native', balance: '100.0000000' }],
+      }),
+    });
+  });
+
+  it('renders copy button in the header bar when wallet is connected', async () => {
+    await act(async () => {
+      renderConnectedHeader();
+    });
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    expect(copyBtn).toBeInTheDocument();
+  });
+
+  it('copy button has aria-label="Copy wallet address"', async () => {
+    await act(async () => {
+      renderConnectedHeader();
+    });
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    expect(copyBtn).toHaveAttribute('aria-label', 'Copy wallet address');
+  });
+
+  it('clicking copy button writes full address to clipboard', async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    await act(async () => {
+      renderConnectedHeader();
+    });
+
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(TEST_ADDRESS);
+    });
+  });
+
+  it('tooltip shows "Copied!" after clicking copy button', async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    await act(async () => {
+      renderConnectedHeader();
+    });
+
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Copied!');
+    });
+  });
+
+  it('tooltip disappears after 2 s', async () => {
+    jest.useFakeTimers();
+    mockWriteText.mockResolvedValue(undefined);
+    await act(async () => {
+      renderConnectedHeader();
+    });
+
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    // tooltip should be present
+    await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
+
+    // Advance 2 s
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+    jest.useRealTimers();
+  });
+
+  it('copy button is keyboard accessible', async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    await act(async () => {
+      renderConnectedHeader();
+    });
+
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+    // Focus the button
+    copyBtn.focus();
+    expect(document.activeElement).toBe(copyBtn);
+
+    // Simulate keyboard activation via click (browser fires click on Enter for buttons)
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(TEST_ADDRESS);
+    });
+  });
+
+  it('graceful fallback when Clipboard API throws', async () => {
+    mockWriteText.mockRejectedValue(new Error('NotAllowedError'));
+    await act(async () => {
+      renderConnectedHeader();
+    });
+
+    const copyBtn = screen.getByTestId('wallet-header-copy-btn');
+
+    // Should not throw
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    // tooltip should NOT show on failure
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render header copy button when wallet is not connected', async () => {
+    walletState = {
+      address: null,
+      freighterInstalled: true,
+      connecting: false,
+      error: null,
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+    };
+    await act(async () => {
+      render(<WalletHeader />);
+    });
+    expect(screen.queryByTestId('wallet-header-copy-btn')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/WalletHeader.tsx
+++ b/frontend/src/components/WalletHeader.tsx
@@ -115,7 +115,60 @@ export default function WalletHeader() {
 
       <div className="text-sm relative">
         {address ? (
-          <div className="relative">
+          <div className="relative flex items-center gap-1">
+            {/* Always-visible copy button in header bar */}
+            <div className="relative">
+              <button
+                onClick={copyAddress}
+                aria-label="Copy wallet address"
+                title={copied ? 'Copied!' : 'Copy wallet address'}
+                data-testid="wallet-header-copy-btn"
+                className="text-cream/70 hover:text-cream transition focus:outline-none focus-visible:ring-2 focus-visible:ring-cream/60 rounded p-1"
+              >
+                {copied ? (
+                  /* checkmark icon */
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4 text-green-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  /* clipboard icon */
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+                    />
+                  </svg>
+                )}
+              </button>
+              {/* Tooltip */}
+              {copied && (
+                <span
+                  role="tooltip"
+                  className="absolute right-0 top-full mt-1 whitespace-nowrap rounded-md bg-brown-900 px-2 py-1 text-xs text-cream shadow-lg pointer-events-none z-50"
+                  style={{ background: 'rgba(30,20,10,0.85)' }}
+                >
+                  Copied!
+                </span>
+              )}
+            </div>
+
             {/* Trigger button */}
             <button
               ref={triggerRef}


### PR DESCRIPTION
- Add always-visible copy button in the header bar next to the truncated wallet address (previously copy was only inside the popover)
- Clicking the button writes the full address to clipboard via the Clipboard API
- Shows a 'Copied!' tooltip for 2s after a successful copy, then hides
- Button has aria-label='Copy wallet address' for screen-reader support
- Button is keyboard accessible; includes focus-visible ring
- Graceful fallback: clipboard errors are caught silently with no tooltip
- Add WalletHeaderCopyButton.test.tsx with 7 tests covering all acceptance criteria



## Changes

- 
- 
- 

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**

closes #555 



