### PR TITLE
feat: webhook payload reference docs and loan status animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ npm run test:frontend
 |---|---|
 | [Register Livestock as Collateral](docs/guides/register-collateral.md) | Step-by-step guide (English + Kiswahili) for registering animals and requesting a loan |
 | [API Integration Tutorial](docs/guides/api-integration-tutorial.md) | How an external app can register collateral, request a loan, and monitor loan status via webhooks |
+| [Webhook Payload Reference](docs/guides/webhooks.md) | JSON schemas, example payloads, signature verification, and encrypted-delivery guide for all event types |
 
 See also: [Help & Guides page](/help) in the app.
 

--- a/docs/adr/ADR-008-webhooks.md
+++ b/docs/adr/ADR-008-webhooks.md
@@ -141,4 +141,5 @@ Retry behavior:
 - Events fired from: `backend/src/services/loanService.ts` — `requestLoan()`, `repayLoan()`, `liquidateLoan()`.
 - Tests: `backend/src/webhooks.test.ts` (unit), `backend/src/webhooks.encryption.test.ts` (encryption round-trip), `backend/src/webhooks.events.test.ts` (event type integration).
 - Related: [ADR-002](ADR-002-jwt-auth.md) (authentication strategy — webhooks use a separate HMAC model, not JWT).
