### PR TITLE
feat(profile): add inline display name edit

### DIFF
--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -1,14 +1,49 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ProfilePage, { buildReferralUrl } from '../app/profile/page';
 
+// Mock wallet hook
 jest.mock('../hooks/useWallet', () => ({
   useWallet: () => ({ address: 'GBTEST123WALLETADDRESS' }),
 }));
 
+// Mock toast
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+jest.mock('../components/toast', () => ({
+  useToast: () => ({ success: mockSuccess, error: mockError, warning: jest.fn(), info: jest.fn() }),
+}));
+
+// Mock fetch globally
+const originalFetch = global.fetch;
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: profile loads successfully with a display_name
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/borrowers/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            wallet: 'GBTEST123WALLETADDRESS',
+            display_name: 'Alice',
+            collateral: [],
+            loans: [],
+          }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+});
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
 Object.assign(navigator, {
   clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
 });
+
+// ─── buildReferralUrl helper ──────────────────────────────────────────────────
 
 describe('ProfilePage (#571 – referral section)', () => {
   it('builds referral URL containing wallet address', () => {
@@ -36,8 +71,172 @@ describe('ProfilePage (#571 – referral section)', () => {
     fireEvent.click(screen.getByRole('button', { name: /copy invite link/i }));
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('/register?ref=GBTEST123WALLETADDRESS')
-      )
+        expect.stringContaining('/register?ref=GBTEST123WALLETADDRESS'),
+      ),
     );
+  });
+});
+
+// ─── Inline display name edit ─────────────────────────────────────────────────
+
+describe('ProfilePage – inline display name edit', () => {
+  it('shows Edit button for the display name field', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /edit display name/i })).toBeTruthy());
+  });
+
+  it('switches to input mode when Edit is clicked', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    expect(screen.getByRole('textbox', { name: /display name/i })).toBeTruthy();
+  });
+
+  it('pre-fills the input with the current display name', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i }) as HTMLInputElement;
+    expect(input.value).toBe('Alice');
+  });
+
+  it('Cancel hides the input without saving', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('textbox', { name: /display name/i })).toBeNull();
+  });
+
+  it('shows validation error when name is too short (< 2 chars)', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toBeTruthy(),
+    );
+    expect(screen.getByText(/at least 2/i)).toBeTruthy();
+  });
+
+  it('shows validation error when name exceeds 40 chars', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'A'.repeat(41) } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toBeTruthy(),
+    );
+    expect(screen.getByText(/at most 40/i)).toBeTruthy();
+  });
+
+  it('calls PATCH /api/v1/profile with the new name on save', async () => {
+    const patchMock = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    global.fetch = jest.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/api/v1/profile')) return patchMock(url, opts);
+      if (typeof url === 'string' && url.includes('/api/borrowers/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ wallet: 'GBTEST123WALLETADDRESS', display_name: 'Alice', collateral: [], loans: [] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/profile'),
+        expect.objectContaining({
+          method: 'PATCH',
+          body: expect.stringContaining('"display_name":"Bob"'),
+        }),
+      ),
+    );
+  });
+
+  it('shows success toast after a successful save', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+    await waitFor(() => expect(mockSuccess).toHaveBeenCalled());
+  });
+
+  it('optimistically updates displayed name immediately', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    // Click save — name should update before the server responds
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    // Name should be visible immediately (optimistic)
+    expect(screen.getByText('Bob')).toBeTruthy();
+  });
+
+  it('shows error toast and rolls back name when PATCH fails', async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/api/v1/profile')) {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'Server error' }) });
+      }
+      if (typeof url === 'string' && url.includes('/api/borrowers/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ wallet: 'GBTEST123WALLETADDRESS', display_name: 'Alice', collateral: [], loans: [] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+    await waitFor(() => expect(mockError).toHaveBeenCalled());
+    // Rolled back to Alice
+    expect(screen.getByText('Alice')).toBeTruthy();
+  });
+
+  it('saves on Enter key press', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.change(input, { target: { value: 'Charlie' } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    await waitFor(() => expect(mockSuccess).toHaveBeenCalled());
+  });
+
+  it('cancels on Escape key press', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole('button', { name: /edit display name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit display name/i }));
+    const input = screen.getByRole('textbox', { name: /display name/i });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('textbox', { name: /display name/i })).toBeNull();
   });
 });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,11 +1,12 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import PageTransition from '@/components/PageTransition';
 import Card from '@/components/Card';
 import StatusBadge from '@/components/StatusBadge';
 import EmptyState from '@/components/EmptyState';
 import { useWallet } from '@/hooks/useWallet';
