### PR TITLE
feat(autosave): add Draft saved indicator to useFormAutoSave

### DIFF
--- a/frontend/src/__tests__/useFormAutoSave.test.ts
+++ b/frontend/src/__tests__/useFormAutoSave.test.ts
@@ -1,9 +1,9 @@
-import { renderHook, act } from "@testing-library/react";
-import { useFormAutoSave } from "@/hooks/useFormAutoSave";
+import { renderHook, act } from '@testing-library/react';
+import { useFormAutoSave } from '@/hooks/useFormAutoSave';
 
-describe("useFormAutoSave", () => {
-  const storageKey = "test_form";
-  const walletAddress = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+describe('useFormAutoSave', () => {
+  const storageKey = 'test_form';
+  const walletAddress = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
 
   beforeEach(() => {
     localStorage.clear();
@@ -14,11 +14,11 @@ describe("useFormAutoSave", () => {
     jest.useRealTimers();
   });
 
-  it("auto-saves data after interval", () => {
-    const { result } = renderHook(() =>
+  it('auto-saves data after interval', () => {
+    renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "value1", field2: "value2" },
+        data: { field1: 'value1', field2: 'value2' },
         walletAddress,
         interval: 5000,
       })
@@ -31,15 +31,15 @@ describe("useFormAutoSave", () => {
     const saved = localStorage.getItem(storageKey);
     expect(saved).toBeTruthy();
     const parsed = JSON.parse(saved!);
-    expect(parsed.data.field1).toBe("value1");
+    expect(parsed.data.field1).toBe('value1');
     expect(parsed.walletAddress).toBe(walletAddress);
   });
 
-  it("does not save empty data", () => {
+  it('does not save empty data', () => {
     renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "", field2: "" },
+        data: { field1: '', field2: '' },
         walletAddress,
       })
     );
@@ -51,12 +51,12 @@ describe("useFormAutoSave", () => {
     expect(localStorage.getItem(storageKey)).toBeNull();
   });
 
-  it("detects existing saved data on mount", () => {
+  it('detects existing saved data on mount', () => {
     localStorage.setItem(
       storageKey,
       JSON.stringify({
         walletAddress,
-        data: { field1: "saved" },
+        data: { field1: 'saved' },
         timestamp: new Date().toISOString(),
       })
     );
@@ -64,7 +64,7 @@ describe("useFormAutoSave", () => {
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "" },
+        data: { field1: '' },
         walletAddress,
       })
     );
@@ -72,8 +72,8 @@ describe("useFormAutoSave", () => {
     expect(result.current.hasSavedData).toBe(true);
   });
 
-  it("restores saved data", () => {
-    const savedData = { field1: "restored", field2: "data" };
+  it('restores saved data', () => {
+    const savedData = { field1: 'restored', field2: 'data' };
     localStorage.setItem(
       storageKey,
       JSON.stringify({
@@ -86,22 +86,25 @@ describe("useFormAutoSave", () => {
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "", field2: "" },
+        data: { field1: '', field2: '' },
         walletAddress,
       })
     );
 
-    const restored = result.current.restoreSavedData();
+    let restored: typeof savedData | null = null;
+    act(() => {
+      restored = result.current.restoreSavedData();
+    });
     expect(restored).toEqual(savedData);
     expect(result.current.hasSavedData).toBe(false);
   });
 
-  it("clears saved data", () => {
+  it('clears saved data', () => {
     localStorage.setItem(
       storageKey,
       JSON.stringify({
         walletAddress,
-        data: { field1: "value" },
+        data: { field1: 'value' },
         timestamp: new Date().toISOString(),
       })
     );
@@ -109,7 +112,7 @@ describe("useFormAutoSave", () => {
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "value" },
+        data: { field1: 'value' },
         walletAddress,
       })
     );
@@ -122,11 +125,11 @@ describe("useFormAutoSave", () => {
     expect(result.current.hasSavedData).toBe(false);
   });
 
-  it("updates lastSaved timestamp", () => {
+  it('updates lastSaved timestamp', () => {
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "value" },
+        data: { field1: 'value' },
         walletAddress,
         interval: 5000,
       })
@@ -141,11 +144,11 @@ describe("useFormAutoSave", () => {
     expect(result.current.lastSaved).toBeInstanceOf(Date);
   });
 
-  it("respects enabled flag", () => {
+  it('respects enabled flag', () => {
     renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "value" },
+        data: { field1: 'value' },
         walletAddress,
         enabled: false,
       })
@@ -158,12 +161,12 @@ describe("useFormAutoSave", () => {
     expect(localStorage.getItem(storageKey)).toBeNull();
   });
 
-  it("only restores data for matching wallet address", () => {
+  it('only restores data for matching wallet address', () => {
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        walletAddress: "DIFFERENT_ADDRESS",
-        data: { field1: "value" },
+        walletAddress: 'DIFFERENT_ADDRESS',
+        data: { field1: 'value' },
         timestamp: new Date().toISOString(),
       })
     );
@@ -171,7 +174,7 @@ describe("useFormAutoSave", () => {
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "" },
+        data: { field1: '' },
         walletAddress,
       })
     );
@@ -181,13 +184,13 @@ describe("useFormAutoSave", () => {
     expect(restored).toBeNull();
   });
 
-  it("handles invalid JSON gracefully", () => {
-    localStorage.setItem(storageKey, "invalid json");
+  it('handles invalid JSON gracefully', () => {
+    localStorage.setItem(storageKey, 'invalid json');
 
     const { result } = renderHook(() =>
       useFormAutoSave({
         storageKey,
-        data: { field1: "" },
+        data: { field1: '' },
         walletAddress,
       })
     );
@@ -195,7 +198,7 @@ describe("useFormAutoSave", () => {
     expect(result.current.hasSavedData).toBe(false);
   });
 
-  it("saves data with updated values", () => {
+  it('saves data with updated values', () => {
     const { rerender } = renderHook(
       ({ data }) =>
         useFormAutoSave({
@@ -205,7 +208,7 @@ describe("useFormAutoSave", () => {
           interval: 5000,
         }),
       {
-        initialProps: { data: { field1: "initial" } },
+        initialProps: { data: { field1: 'initial' } },
       }
     );
 
@@ -214,15 +217,143 @@ describe("useFormAutoSave", () => {
     });
 
     let saved = JSON.parse(localStorage.getItem(storageKey)!);
-    expect(saved.data.field1).toBe("initial");
+    expect(saved.data.field1).toBe('initial');
 
-    rerender({ data: { field1: "updated" } });
+    rerender({ data: { field1: 'updated' } });
 
     act(() => {
       jest.advanceTimersByTime(5000);
     });
 
     saved = JSON.parse(localStorage.getItem(storageKey)!);
-    expect(saved.data.field1).toBe("updated");
+    expect(saved.data.field1).toBe('updated');
+  });
+
+  // ── Draft saved indicator ──────────────────────────────────────────────────
+
+  describe('draftSaved indicator', () => {
+    it('is false initially', () => {
+      const { result } = renderHook(() =>
+        useFormAutoSave({
+          storageKey,
+          data: { field1: 'hello' },
+          walletAddress,
+        })
+      );
+
+      expect(result.current.draftSaved).toBe(false);
+    });
+
+    it('becomes true 1 s after the last data change', () => {
+      const { result } = renderHook(() =>
+        useFormAutoSave({
+          storageKey,
+          data: { field1: 'hello' },
+          walletAddress,
+        })
+      );
+
+      // Before 1 s – still false
+      act(() => {
+        jest.advanceTimersByTime(999);
+      });
+      expect(result.current.draftSaved).toBe(false);
+
+      // After 1 s – true
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(result.current.draftSaved).toBe(true);
+    });
+
+    it('resets to false after 3 s of being visible', () => {
+      const { result } = renderHook(() =>
+        useFormAutoSave({
+          storageKey,
+          data: { field1: 'hello' },
+          walletAddress,
+        })
+      );
+
+      // Show the indicator
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(result.current.draftSaved).toBe(true);
+
+      // After another 3 s it should hide
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(result.current.draftSaved).toBe(false);
+    });
+
+    it('debounces: does not show indicator until typing pauses for 1 s', () => {
+      const { result, rerender } = renderHook(
+        ({ data }) =>
+          useFormAutoSave({
+            storageKey,
+            data,
+            walletAddress,
+          }),
+        { initialProps: { data: { field1: 'a' } } }
+      );
+
+      // Simulate rapid keystrokes at 400 ms intervals
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      rerender({ data: { field1: 'ab' } });
+
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      rerender({ data: { field1: 'abc' } });
+
+      // Only 400 ms since last change — still false
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      expect(result.current.draftSaved).toBe(false);
+
+      // Now let 1 s pass with no further changes
+      act(() => {
+        jest.advanceTimersByTime(600);
+      });
+      expect(result.current.draftSaved).toBe(true);
+    });
+
+    it('does not show indicator when enabled is false', () => {
+      const { result } = renderHook(() =>
+        useFormAutoSave({
+          storageKey,
+          data: { field1: 'hello' },
+          walletAddress,
+          enabled: false,
+        })
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.draftSaved).toBe(false);
+    });
+
+    it('does not show indicator for empty data', () => {
+      const { result } = renderHook(() =>
+        useFormAutoSave({
+          storageKey,
+          data: { field1: '' },
+          walletAddress,
+        })
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.draftSaved).toBe(false);
+    });
   });
 });

--- a/frontend/src/hooks/useFormAutoSave.ts
+++ b/frontend/src/hooks/useFormAutoSave.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from 'react';
 
 interface AutoSaveOptions<T> {
   storageKey: string;
@@ -14,7 +14,13 @@ interface SavedData<T> {
   timestamp: string;
 }
 
-export function useFormAutoSave<T extends Record<string, any>>({
+/** How long after the last data change before showing the indicator (ms). */
+const DRAFT_SAVED_DEBOUNCE_MS = 1000;
+
+/** How long the indicator stays visible before fading out (ms). */
+const DRAFT_SAVED_VISIBLE_MS = 3000;
+
+export function useFormAutoSave<T extends Record<string, unknown>>({
   storageKey,
   data,
   enabled = true,
@@ -23,6 +29,11 @@ export function useFormAutoSave<T extends Record<string, any>>({
 }: AutoSaveOptions<T>) {
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [hasSavedData, setHasSavedData] = useState(false);
+  /** True while the "Draft saved" indicator should be visible. */
+  const [draftSaved, setDraftSaved] = useState(false);
+
+  // Ref to hold the debounce timer ID so we can cancel it on re-runs.
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Check for saved data on mount
   useEffect(() => {
@@ -33,19 +44,19 @@ export function useFormAutoSave<T extends Record<string, any>>({
         if (!walletAddress || parsed.walletAddress === walletAddress) {
           setHasSavedData(true);
         }
-      } catch (e) {
-        // Invalid saved data
+      } catch {
+        // Invalid saved data — ignore
       }
     }
   }, [storageKey, walletAddress]);
 
-  // Auto-save
+  // Auto-save on interval
   useEffect(() => {
     if (!enabled) return;
 
     const hasData = Object.values(data).some((value) => {
-      if (typeof value === "string") return value.trim().length > 0;
-      if (typeof value === "number") return true;
+      if (typeof value === 'string') return value.trim().length > 0;
+      if (typeof value === 'number') return true;
       return Boolean(value);
     });
 
@@ -66,6 +77,48 @@ export function useFormAutoSave<T extends Record<string, any>>({
     return () => clearInterval(interval_id);
   }, [data, enabled, interval, storageKey, walletAddress]);
 
+  // Debounced "Draft saved" indicator —
+  // shows 1 s after the last change to `data`.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const hasData = Object.values(data).some((value) => {
+      if (typeof value === 'string') return value.trim().length > 0;
+      if (typeof value === 'number') return true;
+      return Boolean(value);
+    });
+
+    if (!hasData) return;
+
+    // Cancel any pending debounce from a previous render
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      setDraftSaved(true);
+      debounceTimerRef.current = null;
+    }, DRAFT_SAVED_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, [data, enabled]);
+
+  // Fade-out timer — fires 3 s after the indicator becomes visible.
+  useEffect(() => {
+    if (!draftSaved) return;
+
+    const fadeId = setTimeout(() => {
+      setDraftSaved(false);
+    }, DRAFT_SAVED_VISIBLE_MS);
+
+    return () => clearTimeout(fadeId);
+  }, [draftSaved]);
+
   const restoreSavedData = (): T | null => {
     const saved = localStorage.getItem(storageKey);
     if (!saved) return null;
@@ -77,7 +130,7 @@ export function useFormAutoSave<T extends Record<string, any>>({
       }
       setHasSavedData(false);
       return parsed.data;
-    } catch (e) {
+    } catch {
       return null;
     }
   };
@@ -91,6 +144,7 @@ export function useFormAutoSave<T extends Record<string, any>>({
   return {
     lastSaved,
     hasSavedData,
+    draftSaved,
     restoreSavedData,
     clearSavedData,
   };


### PR DESCRIPTION
- Add draftSaved boolean to hook return value
- Show indicator 1 s after the last data change (debounced)
- Automatically hide indicator after 3 s via a separate fade-out effect
- Use a ref to track the debounce timer for safe cancellation on re-runs
- Indicator stays false when enabled=false or data is empty
- Fix pre-existing test: wrap restoreSavedData() call in act()
- Add 6 new unit tests for draftSaved acceptance criteria:
    * initial state is false
    * becomes true after 1 s debounce
    * resets to false after 3 s of being visible
    * debounce resets on rapid keystrokes (typing scenario)
    * stays false when enabled is false
    * stays false for empty data

Consumers render the indicator with aria-live='polite':
  {draftSaved && <span aria-live='polite'>Draft saved</span>}



## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**

closes #549 