+- **Payload reference:** [docs/guides/webhooks.md](../guides/webhooks.md) — JSON schemas, example payloads, signature verification steps, and encrypted-delivery decryption guide for each event type.
 - **Future improvements to consider:** durable storage (database-backed registry and logs), per-event topic filtering, delivery ordering guarantees, admin auth on management endpoints, secret rotation, dead-letter queue integration.

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -1,0 +1,447 @@
+# Webhook Payload Reference
+
+StellarKraal emits HTTP webhook callbacks whenever a loan changes state. This
+guide documents the exact JSON shape for each event type, how to verify
+delivery signatures, and how to decrypt encrypted payloads.
+
+For architectural context — including registration endpoints, retry strategy,
+and security model — see [ADR-008: Webhook-Based Event Delivery](../adr/ADR-008-webhooks.md).
+
+---
+
+## Envelope
+
+Every webhook delivery is an HTTP `POST` with `Content-Type: application/json`.
+The body always uses the following top-level envelope:
+
+```json
+{
+  "event": "<event-type>",
+  "payload": { ... },
+  "timestamp": 1690000000000
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | `string` | Event type identifier (see [Event types](#event-types)). |
+| `payload` | `object` | Event-specific data (see per-event schemas below). |
+| `timestamp` | `number` | Unix epoch **milliseconds** when the event was generated on the server. |
+
+For webhooks registered with `encrypt: true`, the body uses a different
+structure — see [Encrypted delivery](#encrypted-delivery).
+
+---
+
+## Event types
+
+### `loan.approved`
+
+Fired when a loan request transaction is built (in `loanService.requestLoan()`),
+immediately before submission to the Soroban contract.
+
+**JSON Schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loan.approved payload",
+  "type": "object",
+  "required": ["borrower", "collateral_ids", "amount"],
+  "additionalProperties": false,
+  "properties": {
+    "borrower": {
+      "type": "string",
+      "description": "Stellar public key (G...) of the borrowing account.",
+      "pattern": "^G[A-Z2-7]{55}$"
+    },
+    "collateral_ids": {
+      "type": "array",
+      "description": "IDs of the collateral records pledged for this loan.",
+      "items": { "type": "integer", "minimum": 0 },
+      "minItems": 1
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Loan amount in stroops (1 XLM = 10,000,000 stroops).",
+      "minimum": 1
+    }
+  }
+}
+```
+
+**Example payload**
+
+```json
+{
+  "event": "loan.approved",
+  "payload": {
+    "borrower": "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TMVSWN7KV",
+    "collateral_ids": [12, 17],
+    "amount": 5000000000
+  },
+  "timestamp": 1690000000000
+}
+```
+
+---
+
+### `loan.repaid`
+
+Fired when a repayment transaction is built (in `loanService.repayLoan()`).
+
+**JSON Schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loan.repaid payload",
+  "type": "object",
+  "required": ["borrower", "loan_id", "amount"],
+  "additionalProperties": false,
+  "properties": {
+    "borrower": {
+      "type": "string",
+      "description": "Stellar public key of the account repaying the loan.",
+      "pattern": "^G[A-Z2-7]{55}$"
+    },
+    "loan_id": {
+      "type": "integer",
+      "description": "Database ID of the loan being repaid.",
+      "minimum": 0
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Repayment amount in stroops.",
+      "minimum": 1
+    }
+  }
+}
+```
+
+**Example payload**
+
+```json
+{
+  "event": "loan.repaid",
+  "payload": {
+    "borrower": "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TMVSWN7KV",
+    "loan_id": 42,
+    "amount": 5000000000
+  },
+  "timestamp": 1690003600000
+}
+```
+
+---
+
+### `loan.liquidated`
+
+Fired when a liquidation transaction is built (in `loanService.liquidateLoan()`).
+
+**JSON Schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loan.liquidated payload",
+  "type": "object",
+  "required": ["liquidator", "loan_id", "repay_amount"],
+  "additionalProperties": false,
+  "properties": {
+    "liquidator": {
+      "type": "string",
+      "description": "Stellar public key of the account performing the liquidation.",
+      "pattern": "^G[A-Z2-7]{55}$"
+    },
+    "loan_id": {
+      "type": "integer",
+      "description": "Database ID of the liquidated loan.",
+      "minimum": 0
+    },
+    "repay_amount": {
+      "type": "integer",
+      "description": "Amount repaid during liquidation in stroops.",
+      "minimum": 1
+    }
+  }
+}
+```
+
+**Example payload**
+
+```json
+{
+  "event": "loan.liquidated",
+  "payload": {
+    "liquidator": "GBVZQ4TBTSNKZXJD5CKAHVTQNTLFKBHXNZENAPQVMQPF36KZOLKIIG4A",
+    "loan_id": 42,
+    "repay_amount": 4800000000
+  },
+  "timestamp": 1690007200000
+}
+```
+
+---
+
+### `loan.activated`
+
+Fired by the contract event listener when the on-chain `loan_activated` event
+is confirmed on Stellar. This event arrives **after** `loan.approved` once the
+Soroban transaction is included in a ledger.
+
+**JSON Schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loan.activated payload",
+  "type": "object",
+  "required": ["loanId", "borrower", "amount", "timestamp"],
+  "additionalProperties": false,
+  "properties": {
+    "loanId": {
+      "type": "string",
+      "description": "On-chain loan identifier as returned by the Soroban contract."
+    },
+    "borrower": {
+      "type": "string",
+      "description": "Stellar public key of the borrower.",
+      "pattern": "^G[A-Z2-7]{55}$"
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Activated loan amount in stroops.",
+      "minimum": 1
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Ledger close time as Unix epoch milliseconds."
+    }
+  }
+}
+```
+
+**Example payload**
+
+```json
+{
+  "event": "loan.activated",
+  "payload": {
+    "loanId": "loan-78a3f2",
+    "borrower": "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TMVSWN7KV",
+    "amount": 5000000000,
+    "timestamp": 1690000120000
+  },
+  "timestamp": 1690000121500
+}
+```
+
+> **Note:** `payload.timestamp` is the ledger close time; the top-level
+> `timestamp` is when the webhook delivery was generated (slightly later).
+
+---
+
+## Signature verification
+
+Every delivery includes an `X-StellarKraal-Signature` header:
+
+```
+X-StellarKraal-Signature: sha256=<hex>
+```
+
+The signature is HMAC-SHA256 of the **raw request body** (the JSON bytes as
+received over the wire) using the per-webhook secret that was returned at
+registration time.
+
+### Verification steps
+
+1. Read the raw request body as bytes — do **not** parse JSON first.
+2. Compute `sha256=` + HMAC-SHA256 hex of the raw body using your webhook secret.
+3. Compare using a **timing-safe equality function** to prevent timing attacks.
+4. Reject the request if the signatures do not match.
+
+### Node.js example
+
+```js
+import crypto from 'node:crypto';
+
+function verifySignature(rawBody, signature, secret) {
+  const expected = 'sha256=' + crypto
+    .createHmac('sha256', secret)
+    .update(rawBody)          // Buffer or string — must be the raw bytes
+    .digest('hex');
+
+  // Use timingSafeEqual to prevent timing side-channel attacks
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expected);
+
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+// Express handler example
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['x-stellarkraal-signature'];
+  if (!verifySignature(req.body, sig, process.env.WEBHOOK_SECRET)) {
+    return res.status(401).send('Invalid signature');
+  }
+  const event = JSON.parse(req.body);
+  // process event...
+  res.status(200).send('OK');
+});
+```
+
+> **Important:** Use `express.raw()` (not `express.json()`) so the body is
+> available as a raw `Buffer` before JSON parsing.
+
+### Python example
+
+```python
+import hmac
+import hashlib
+
+def verify_signature(raw_body: bytes, signature: str, secret: str) -> bool:
+    expected = 'sha256=' + hmac.new(
+        secret.encode(),
+        raw_body,
+        hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+# Flask handler example
+from flask import Flask, request, abort
+import json
+
+app = Flask(__name__)
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    sig = request.headers.get('X-StellarKraal-Signature', '')
+    if not verify_signature(request.get_data(), sig, WEBHOOK_SECRET):
+        abort(401)
+    event = request.get_json()
+    # process event...
+    return 'OK', 200
+```
+
+---
+
+## Encrypted delivery
+
+Webhooks registered with `encrypt: true` receive an encrypted body instead of
+a plain `payload`. The encryption key is derived from your webhook secret using
+HKDF-SHA256 and the plaintext is encrypted with AES-256-GCM.
+
+**Encrypted envelope structure**
+
+```json
+{
+  "event": "loan.approved",
+  "encrypted_payload": "a3f2...",
+  "iv": "9b1c...",
+  "auth_tag": "d4e5...",
+  "timestamp": 1690000000000
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `encrypted_payload` | `string` | Hex-encoded AES-256-GCM ciphertext of the JSON payload. |
+| `iv` | `string` | Hex-encoded 12-byte initialisation vector. |
+| `auth_tag` | `string` | Hex-encoded 16-byte GCM authentication tag. |
+
+The `X-StellarKraal-Signature` header is still present and covers the entire
+encrypted envelope body — verify it before attempting decryption.
+
+**Decryption — Node.js**
+
+```js
+import crypto from 'node:crypto';
+
+function deriveKey(secret) {
+  return crypto.hkdfSync(
+    'sha256',
+    Buffer.from(secret, 'utf8'),
+    Buffer.alloc(0),                                        // empty salt
+    Buffer.from('stellarkraal-webhook-encryption', 'utf8'), // info
+    32                                                      // 32-byte AES-256 key
+  );
+}
+
+function decryptPayload(encryptedPayload, iv, authTag, secret) {
+  const key    = Buffer.from(deriveKey(secret));
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    key,
+    Buffer.from(iv, 'hex')
+  );
+  decipher.setAuthTag(Buffer.from(authTag, 'hex'));
+  const plain = Buffer.concat([
+    decipher.update(Buffer.from(encryptedPayload, 'hex')),
+    decipher.final(),
+  ]);
+  return JSON.parse(plain.toString('utf8'));
+}
+
+// Usage:
+const { encrypted_payload, iv, auth_tag } = body;
+const payload = decryptPayload(encrypted_payload, iv, auth_tag, WEBHOOK_SECRET);
+```
+
+---
+
+## Registering a webhook
+
+```http
+POST /api/v1/webhooks
+Content-Type: application/json
+
+{
+  "url": "https://your-server.example.com/hooks/stellarkraal",
+  "encrypt": false
+}
+```
+
+**Response (201 Created)**
+
+```json
+{
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "url": "https://your-server.example.com/hooks/stellarkraal",
+  "secret": "a1b2c3d4...",
+  "createdAt": 1690000000000
+}
+```
+
+> **Store the `secret` immediately.** It is returned only once and cannot be
+> retrieved later. If you lose it, delete the webhook and register a new one.
+
+---
+
+## Delivery and retry
+
+- Maximum **5 delivery attempts** per event.
+- Exponential backoff: 1 s, 2 s, 4 s, 8 s, 16 s between retries.
+- Your endpoint should return `2xx` within a reasonable timeout. Non-`2xx`
+  responses and network errors are both treated as failures.
+- After 5 failed attempts the event is abandoned. Use the `/api/v1/admin/webhooks/logs`
+  endpoint to inspect failed deliveries.
+
+---
+
+## Security checklist
+
+- [ ] Verify `X-StellarKraal-Signature` on every request using a timing-safe comparison.
+- [ ] Store your webhook secret in an environment variable or secret manager — never commit it to source control.
+- [ ] Respond quickly (< 5 s) and process the event asynchronously to avoid delivery timeouts.
+- [ ] Use `timestamp` to detect and discard replayed or stale events.
+- [ ] Register with `encrypt: true` when transmitting over untrusted networks.
+
+---
+
+## Related documentation
+
+- [ADR-008: Webhook-Based Event Delivery](../adr/ADR-008-webhooks.md) — architecture, retry strategy, security model
+- [API Integration Tutorial](api-integration-tutorial.md) — end-to-end example using webhooks to monitor loan status
+- [API Quickstart](api-quickstart.md) — authentication and base URL

--- a/frontend/src/__tests__/HealthGauge.test.tsx
+++ b/frontend/src/__tests__/HealthGauge.test.tsx
@@ -7,6 +7,22 @@ jest.mock('../lib/design-tokens', () => ({
   colors: { text: { secondary: 'text-brown-600' } },
 }));
 
+// ── framer-motion mock (#1093) ────────────────────────────────────────────────
+let mockReducedMotion = false;
+jest.mock('framer-motion', () => ({
+  ...jest.requireActual('framer-motion'),
+  useReducedMotion: () => mockReducedMotion,
+}));
+
+beforeEach(() => {
+  mockReducedMotion = false;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+// ─────────────────────────────────────────────────────────────────────────────
+
 describe('HealthGauge', () => {
   it('shows Safe label when hf >= 15_000', () => {
     render(<HealthGauge value={15_000} />);
@@ -311,5 +327,55 @@ describe('HealthGauge skeleton', () => {
     // Both use the same viewBox and className, so no layout shift
     expect(skeletonSvg!.getAttribute('viewBox')).toBe(gaugeSvg!.getAttribute('viewBox'));
     expect(skeletonSvg!.getAttribute('class')).toBe(gaugeSvg!.getAttribute('class'));
+  });
+});
+
+// ── #1093: prefers-reduced-motion via useReducedMotion ───────────────────────
+
+describe('HealthGauge — reduced-motion (#1093)', () => {
+  it('sets transition duration to 0s on progress arc when reduced-motion is true', () => {
+    mockReducedMotion = true;
+    const { container } = render(<HealthGauge value={12_000} />);
+    const paths = container.querySelectorAll('path');
+    const progressArc = Array.from(paths).find(
+      (p) => p.style.strokeDashoffset !== '',
+    );
+    expect(progressArc).toBeTruthy();
+    // Duration should be 0s when reducedMotion is true
+    expect(progressArc!.style.transition).toMatch(/0s/);
+  });
+
+  it('sets transition duration to 0s on needle when reduced-motion is true', () => {
+    mockReducedMotion = true;
+    const { container } = render(<HealthGauge value={12_000} />);
+    const needle = container.querySelector('line');
+    expect(needle).toBeTruthy();
+    expect(needle!.style.transition).toMatch(/0s/);
+  });
+
+  it('uses non-zero transition duration on progress arc when reduced-motion is false', () => {
+    mockReducedMotion = false;
+    const { container } = render(<HealthGauge value={12_000} />);
+    const paths = container.querySelectorAll('path');
+    const progressArc = Array.from(paths).find(
+      (p) => p.style.strokeDashoffset !== '',
+    );
+    expect(progressArc).toBeTruthy();
+    expect(progressArc!.style.transition).toMatch(/0\.6s/);
+  });
+
+  it('uses non-zero transition duration on needle when reduced-motion is false', () => {
+    mockReducedMotion = false;
+    const { container } = render(<HealthGauge value={12_000} />);
+    const needle = container.querySelector('line');
+    expect(needle).toBeTruthy();
+    expect(needle!.style.transition).toMatch(/0\.6s/);
+  });
+
+  it('still renders correctly with reduced-motion enabled', () => {
+    mockReducedMotion = true;
+    render(<HealthGauge value={15_000} />);
+    expect(screen.getByText('Safe')).toBeTruthy();
+    expect(screen.getByText('1.50x')).toBeTruthy();
   });
 });

--- a/frontend/src/__tests__/StatusBadge.test.tsx
+++ b/frontend/src/__tests__/StatusBadge.test.tsx
@@ -5,6 +5,42 @@ import type { BadgeStatus } from '../components/StatusBadge';
 
 expect.extend(toHaveNoViolations);
 
+// ── framer-motion mock ────────────────────────────────────────────────────────
+// Control useReducedMotion and stub motion/AnimatePresence so tests are stable.
+let mockReducedMotion = false;
+
+jest.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    ...jest.requireActual('framer-motion'),
+    useReducedMotion: () => mockReducedMotion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: {
+      span: React.forwardRef(
+        (
+          { children, className, ...rest }: React.HTMLAttributes<HTMLSpanElement>,
+          ref: React.Ref<HTMLSpanElement>,
+        ) =>
+          React.createElement(
+            'span',
+            { ...rest, className, ref },
+            children,
+          ),
+      ),
+    },
+  };
+});
+
+beforeEach(() => {
+  mockReducedMotion = false;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+// ─────────────────────────────────────────────────────────────────────────────
+
 const ALL_STATUSES: BadgeStatus[] = [
   'active',
   'repaid',
@@ -82,6 +118,47 @@ describe('StatusBadge', () => {
       render(<StatusBadge status="pledged" />);
       const badge = screen.getByRole('status');
       expect(badge.className).toContain('text-color-secondary');
+    });
+  });
+
+  // ── #1093: Animation tests ───────────────────────────────────────────────────
+
+  describe('Framer Motion animation (#1093)', () => {
+    test('badge wrapper has no layout-shifting outer element', () => {
+      const { container } = render(<StatusBadge status="active" />);
+      // The outer wrapper is a plain span, not a block-level element
+      const wrapper = container.querySelector('[data-testid="status-badge-wrapper"]');
+      expect(wrapper).toBeTruthy();
+      expect(wrapper!.tagName.toLowerCase()).toBe('span');
+    });
+
+    test('badge is wrapped in AnimatePresence for transition animations', () => {
+      // The animated span is inside the wrapper
+      render(<StatusBadge status="active" />);
+      const badge = screen.getByRole('status');
+      expect(badge).toBeInTheDocument();
+    });
+
+    test('does not cause layout shift — wrapper is inline-flex', () => {
+      const { container } = render(<StatusBadge status="active" />);
+      const wrapper = container.querySelector('[data-testid="status-badge-wrapper"]');
+      expect(wrapper).toBeTruthy();
+      expect(wrapper!.className).toContain('inline-flex');
+    });
+
+    test('badge renders correctly when prefers-reduced-motion is set', () => {
+      mockReducedMotion = true;
+      render(<StatusBadge status="active" />);
+      const badge = screen.getByRole('status');
+      // Should still render and display the label
+      expect(badge).toHaveTextContent('Active');
+      expect(badge).toBeInTheDocument();
+    });
+
+    test('unknown status renders correctly with reduced-motion', () => {
+      mockReducedMotion = true;
+      render(<StatusBadge status="unknown-xyz" />);
+      expect(screen.getByText('unknown-xyz')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/HealthGauge.tsx
+++ b/frontend/src/components/HealthGauge.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
 import { healthColor } from '@/lib/design-tokens';
 
 interface DataPoint {
@@ -298,6 +299,8 @@ export default function HealthGauge({ value, history, loading }: Props) {
   const color = healthColor(value);
   const label = value >= 15_000 ? 'Safe' : value >= 10_000 ? 'Warning' : 'Danger';
 
+  const reducedMotion = useReducedMotion();
+
   const prevValueRef = useRef<number>(value);
   const [flash, setFlash] = useState(false);
   const [direction, setDirection] = useState<'up' | 'down' | 'none'>('none');
@@ -343,6 +346,14 @@ export default function HealthGauge({ value, history, loading }: Props) {
   const nx = CX + (R - STROKE / 2) * Math.cos(needleRad);
   const ny = CY + (R - STROKE / 2) * Math.sin(needleRad);
 
+  /**
+   * Transition duration strings — 0s when the user prefers reduced motion so
+   * every CSS transition snaps to the final value immediately. This supplements
+   * the existing `motion-reduce:transition-none` Tailwind classes and ensures
+   * the inline `style` transitions also respect the preference.
+   */
+  const transitionDuration = reducedMotion ? '0s' : '0.6s';
+
   return (
     <div
       className={`flex flex-col items-center w-full ${flash ? 'motion-safe:animate-[flashHighlight_1s_ease-out]' : ''}`}
@@ -384,7 +395,7 @@ export default function HealthGauge({ value, history, loading }: Props) {
           style={{
             strokeDasharray: `${Math.PI * R}`,
             strokeDashoffset: `${Math.PI * R * (1 - frac)}`,
-            transition: 'stroke-dashoffset 0.6s ease-out, stroke 0.6s ease-out',
+            transition: `stroke-dashoffset ${transitionDuration} ease-out, stroke ${transitionDuration} ease-out`,
           }}
         />
 
@@ -398,7 +409,10 @@ export default function HealthGauge({ value, history, loading }: Props) {
           strokeWidth={2.5}
           strokeLinecap="round"
           className="motion-reduce:transition-none"
-          style={{ stroke: 'var(--token-text)', transition: 'x2 0.6s ease-out, y2 0.6s ease-out' }}
+          style={{
+            stroke: 'var(--token-text)',
+            transition: `x2 ${transitionDuration} ease-out, y2 ${transitionDuration} ease-out`,
+          }}
         />
         <circle cx={CX} cy={CY} r={5} style={{ fill: 'var(--token-text)' }} />
 

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * StatusBadge — #539
+ * StatusBadge — #539 / #1093
  *
  * Colours are sourced from design tokens (CSS custom properties via Tailwind
  * semantic colour utilities) instead of hard-coded Tailwind palette classes.
@@ -19,9 +19,21 @@
  *
  * All token colours pass WCAG AA (≥ 4.5:1) for normal text on both
  * light and dark backgrounds — verified in docs/guides/design-tokens.md.
+ *
+ * Animation — #1093
+ * ──────────────────
+ * Status transitions animate with a subtle fade + scale entrance (200 ms).
+ * When `status` changes, the badge exits (fade + scale down) and the new
+ * badge enters (fade + scale up) via AnimatePresence keyed on `status`.
+ * Animations are suppressed when the user has `prefers-reduced-motion`
+ * enabled — `useReducedMotion()` returns true and we skip the variant
+ * spring entirely, snapping to the final value immediately.
+ * The wrapping element retains its inline-flex layout so there is no
+ * layout shift caused by the animation.
  */
 
 import React from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
 export type LoanStatus = 'active' | 'repaid' | 'defaulted' | 'liquidated';
 export type CollateralStatus = 'available' | 'pledged';
@@ -38,43 +50,37 @@ interface Config {
 const STATUS_CONFIG: Record<BadgeStatus, Config> = {
   active: {
     label: 'Active',
-    classes:
-      'bg-color-success-subtle text-color-success',
+    classes: 'bg-color-success-subtle text-color-success',
     icon: '●',
     ariaLabel: 'Status: Active',
   },
   repaid: {
     label: 'Repaid',
-    classes:
-      'bg-color-primary/10 text-color-primary',
+    classes: 'bg-color-primary/10 text-color-primary',
     icon: '✓',
     ariaLabel: 'Status: Repaid',
   },
   defaulted: {
     label: 'Defaulted',
-    classes:
-      'bg-color-warning-subtle text-color-warning',
+    classes: 'bg-color-warning-subtle text-color-warning',
     icon: '⚠',
     ariaLabel: 'Status: Defaulted',
   },
   liquidated: {
     label: 'Liquidated',
-    classes:
-      'bg-color-danger-subtle text-color-danger',
+    classes: 'bg-color-danger-subtle text-color-danger',
     icon: '✕',
     ariaLabel: 'Status: Liquidated',
   },
   available: {
     label: 'Available',
-    classes:
-      'bg-color-success-subtle text-color-success',
+    classes: 'bg-color-success-subtle text-color-success',
     icon: '◆',
     ariaLabel: 'Status: Available',
   },
   pledged: {
     label: 'Pledged',
-    classes:
-      'bg-color-secondary/15 text-color-secondary',
+    classes: 'bg-color-secondary/15 text-color-secondary',
     icon: '⬡',
     ariaLabel: 'Status: Pledged',
   },
@@ -85,24 +91,77 @@ interface Props {
 }
 
 export default function StatusBadge({ status }: Props) {
+  const reducedMotion = useReducedMotion();
   const config = STATUS_CONFIG[status as BadgeStatus];
+
+  /**
+   * Variants for the fade + scale entrance/exit.
+   * When reducedMotion is true every variant resolves to the resting state
+   * immediately (duration: 0) so the badge snaps without any movement.
+   */
+  const variants = {
+    initial: reducedMotion
+      ? { opacity: 1, scale: 1 }
+      : { opacity: 0, scale: 0.85 },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      transition: reducedMotion
+        ? { duration: 0 }
+        : { duration: 0.2, ease: 'easeOut' as const },
+    },
+    exit: reducedMotion
+      ? { opacity: 1, scale: 1 }
+      : {
+          opacity: 0,
+          scale: 0.85,
+          transition: { duration: 0.15, ease: 'easeIn' as const },
+        },
+  };
 
   if (!config) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium bg-color-surface text-color-text-subtle">
-        {status}
+      /* Wrap in a non-animated span to keep layout stable for fallback */
+      <span className="inline-flex items-center">
+        <motion.span
+          key={status}
+          variants={variants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium bg-color-surface text-color-text-subtle"
+        >
+          {status}
+        </motion.span>
       </span>
     );
   }
 
   return (
-    <span
-      role="status"
-      aria-label={config.ariaLabel}
-      className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ${config.classes}`}
-    >
-      <span aria-hidden="true">{config.icon}</span>
-      {config.label}
+    /*
+     * AnimatePresence re-mounts the inner motion.span whenever `status`
+     * changes (keyed by `status`), triggering the exit of the old badge
+     * and the entrance of the new one.
+     *
+     * The outer <span> is a plain inline-flex container so the surrounding
+     * layout never reflows — the animated child fills the same space.
+     */
+    <span className="inline-flex items-center" data-testid="status-badge-wrapper">
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={status}
+          role="status"
+          aria-label={config.ariaLabel}
+          variants={variants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ${config.classes}`}
+        >
+          <span aria-hidden="true">{config.icon}</span>
+          {config.label}
+        </motion.span>
+      </AnimatePresence>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Implements two tracked issues in a single PR:

---

### #1111 — Webhook Payload Reference Docs

- Added **`docs/guides/webhooks.md`** with:
  - JSON Schema definitions for all four event types: `loan.approved`, `loan.repaid`, `loan.liquidated`, `loan.activated`
  - Realistic example payloads for each event
  - Signature verification steps with Node.js and Python code samples (timing-safe `timingSafeEqual`)
  - Encrypted delivery decryption guide (AES-256-GCM + HKDF)
  - Webhook registration, delivery/retry, and security checklist sections
- Linked the new guide from **ADR-008 Notes** section
- Added **Webhook Payload Reference** row to the README User Guides table

Closes #1111

---

### #1093 — Loan Status Animations

**StatusBadge (`src/components/StatusBadge.tsx`)**
- Wrapped badge in `AnimatePresence` + `motion.span` with fade + scale entrance/exit (200 ms enter, 150 ms exit)
- `useReducedMotion()` snaps all variants to the resting state (opacity 1, scale 1, duration 0) — no motion at all
- Outer wrapper is a plain inline-flex `<span>` so surrounding layout never reflows (no layout shift)

**HealthGauge (`src/components/HealthGauge.tsx`)**
- Imported `useReducedMotion` from `framer-motion`
- `transitionDuration` is `'0s'` when `useReducedMotion()` is true, `'0.6s'` otherwise
- This cleanly replaces the previously hard-coded `0.6s` strings in the inline SVG transition styles, complementing the existing `motion-reduce:transition-none` Tailwind classes

**Tests**
- 59 tests pass (34 HealthGauge + 25 StatusBadge)
- New reduced-motion test suite for HealthGauge: verifies `0s` vs `0.6s` transitions
- New animation test suite for StatusBadge: verifies inline-flex wrapper, AnimatePresence rendering, and reduced-motion behaviour

Closes #1093

---

## Checklist

- [x] Branch created from latest `main`
- [x] Commit messages follow Conventional Commits
- [x] Tests run successfully locally (59 passing)
- [x] Documentation updated (webhooks.md, ADR-008, README)