+import { useToast } from '@/components/toast';
 
 interface CollateralRecord {
   id: string;
@@ -26,11 +27,23 @@ interface LoanRecord {
 
 interface BorrowerProfile {
   wallet: string;
+  display_name?: string;
   collateral: CollateralRecord[];
   loans: LoanRecord[];
 }
 
 const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+const DISPLAY_NAME_MIN = 2;
+const DISPLAY_NAME_MAX = 40;
+
+export function buildReferralUrl(walletAddress: string): string {
+  const base =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : 'https://stellarkraal.example.com';
+  return `${base}/register?ref=${walletAddress}`;
+}
 
 function SkeletonRow() {
   return (
@@ -44,11 +57,175 @@ function SkeletonRow() {
   );
 }
 
+/** Inline display-name editor */
+function DisplayNameField({
+  walletAddress,
+  initialName,
+  onSaved,
+}: {
+  walletAddress: string;
+  initialName: string;
+  onSaved: (name: string) => void;
+}) {
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initialName);
+  const [saving, setSaving] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  function validate(value: string): string | null {
+    const trimmed = value.trim();
+    if (trimmed.length < DISPLAY_NAME_MIN) {
+      return `Name must be at least ${DISPLAY_NAME_MIN} characters.`;
+    }
+    if (trimmed.length > DISPLAY_NAME_MAX) {
+      return `Name must be at most ${DISPLAY_NAME_MAX} characters.`;
+    }
+    return null;
+  }
+
+  function handleEdit() {
+    setDraft(initialName);
+    setValidationError(null);
+    setEditing(true);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+    setDraft(initialName);
+    setValidationError(null);
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setDraft(e.target.value);
+    if (validationError) {
+      setValidationError(validate(e.target.value));
+    }
+  }
+
+  async function handleSave() {
+    const err = validate(draft);
+    if (err) {
+      setValidationError(err);
+      inputRef.current?.focus();
+      return;
+    }
+
+    const trimmed = draft.trim();
+
+    // Optimistic update
+    onSaved(trimmed);
+    setEditing(false);
+
+    setSaving(true);
+    try {
+      const res = await fetch(`${API}/api/v1/profile`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ wallet: walletAddress, display_name: trimmed }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error || `Server error ${res.status}`);
+      }
+      toast.success('Display name saved successfully!');
+    } catch (e: unknown) {
+      // Rollback optimistic update
+      onSaved(initialName);
+      toast.error(
+        e instanceof Error ? e.message : 'Failed to save display name. Please try again.',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void handleSave();
+    }
+    if (e.key === 'Escape') {
+      handleCancel();
+    }
+  }
+
+  if (editing) {
+    return (
+      <div>
+        <dt className="text-brown-500 mb-1">Display Name</dt>
+        <dd className="flex items-center gap-2 flex-wrap">
+          <input
+            ref={inputRef}
+            type="text"
+            value={draft}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            maxLength={DISPLAY_NAME_MAX + 1}
+            aria-label="Display name"
+            aria-describedby={validationError ? 'display-name-error' : undefined}
+            aria-invalid={validationError ? 'true' : 'false'}
+            className="rounded-lg border border-brown/30 px-3 py-1.5 text-sm text-brown-700 dark:bg-[#2A1A08] dark:text-cream focus:outline-none focus:ring-2 focus:ring-gold"
+          />
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="text-xs font-semibold bg-gold text-brown rounded px-3 py-1.5 hover:bg-gold/80 transition disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            onClick={handleCancel}
+            disabled={saving}
+            className="text-xs font-medium text-brown-500 hover:text-brown-700 underline transition disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          {validationError && (
+            <p id="display-name-error" role="alert" className="w-full text-xs text-red-600 mt-0.5">
+              {validationError}
+            </p>
+          )}
+        </dd>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <dt className="text-brown-500 mb-1">Display Name</dt>
+      <dd className="flex items-center gap-2">
+        <span className="text-brown-700 dark:text-cream font-medium">
+          {initialName || <span className="text-brown-400 italic">Not set</span>}
+        </span>
+        <button
+          onClick={handleEdit}
+          aria-label="Edit display name"
+          className="text-xs font-medium text-gold hover:text-gold/80 underline transition"
+        >
+          Edit
+        </button>
+      </dd>
+    </div>
+  );
+}
+
 export default function ProfilePage() {
   const { address, freighterInstalled, connecting, connect } = useWallet();
   const [profile, setProfile] = useState<BorrowerProfile | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState('');
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (!address) return;
@@ -59,10 +236,20 @@ export default function ProfilePage() {
         if (!r.ok) throw new Error('Failed to load profile');
         return r.json();
       })
-      .then(setProfile)
+      .then((data: BorrowerProfile) => {
+        setProfile(data);
+        setDisplayName(data.display_name ?? '');
+      })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, [address]);
+
+  async function handleCopy() {
+    if (!address) return;
+    await navigator.clipboard.writeText(buildReferralUrl(address));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   if (!address) {
     return (
@@ -94,6 +281,8 @@ export default function ProfilePage() {
     );
   }
 
+  const referralUrl = buildReferralUrl(address);
+
   return (
     <PageTransition>
       <main className="max-w-4xl mx-auto px-4 py-10 space-y-8">
@@ -106,7 +295,28 @@ export default function ProfilePage() {
               <dt className="text-brown-500 mb-1">Address</dt>
               <dd className="font-mono break-all text-brown-700">{address}</dd>
             </div>
+            <DisplayNameField
+              walletAddress={address}
+              initialName={displayName}
+              onSaved={setDisplayName}
+            />
           </dl>
+        </Card>
+
+        {/* Referral Section */}
+        <Card header={<h2 className="text-lg font-semibold text-brown-700">Referral</h2>}>
+          <p className="text-sm text-brown-600 mb-3">
+            Share your referral link to invite others to StellarKraal.
+          </p>
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className="font-mono text-sm text-brown-700 break-all">{referralUrl}</span>
+            <button
+              onClick={() => void handleCopy()}
+              className="text-sm font-semibold bg-gold text-brown rounded px-3 py-1.5 hover:bg-gold/80 transition shrink-0"
+            >
+              {copied ? 'Copied!' : 'Copy Invite Link'}
+            </button>
+          </div>
         </Card>
 
         {error && (


### PR DESCRIPTION
- Add DisplayNameField component with edit/save/cancel toggle
- PATCH /api/v1/profile with { wallet, display_name }
- Validation: 2–40 characters (trims whitespace)
- Optimistic UI updates displayed name immediately on save
- Rolls back on PATCH failure
- Success toast on save; error toast on failure
- Enter key submits, Escape cancels
- Inline validation message shown on invalid input
- Tests: edit toggle, validation, PATCH call, toasts, optimistic update, rollback, keyboard shortcuts

## Summary

Please describe the change and why it is needed.

## Related Issue


## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

closes #545 


