### PR TITLE
perf(dashboard): next/dynamic imports for HealthGauge, LoanRepaymentC…

### DIFF
--- a/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/frontend/src/app/dashboard/DashboardClient.tsx
@@ -2,18 +2,41 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { GlossaryTerm } from "@/components/GlossaryTerm";
 import WalletConnect from "@/components/WalletConnect";
 import CollateralCard from "@/components/CollateralCard";
-import RepayPanel from "@/components/RepayPanel";
-import HealthGauge from "@/components/HealthGauge";
-import LoanRepaymentCalculator from "@/components/LoanRepaymentCalculator";
 import TransactionHistory from "@/components/TransactionHistory";
 import SkeletonHealthDashboard from "@/components/SkeletonHealthDashboard";
+import SkeletonLoanCard from "@/components/SkeletonLoanCard";
 import HelpMenu from "@/components/HelpMenu";
 import OnboardingModal from "@/components/OnboardingModal";
 import { useHealthFactor } from "@/hooks/useHealthFactor";
 import { useOnboarding } from "@/hooks/useOnboarding";
+
+// ── Lazy-loaded heavy components ─────────────────────────────────────────────
+// Using next/dynamic with ssr:false prevents hydration mismatches for
+// canvas/SVG-heavy components. Skeleton fallbacks maintain layout stability.
+
+const HealthGauge = dynamic(() => import("@/components/HealthGauge"), {
+  ssr: false,
+  loading: () => <SkeletonHealthDashboard />,
+});
+
+const LoanRepaymentCalculator = dynamic(
+  () => import("@/components/LoanRepaymentCalculator"),
+  {
+    ssr: false,
+    loading: () => <SkeletonLoanCard />,
+  },
+);
+
+const RepayPanel = dynamic(() => import("@/components/RepayPanel"), {
+  ssr: false,
+  loading: () => <SkeletonLoanCard />,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function DashboardClient() {
   const router = useRouter();


### PR DESCRIPTION
…alculator, RepayPanel

Duplicate of feat/lazy-load-heavy-components — covers issue #4 (same acceptance criteria as issue #3: split chunks via next/dynamic).

Each component:
- Wrapped with dynamic(() => import(...), { ssr: false, loading: <Skeleton> })
- ssr:false avoids hydration errors (components use browser APIs)
- Skeleton fallback maintains layout during code-split load
- Next.js bundler outputs a separate chunk for each component

## Summary

Please describe the change and why it is needed.

## Related Issue

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

closes #547 



