### PR TITLE
feat(frontend): add exponential-backoff retry to all fetch calls

### DIFF
--- a/frontend/src/__tests__/fetchWithRetry.test.ts
+++ b/frontend/src/__tests__/fetchWithRetry.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for fetchWithRetry.
+ *
+ * Covers:
+ *  - Success on first attempt (no retries)
+ *  - 4xx responses are NOT retried (returned immediately)
+ *  - 5xx responses ARE retried up to maxAttempts
+ *  - Network errors are retried up to maxAttempts
+ *  - onRetry toast callback is called on each retry with correct attempt number
+ *  - onError callback is called once after all retries are exhausted
+ *  - Backoff delays follow the 1 s / 2 s pattern (using fake timers)
+ *  - Total fetch call count equals maxAttempts on total failure
+ *  - Throws after all attempts fail
+ */
+
+import { fetchWithRetry } from '@/lib/fetchWithRetry';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeResponse(status: number, ok: boolean): Response {
+  return { ok, status, json: async () => ({}) } as unknown as Response;
+}
+
+/**
+ * Run the fetchWithRetry promise to completion, advancing fake timers as needed.
+ * Returns the settled result (value or error).
+ */
+async function runToCompletion<T>(
+  promise: Promise<T>,
+): Promise<{ value: T; error?: never } | { value?: never; error: unknown }> {
+  // Attach catch early to prevent unhandled rejection warnings.
+  const settled = promise.then(
+    (value) => ({ value } as { value: T }),
+    (error) => ({ error } as { error: unknown }),
+  );
+  // Advance all timers so backoff delays resolve.
+  await jest.runAllTimersAsync();
+  return settled;
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.resetAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('fetchWithRetry', () => {
+  describe('successful requests', () => {
+    it('resolves immediately on a 200 response without retrying', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(200, true));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test'));
+      expect(result.error).toBeUndefined();
+      expect((result.value as Response).status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('4xx responses (non-retryable)', () => {
+    it('returns a 404 response immediately without retrying', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(404, false));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test'));
+      expect(result.error).toBeUndefined();
+      expect((result.value as Response).status).toBe(404);
+      // Must NOT retry
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a 401 response immediately without retrying', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(401, false));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test'));
+      expect((result.value as Response).status).toBe(401);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onRetry or onError for 4xx', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(400, false));
+      global.fetch = mockFetch;
+      const onRetry = jest.fn();
+      const onError = jest.fn();
+
+      await runToCompletion(fetchWithRetry('/api/test', { toast: { onRetry, onError } }));
+      expect(onRetry).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('5xx responses (retryable)', () => {
+    it('retries a 500 response up to maxAttempts and then throws', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test', { maxAttempts: 3 }));
+      expect(result.error).toBeDefined();
+      expect((result.error as Error).message).toBe('Server error: 500');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('succeeds on the second attempt after an initial 503', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce(makeResponse(503, false))
+        .mockResolvedValueOnce(makeResponse(200, true));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test'));
+      expect(result.error).toBeUndefined();
+      expect((result.value as Response).status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('network errors (retryable)', () => {
+    it('retries on TypeError (network failure) up to maxAttempts', async () => {
+      const networkError = new TypeError('Failed to fetch');
+      const mockFetch = jest.fn().mockRejectedValue(networkError);
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test', { maxAttempts: 3 }));
+      expect(result.error).toBeDefined();
+      expect((result.error as TypeError).message).toBe('Failed to fetch');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('succeeds if the network error clears on retry', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(makeResponse(200, true));
+      global.fetch = mockFetch;
+
+      const result = await runToCompletion(fetchWithRetry('/api/test'));
+      expect(result.error).toBeUndefined();
+      expect((result.value as Response).status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('toast callbacks', () => {
+    it('calls onRetry before each retry with the correct attempt number', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+      const onRetry = jest.fn();
+
+      await runToCompletion(
+        fetchWithRetry('/api/test', { maxAttempts: 3, toast: { onRetry } }),
+      );
+
+      // 3 attempts → 2 retries → onRetry called twice: attempt 1 and attempt 2
+      expect(onRetry).toHaveBeenCalledTimes(2);
+      expect(onRetry).toHaveBeenNthCalledWith(1, 1);
+      expect(onRetry).toHaveBeenNthCalledWith(2, 2);
+    });
+
+    it('calls onError once after all retries are exhausted', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+      const onError = jest.fn();
+
+      await runToCompletion(
+        fetchWithRetry('/api/test', { maxAttempts: 3, toast: { onError } }),
+      );
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith('Server error: 500');
+    });
+
+    it('calls onError with the network error message', async () => {
+      const mockFetch = jest.fn().mockRejectedValue(new TypeError('Network offline'));
+      global.fetch = mockFetch;
+      const onError = jest.fn();
+
+      await runToCompletion(
+        fetchWithRetry('/api/test', { maxAttempts: 2, toast: { onError } }),
+      );
+
+      expect(onError).toHaveBeenCalledWith('Network offline');
+    });
+  });
+
+  describe('backoff timing', () => {
+    it('waits 1 s before the first retry (backoff delay = baseDelayMs * 2^0)', async () => {
+      // Track recorded delays via a spy on the delay helper (setTimeout)
+      const delays: number[] = [];
+      const origSetTimeout = globalThis.setTimeout;
+      jest
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(
+          (
+            fn: (...args: unknown[]) => void,
+            ms?: number,
+            ...args: unknown[]
+          ) => {
+            if (ms !== undefined && ms >= 100) delays.push(ms);
+            // Fake timers are already installed; call the real impl with 0ms
+            // so Jest can control advancement.
+            return origSetTimeout(fn, 0, ...args);
+          },
+        );
+
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce(makeResponse(500, false))
+        .mockResolvedValueOnce(makeResponse(200, true));
+      global.fetch = mockFetch;
+
+      await runToCompletion(fetchWithRetry('/api/test', { baseDelayMs: 1000 }));
+
+      jest.restoreAllMocks();
+      // First retry → delay = 1000 ms
+      expect(delays[0]).toBe(1000);
+    });
+
+    it('waits 2 s before the second retry (backoff delay = baseDelayMs * 2^1)', async () => {
+      const delays: number[] = [];
+      const origSetTimeout = globalThis.setTimeout;
+      jest
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(
+          (
+            fn: (...args: unknown[]) => void,
+            ms?: number,
+            ...args: unknown[]
+          ) => {
+            if (ms !== undefined && ms >= 100) delays.push(ms);
+            return origSetTimeout(fn, 0, ...args);
+          },
+        );
+
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+
+      await runToCompletion(fetchWithRetry('/api/test', { maxAttempts: 3, baseDelayMs: 1000 }));
+
+      jest.restoreAllMocks();
+      // Delays for 3 attempts: 1000 ms (before attempt 2) and 2000 ms (before attempt 3)
+      expect(delays).toEqual([1000, 2000]);
+    });
+
+    it('the third backoff delay would be 4 s (2^2 * baseDelayMs)', async () => {
+      const delays: number[] = [];
+      const origSetTimeout = globalThis.setTimeout;
+      jest
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(
+          (
+            fn: (...args: unknown[]) => void,
+            ms?: number,
+            ...args: unknown[]
+          ) => {
+            if (ms !== undefined && ms >= 100) delays.push(ms);
+            return origSetTimeout(fn, 0, ...args);
+          },
+        );
+
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+
+      await runToCompletion(fetchWithRetry('/api/test', { maxAttempts: 4, baseDelayMs: 1000 }));
+
+      jest.restoreAllMocks();
+      // 4 attempts → 3 retries → delays: 1000, 2000, 4000
+      expect(delays).toEqual([1000, 2000, 4000]);
+    });
+  });
+
+  describe('maxAttempts option', () => {
+    it('respects a custom maxAttempts value', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+
+      await runToCompletion(fetchWithRetry('/api/test', { maxAttempts: 5 }));
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('does not retry at all when maxAttempts is 1', async () => {
+      const mockFetch = jest.fn().mockResolvedValue(makeResponse(500, false));
+      global.fetch = mockFetch;
+      const onRetry = jest.fn();
+
+      await runToCompletion(
+        fetchWithRetry('/api/test', { maxAttempts: 1, toast: { onRetry } }),
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/dashboard/DashboardClient.tsx
+++ b/frontend/src/app/dashboard/DashboardClient.tsx
@@ -16,11 +16,14 @@ import OnboardingChecklist from "@/components/OnboardingChecklist";
 import { useHealthFactor } from "@/hooks/useHealthFactor";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { Hero } from "@/components/Hero";
+import { useToast } from "@/components/toast";
+import { fetchWithRetry } from "@/lib/fetchWithRetry";
 
 const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export default function DashboardClient() {
   const router = useRouter();
+  const toast = useToast();
   const [wallet, setWallet] = useState<string | null>(null);
   const [loanId, setLoanId] = useState("");
   const [activeTab, setActiveTab] = useState<TabName>("overview");
@@ -37,14 +40,19 @@ export default function DashboardClient() {
       setHasCollateral(false);
       return;
     }
-    fetch(`${API}/api/collateral?owner=${wallet}`)
+    fetchWithRetry(`${API}/api/collateral?owner=${wallet}`, {
+      toast: {
+        onRetry: (attempt) => toast.warning(`Retrying… (attempt ${attempt + 1})`),
+        onError: (message) => toast.error(message),
+      },
+    })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((body) => {
         const items = Array.isArray(body?.data) ? body.data : [];
         setHasCollateral(items.length > 0);
       })
       .catch(() => setHasCollateral(false));
-  }, [wallet]);
+  }, [wallet]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Detect if user has loan
   useEffect(() => {
@@ -52,14 +60,19 @@ export default function DashboardClient() {
       setHasLoan(false);
       return;
     }
-    fetch(`${API}/api/loans?borrower=${wallet}`)
+    fetchWithRetry(`${API}/api/loans?borrower=${wallet}`, {
+      toast: {
+        onRetry: (attempt) => toast.warning(`Retrying… (attempt ${attempt + 1})`),
+        onError: (message) => toast.error(message),
+      },
+    })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((body) => {
         const items = Array.isArray(body?.data) ? body.data : [];
         setHasLoan(items.length > 0);
       })
       .catch(() => setHasLoan(false));
-  }, [wallet]);
+  }, [wallet]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Read hash from URL on mount and when it changes
   useEffect(() => {

--- a/frontend/src/lib/fetchWithRetry.ts
+++ b/frontend/src/lib/fetchWithRetry.ts
@@ -1,0 +1,82 @@
+/**
+ * fetchWithRetry — exponential-backoff wrapper around the Fetch API.
+ *
+ * Behaviour:
+ *  - Max 3 attempts (initial + 2 retries).
+ *  - Backoff delays: 1 s, 2 s, 4 s (powers of 2 starting at 1 s).
+ *  - Retries ONLY on network errors (fetch throws) and 5xx responses.
+ *  - 4xx responses are treated as permanent failures and are NOT retried.
+ *  - Calls `onRetry(attempt)` before each retry so callers can show a toast.
+ *  - Calls `onError(message)` when all attempts are exhausted.
+ */
+
+export interface RetryToastCallbacks {
+  /** Called before every retry, with the 1-based attempt number (1 = first retry). */
+  onRetry?: (attempt: number) => void;
+  /** Called once all retries are exhausted with the final error message. */
+  onError?: (message: string) => void;
+}
+
+export interface FetchWithRetryOptions extends RequestInit {
+  /** Maximum number of total attempts (default: 3). */
+  maxAttempts?: number;
+  /** Base delay in milliseconds for exponential backoff (default: 1000). */
+  baseDelayMs?: number;
+  toast?: RetryToastCallbacks;
+}
+
+/** Resolves after `ms` milliseconds. Wraps in a `setTimeout` so Jest fake timers can control it. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns `true` when the response should trigger a retry (5xx server errors).
+ * 4xx responses are permanent client errors and must NOT be retried.
+ */
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 && status <= 599;
+}
+
+export async function fetchWithRetry(
+  url: string,
+  options: FetchWithRetryOptions = {},
+): Promise<Response> {
+  const { maxAttempts = 3, baseDelayMs = 1000, toast, ...fetchOptions } = options;
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await fetch(url, fetchOptions);
+
+      // Non-retryable failure (e.g. 4xx) — return as-is so callers can handle it.
+      if (!response.ok && !isRetryableStatus(response.status)) {
+        return response;
+      }
+
+      // Success OR 5xx that we'll retry below.
+      if (response.ok) {
+        return response;
+      }
+
+      // 5xx — treat as a network-like failure so the retry logic below applies.
+      lastError = new Error(`Server error: ${response.status}`);
+    } catch (err) {
+      // Network error (fetch itself threw — e.g. no connectivity).
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+
+    // If we still have retries left, wait and notify the caller.
+    if (attempt < maxAttempts) {
+      const waitMs = baseDelayMs * Math.pow(2, attempt - 1); // 1s, 2s, 4s
+      toast?.onRetry?.(attempt);
+      await delay(waitMs);
+    }
+  }
+
+  // All attempts exhausted — notify caller and re-throw.
+  const message = lastError?.message ?? 'Request failed after retries';
+  toast?.onError?.(message);
+  throw lastError ?? new Error(message);
+}


### PR DESCRIPTION
- Add fetchWithRetry utility in src/lib/fetchWithRetry.ts
  - Retries up to 3 attempts (configurable via maxAttempts)
  - Backoff delays: 1s, 2s, 4s (baseDelayMs * 2^attempt)
  - Only retries on network errors and 5xx responses
  - 4xx responses returned immediately (not retried)
  - Accepts onRetry / onError toast callbacks
- Replace bare fetch() calls in DashboardClient.tsx with fetchWithRetry
  - Collateral existence check and loan existence check both retried
  - Show 'Retrying…' warning toast and error toast on failure
- Add unit tests covering retry count, 4xx/5xx behaviour, onRetry/onError callbacks, and 1s/2s/4s backoff delays

## Summary

Please describe the change and why it is needed.
## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**


closes #552 
