### PR TITLE
perf(dashboard): lazy load HealthGauge, LoanRepaymentCalculator, Repa…

### DIFF
--- a/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/frontend/src/app/dashboard/DashboardClient.tsx
@@ -2,18 +2,41 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { GlossaryTerm } from "@/components/GlossaryTerm";
 import WalletConnect from "@/components/WalletConnect";
 import CollateralCard from "@/components/CollateralCard";
-import RepayPanel from "@/components/RepayPanel";
-import HealthGauge from "@/components/HealthGauge";
-import LoanRepaymentCalculator from "@/components/LoanRepaymentCalculator";
 import TransactionHistory from "@/components/TransactionHistory";
 import SkeletonHealthDashboard from "@/components/SkeletonHealthDashboard";
+import SkeletonLoanCard from "@/components/SkeletonLoanCard";
 import HelpMenu from "@/components/HelpMenu";
 import OnboardingModal from "@/components/OnboardingModal";
 import { useHealthFactor } from "@/hooks/useHealthFactor";
 import { useOnboarding } from "@/hooks/useOnboarding";
+
+// ── Lazy-loaded heavy components ─────────────────────────────────────────────
+// Using next/dynamic with ssr:false prevents hydration mismatches for
+// canvas/SVG-heavy components. Skeleton fallbacks maintain layout stability.
+
+const HealthGauge = dynamic(() => import("@/components/HealthGauge"), {
+  ssr: false,
+  loading: () => <SkeletonHealthDashboard />,
+});
+
+const LoanRepaymentCalculator = dynamic(
+  () => import("@/components/LoanRepaymentCalculator"),
+  {
+    ssr: false,
+    loading: () => <SkeletonLoanCard />,
+  },
+);
+
+const RepayPanel = dynamic(() => import("@/components/RepayPanel"), {
+  ssr: false,
+  loading: () => <SkeletonLoanCard />,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function DashboardClient() {
   const router = useRouter();


### PR DESCRIPTION
…yPanel

Switch eager imports to next/dynamic for the three heaviest dashboard components to reduce initial bundle size and improve Lighthouse score.

- HealthGauge: large SVG/canvas component; SkeletonHealthDashboard fallback
- LoanRepaymentCalculator: embeds HealthGauge and has heavy fetch logic; SkeletonLoanCard fallback
- RepayPanel: uses @stellar/freighter-api; SkeletonLoanCard fallback

All three use ssr:false to prevent hydration mismatches (components rely on browser APIs and dynamic imports are resolved client-side).

Each component is split into its own chunk by the Next.js bundler, reducing the initial JS payload served to the client.

## Summary

Please describe the change and why it is needed.

## Related Issue



## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

closes #546 



