### PR TITLE
feat(frontend): make CollateralCard a navigable Next.js Link

### DIFF
--- a/frontend/src/__tests__/CollateralCard.test.tsx
+++ b/frontend/src/__tests__/CollateralCard.test.tsx
@@ -1,63 +1,246 @@
+/**
+ * Tests for CollateralCard.
+ *
+ * Covers:
+ *  - Basic render (Loan Lookup form)
+ *  - Fetch and display loan data (via fetchWithRetry)
+ *  - Loading / disabled state
+ *  - Error display
+ *  - id prop → entire card wrapped in a Next.js Link with correct href
+ *  - Pointer cursor applied when id is provided
+ *  - Focus ring present for keyboard navigation
+ *  - Enter key triggers navigation (href is correct)
+ */
+
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import CollateralCard from "../components/CollateralCard";
 
-const fetchMock = jest.fn();
-beforeEach(() => {
-  fetchMock.mockReset();
-  (global as any).fetch = fetchMock;
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock next/link so it renders as a plain <a> in jsdom
+jest.mock("next/link", () => {
+  const MockLink = ({
+    href,
+    children,
+    className,
+    "aria-label": ariaLabel,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <a href={href} className={className} aria-label={ariaLabel}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
 });
 
+// Mock the toast hook so we don't need a provider
+const mockToast = {
+  success: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn(),
+};
+jest.mock("@/components/toast", () => ({
+  useToast: () => mockToast,
+}));
+
+// Mock fetchWithRetry so we control responses in tests
+const mockFetchWithRetry = jest.fn();
+jest.mock("@/lib/fetchWithRetry", () => ({
+  fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeOkResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockFetchWithRetry.mockReset();
+  mockToast.error.mockReset();
+  mockToast.warning.mockReset();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
 describe("CollateralCard", () => {
-  it("renders loan lookup form", () => {
-    render(<CollateralCard walletAddress="GTEST" />);
-    expect(screen.getByPlaceholderText("Loan ID")).toBeTruthy();
-    expect(screen.getByText("Fetch")).toBeTruthy();
+  describe("basic rendering", () => {
+    it("renders the loan lookup form", () => {
+      render(<CollateralCard walletAddress="GTEST" />);
+      expect(screen.getByPlaceholderText("Loan ID")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Fetch" })).toBeTruthy();
+    });
+
+    it("shows the 'Loan Lookup' heading", () => {
+      render(<CollateralCard walletAddress="GTEST" />);
+      expect(screen.getByText("Loan Lookup")).toBeTruthy();
+    });
   });
 
-  it("fetches and displays loan data", async () => {
-    fetchMock.mockResolvedValue({
-      json: async () => ({ id: 42, status: "active" }),
+  describe("fetch behaviour", () => {
+    it("calls fetchWithRetry with the correct URL when Fetch is clicked", async () => {
+      mockFetchWithRetry.mockReturnValue(makeOkResponse({ id: 1 }));
+
+      render(<CollateralCard walletAddress="GTEST" />);
+      fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
+        target: { value: "loan-42" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Fetch" }));
+
+      await waitFor(() => expect(mockFetchWithRetry).toHaveBeenCalled());
+      const [url] = mockFetchWithRetry.mock.calls[0] as [string, unknown];
+      expect(url).toMatch(/\/api\/loan\/loan-42$/);
     });
 
-    render(<CollateralCard walletAddress="GTEST" />);
-    fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
-      target: { value: "42" },
-    });
-    fireEvent.click(screen.getByText("Fetch"));
+    it("displays JSON data after a successful fetch", async () => {
+      mockFetchWithRetry.mockReturnValue(makeOkResponse({ id: 42, status: "active" }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/"status": "active"/)).toBeTruthy()
-    );
+      render(<CollateralCard walletAddress="GTEST" />);
+      fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
+        target: { value: "42" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Fetch" }));
+
+      await waitFor(() =>
+        expect(screen.getByText(/"status": "active"/)).toBeTruthy()
+      );
+    });
+
+    it("shows loading state (Fetching…) while the request is in flight", async () => {
+      let resolveRequest!: (v: unknown) => void;
+      mockFetchWithRetry.mockReturnValue(
+        new Promise((r) => { resolveRequest = r; })
+      );
+
+      render(<CollateralCard walletAddress="GTEST" />);
+      fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
+        target: { value: "1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Fetch" }));
+
+      expect(screen.getByText("Fetching…")).toBeTruthy();
+
+      // Resolve the pending promise to avoid act() warnings
+      await act(async () => {
+        resolveRequest({ ok: true, status: 200, json: async () => ({}) });
+        await Promise.resolve();
+      });
+    });
+
+    it("disables the Fetch button while loading", async () => {
+      let resolveRequest!: (v: unknown) => void;
+      mockFetchWithRetry.mockReturnValue(
+        new Promise((r) => { resolveRequest = r; })
+      );
+
+      render(<CollateralCard walletAddress="GTEST" />);
+      fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
+        target: { value: "1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Fetch" }));
+
+      const btn = screen.getByText("Fetching…").closest("button")!;
+      expect(btn.disabled).toBe(true);
+
+      // Resolve to avoid act() warnings
+      await act(async () => {
+        resolveRequest({ ok: true, status: 200, json: async () => ({}) });
+        await Promise.resolve();
+      });
+    });
+
+    it("shows an error message when the response is not ok", async () => {
+      mockFetchWithRetry.mockReturnValue(
+        Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+      );
+
+      render(<CollateralCard walletAddress="GTEST" />);
+      fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
+        target: { value: "bad-id" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Fetch" }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toBeTruthy()
+      );
+    });
   });
 
-  it("shows loading state while fetching", async () => {
-    let resolve: (v: any) => void;
-    fetchMock.mockReturnValue(
-      new Promise((r) => { resolve = r; })
-    );
+  describe("id prop → navigable Link", () => {
+    it("wraps the entire card in a Link when id prop is provided", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-123" />);
 
-    render(<CollateralCard walletAddress="GTEST" />);
-    fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
-      target: { value: "1" },
+      // The outer element rendered by our MockLink is an <a>
+      const link = screen.getByRole("link", { name: /col-123/i });
+      expect(link).toBeTruthy();
     });
-    fireEvent.click(screen.getByText("Fetch"));
 
-    expect(screen.getByText("…")).toBeTruthy();
-    resolve!({ json: async () => ({}) });
-  });
+    it("sets href to /dashboard/collateral/[id]", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-123" />);
 
-  it("button is disabled while loading", async () => {
-    let resolve: (v: any) => void;
-    fetchMock.mockReturnValue(new Promise((r) => { resolve = r; }));
-
-    render(<CollateralCard walletAddress="GTEST" />);
-    fireEvent.change(screen.getByPlaceholderText("Loan ID"), {
-      target: { value: "1" },
+      const link = screen.getByRole("link", { name: /col-123/i }) as HTMLAnchorElement;
+      expect(link.href).toContain("/dashboard/collateral/col-123");
     });
-    fireEvent.click(screen.getByText("Fetch"));
 
-    expect((screen.getByText("…") as HTMLButtonElement).disabled).toBe(true);
-    resolve!({ json: async () => ({}) });
+    it("sets the correct href when id is a different value", () => {
+      render(<CollateralCard walletAddress="GTEST" id="abc-999" />);
+
+      const link = screen.getByRole("link", { name: /abc-999/i }) as HTMLAnchorElement;
+      expect(link.href).toContain("/dashboard/collateral/abc-999");
+    });
+
+    it("applies cursor-pointer class when id is provided", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-123" />);
+
+      const link = screen.getByRole("link", { name: /col-123/i });
+      expect(link.className).toContain("cursor-pointer");
+    });
+
+    it("applies focus-visible ring class for keyboard navigation", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-123" />);
+
+      const link = screen.getByRole("link", { name: /col-123/i });
+      // The focus-visible ring is defined via Tailwind classes
+      expect(link.className).toContain("focus-visible:ring-2");
+    });
+
+    it("does NOT render a wrapping link when id is not provided", () => {
+      render(<CollateralCard walletAddress="GTEST" />);
+
+      // The inner "View collateral detail" link should NOT exist yet (no collateralId typed)
+      const links = screen.queryAllByRole("link");
+      // There should be no links at all until a collateralId is entered
+      expect(links).toHaveLength(0);
+    });
+
+    it("the card Link renders as a block element", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-123" />);
+
+      const link = screen.getByRole("link", { name: /col-123/i });
+      expect(link.className).toContain("block");
+    });
+
+    it("keyboard Enter key activates navigation (link has correct href)", () => {
+      render(<CollateralCard walletAddress="GTEST" id="col-fire" />);
+
+      const link = screen.getByRole("link", { name: /col-fire/i }) as HTMLAnchorElement;
+      // A native <a> with an href responds to Enter — verify href is set correctly
+      expect(link.href).toContain("/dashboard/collateral/col-fire");
+      // Simulating keydown Enter on a link with href should not throw
+      expect(() => fireEvent.keyDown(link, { key: "Enter", code: "Enter" })).not.toThrow();
+    });
   });
 });

--- a/frontend/src/components/CollateralCard.tsx
+++ b/frontend/src/components/CollateralCard.tsx
@@ -4,12 +4,21 @@ import Link from "next/link";
 import { colors } from "@/lib/design-tokens";
 import Card from "@/components/Card";
 import Spinner from "@/components/Spinner";
+import { fetchWithRetry } from "@/lib/fetchWithRetry";
+import { useToast } from "@/components/toast";
 
 const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
+interface Props {
+  walletAddress: string;
+  /** When provided the entire card becomes a Next.js Link to /dashboard/collateral/[id]. */
+  id?: string;
+}
+
 // walletAddress is accepted for API consistency but lookup uses a user-entered loan ID
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function CollateralCard(_props: { walletAddress: string }) {
+export default function CollateralCard({ id, walletAddress: _walletAddress }: Props) {
+  const toast = useToast();
   const [collateralId, setCollateralId] = useState('');
   const [data, setData] = useState<unknown>(null);
   const [loading, setLoading] = useState(false);
@@ -20,7 +29,12 @@ export default function CollateralCard(_props: { walletAddress: string }) {
     setError(null);
     setData(null);
     try {
-      const res = await fetch(`${API}/api/loan/${collateralId}`);
+      const res = await fetchWithRetry(`${API}/api/loan/${collateralId}`, {
+        toast: {
+          onRetry: (attempt) => toast.warning(`Retrying… (attempt ${attempt + 1})`),
+          onError: (message) => toast.error(message),
+        },
+      });
       if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setData(await res.json());
     } catch (e: unknown) {
@@ -30,7 +44,7 @@ export default function CollateralCard(_props: { walletAddress: string }) {
     }
   }
 
-  return (
+  const cardContent = (
     <Card
       className={[
         "mb-4",
@@ -43,6 +57,8 @@ export default function CollateralCard(_props: { walletAddress: string }) {
         "focus-within:ring-2 focus-within:ring-gold/50 focus-within:ring-offset-2",
         // Dark-mode hover tint
         "dark:hover:border-brown-500",
+        // Pointer cursor when the card is a link
+        id ? "cursor-pointer" : "",
       ].join(" ")}
       header={<h2 className={`text-xl font-semibold ${colors.text.primary}`}>Loan Lookup</h2>}
     >
@@ -56,9 +72,15 @@ export default function CollateralCard(_props: { walletAddress: string }) {
           placeholder="Loan ID"
           value={collateralId}
           onChange={(e) => setCollateralId(e.target.value)}
+          // Prevent the link navigation when typing inside the card
+          onClick={(e) => e.stopPropagation()}
         />
         <button
-          onClick={lookup}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            void lookup();
+          }}
           disabled={loading}
           className={`${colors.primary.bg} ${colors.primary.text} px-4 py-2 rounded-lg ${colors.primary.hover} transition ${colors.interactive.disabled} ${colors.interactive.focus} flex items-center gap-2`}
         >
@@ -76,9 +98,15 @@ export default function CollateralCard(_props: { walletAddress: string }) {
         <Link
           href={`/collateral/${collateralId}`}
           className="mt-3 inline-block text-sm text-gold hover:underline"
+          onClick={(e) => e.stopPropagation()}
         >
           View collateral detail →
         </Link>
+      )}
+      {error && (
+        <p className="mt-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
       )}
       {data && (
         <pre
@@ -89,4 +117,24 @@ export default function CollateralCard(_props: { walletAddress: string }) {
       )}
     </Card>
   );
+
+  if (id) {
+    return (
+      <Link
+        href={`/dashboard/collateral/${id}`}
+        className={[
+          "block rounded-2xl",
+          // Pointer cursor
+          "cursor-pointer",
+          // Visible keyboard focus ring
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-gold focus-visible:ring-offset-2",
+        ].join(" ")}
+        aria-label={`View collateral ${id}`}
+      >
+        {cardContent}
+      </Link>
+    );
+  }
+
+  return cardContent;
 }


### PR DESCRIPTION
- Accept optional id prop on CollateralCard
- When id is provided, wrap the entire card in a Next.js Link pointing to /dashboard/collateral/[id]
- Apply cursor-pointer so the card shows a pointer on hover
- Apply focus-visible:ring-2 for a visible keyboard focus ring
- Native <a href> means Enter key triggers navigation automatically
- Also replace bare fetch() in CollateralCard.lookup() with fetchWithRetry (Retrying… warning + error toast on failure)
- Update CollateralCard tests:
  - Verify href is set to /dashboard/collateral/[id]
  - Verify cursor-pointer class is present
  - Verify focus-visible ring class is present
  - Verify Enter key navigates (link has correct href)
  - Verify no wrapping link rendered when id is omitted

## Summary

Please describe the change and why it is needed.

## Testing

Describe how this was tested locally.

## Checklist

- [ ] Branch is based on latest `main`
- [ ] Commit messages follow Conventional Commits
- [ ] Tests were run locally
- [ ] Documentation updated if needed
- [ ] CHANGELOG updated or release notes covered by release-please

## Smart Contract Changes (fill out only if this PR touches `contracts/stellarkraal/`)

- [ ] ABI remains backward-compatible, or a migration path is documented below
- [ ] `cargo test` passes locally
- [ ] Integration tested against a local Soroban sandbox, where applicable
- [ ] Storage layout changes (if any) are documented and safe for existing on-chain state
- [ ] New/changed functions have unit test coverage

**Migration notes (if ABI is not backward-compatible):**

closes #551 

